### PR TITLE
fix: resolve SonarCloud security hotspots

### DIFF
--- a/backend/src/ledger_sync/api/analytics_v2.py
+++ b/backend/src/ledger_sync/api/analytics_v2.py
@@ -7,6 +7,7 @@ All aggregation tables are scoped to user_id for multi-user safety.
 """
 
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 from typing import Annotated, Any
 
 from fastapi import APIRouter, HTTPException, Query
@@ -420,8 +421,6 @@ def update_recurring_transaction(
             raise HTTPException(status_code=422, detail=f"Invalid frequency: {body.frequency}")
         record.frequency = RecurrenceFrequency(freq)
     if body.expected_amount is not None:
-        from decimal import Decimal
-
         record.expected_amount = Decimal(str(body.expected_amount))
     if body.is_confirmed is not None:
         record.is_user_confirmed = body.is_confirmed
@@ -451,8 +450,6 @@ def create_recurring_transaction(
     db: DatabaseSession,
 ) -> dict[str, Any]:
     """Create a new recurring transaction manually."""
-    from decimal import Decimal
-
     freq = body.frequency.lower()
     if freq not in _VALID_FREQUENCIES:
         raise HTTPException(status_code=422, detail=f"Invalid frequency: {body.frequency}")

--- a/backend/src/ledger_sync/core/analytics_engine.py
+++ b/backend/src/ledger_sync/core/analytics_engine.py
@@ -973,8 +973,6 @@ class AnalyticsEngine:
         """
         if not note or not note.strip():
             return None
-        import re
-
         text = note.strip().lower()
         # Remove trailing date-like patterns (jan 2026, 01/2026, etc.)
         month_pat = r"\s+(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\w*\s*\d{0,4}$"


### PR DESCRIPTION
## Summary
- CORS: replace wildcard `["*"]` with configured `_cors_origins` from settings
- Remove redundant `import re` inside function (already at module level)
- Move `from decimal import Decimal` to module level (was inside 2 functions)

Fixes the 3 SonarCloud security hotspots + C reliability rating.