### PR TITLE
feat: Add Alembic environment configuration for database migrations.

### DIFF
--- a/backend/src/ledger_sync/db/migrations/env.py
+++ b/backend/src/ledger_sync/db/migrations/env.py
@@ -16,8 +16,13 @@ from ledger_sync.db.base import Base
 # this is the Alembic Config object
 config = context.config
 
-# Set SQLAlchemy URL from application settings
-config.set_main_option("sqlalchemy.url", settings.database_url)
+# Set SQLAlchemy URL from application settings.
+# Normalise to psycopg (v3) driver — same logic as session.py.
+_db_url = settings.database_url
+if _db_url.startswith(("postgresql://", "postgresql+psycopg2://")):
+    _db_url = _db_url.replace("postgresql+psycopg2://", "postgresql+psycopg://", 1)
+    _db_url = _db_url.replace("postgresql://", "postgresql+psycopg://", 1)
+config.set_main_option("sqlalchemy.url", _db_url)
 
 # Interpret the config file for Python logging
 if config.config_file_name is not None:


### PR DESCRIPTION
This pull request updates the database migration configuration to ensure consistent use of the `psycopg` (v3) PostgreSQL driver. The main change is to normalize the SQLAlchemy database URL to use `postgresql+psycopg://`, matching the logic used elsewhere in the codebase.

Database driver normalization:

* Updated `backend/src/ledger_sync/db/migrations/env.py` to replace any `postgresql://` or `postgresql+psycopg2://` prefixes in the database URL with `postgresql+psycopg://`, ensuring the migration environment uses the correct PostgreSQL driver.