### PR TITLE
fix: set CORS to wildcard for public API access

### DIFF
--- a/backend/src/ledger_sync/api/main.py
+++ b/backend/src/ledger_sync/api/main.py
@@ -225,10 +225,10 @@ if settings.frontend_url:
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=_cors_origins,
-    allow_credentials=True,
-    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-    allow_headers=["Authorization", "Content-Type"],
+    allow_origins=["*"],
+    allow_credentials=False,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 


### PR DESCRIPTION
## Summary

- Set CORS `allow_origins` to `["*"]` so any frontend domain can access the API (fixes 404/CORS errors from sagargupta.online -> ledger-sync.onrender.com)
- Set `allow_credentials=False` (required by CORS spec when using wildcard origin -- auth still works via `Authorization` bearer header)
- Allow all methods and headers (`["*"]`)

## Test plan

- [x] Verify `https://sagargupta.online` can upload files to `https://ledger-sync.onrender.com/api/upload` without CORS errors
- [x] Verify API calls from any origin return proper `Access-Control-Allow-Origin: *` header
- [x] Verify JWT auth still works via `Authorization` header