### PR TITLE
feat: income & tax projections with salary structure, RSU tracking, and multi-year forecasting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,4 @@ typings/
 
 .claude/
 .mcp.json
+.superpowers/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented here.
 
-Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioned with [Semantic Versioning](https://semver.org/).
+Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
@@ -30,15 +30,15 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versio
 
 - **Sticky PageHeader consistency** -- moved PageHeader outside Framer Motion containers on InsightsPage, FIRECalculatorPage, and TaxPlanningPage so `position: sticky` works correctly (CSS `transform` from animations was breaking it)
 - **Scroll-to-top on navigation** -- reset `#main-content` scroll position on route change so every page starts from the top
+- **Returns Analysis FY switching** (issue #88) -- CAGR and Monthly ROI now update when changing fiscal year
+- **TaxPlanningPage cognitive complexity** -- extracted helper functions to bring SonarCloud score under threshold
 - **Chart hover/tooltip standardization** -- consistent hover states and tooltip styling across all chart pages
 - **SonarCloud findings** -- `localeCompare` for string sorts, `Number.parseInt` over global `parseInt`, `findLast` over `filter().at(-1)`, extracted nested ternaries, composite keys for RSU vesting rows
 - **Projected tax bar color** -- uses orange instead of green to distinguish from paid tax
 
 ---
 
-## [1.0.0] - 2026-04-10
-
-The first stable release. Ledger Sync graduates from pre-release with multi-currency support, 23 analytics pages, demo mode, and a fully self-hosted architecture on free-tier infrastructure.
+## 1.9.0 - 2026-04-10
 
 ### Added
 
@@ -58,33 +58,31 @@ The first stable release. Ledger Sync graduates from pre-release with multi-curr
 
 ---
 
-## Pre-1.0 Releases
+## 1.8.1 - 2026-04-05
 
-Development history from initial prototype to feature-complete dashboard.
-
-### [0.9.1] - 2026-04-05
-
-#### Added
+### Added
 
 - **Pre-computed daily summaries** -- `daily_summaries` table for instant heatmap rendering (income, expenses, net, transaction counts, top category per day)
 - **Daily summaries API** -- `GET /api/analytics/v2/daily-summaries` with date range and limit filters
 - **Investment holdings API** -- `GET /api/analytics/v2/investment-holdings` with active_only filter and portfolio summary
 - **Auto-populate investment holdings** -- analytics engine dynamically detects investment accounts from preferences and computes net invested amounts from transfer flows
 
-#### Changed
+### Changed
 
 - **Calculations fast path** -- `get_totals`, `get_monthly_aggregation`, and `get_category_breakdown` read from pre-computed tables when no date filter is active
 - **YearInReview heatmap** -- uses daily summaries instead of scanning all transactions
 
-#### Fixed
+### Fixed
 
 - User scoping, cascades, indexes, and constraints added to database schema
 - Regex backtracking risk eliminated in note normalization
 - SonarCloud findings resolved, mobile responsiveness improved
 
-### [0.9.0] - 2026-04-05
+---
 
-#### Added
+## 1.8.0 - 2026-04-05
+
+### Added
 
 - **Demo mode** -- "Try Demo" on landing page lets visitors explore the full dashboard with ~500 realistic sample transactions, zero signup
 - **Smart account classification** -- keyword matching for EPF, PPF, Mutual Funds, Groww, Zerodha, FD, Stocks, Gold, Crypto as Investments; Indian banks as Bank Accounts; EMI/mortgage as Loans
@@ -94,40 +92,46 @@ Development history from initial prototype to feature-complete dashboard.
 - **Neon database via Vercel integration** -- unified dashboard management
 - **Alembic migration workflow** -- GitHub Actions runs migrations on push to main when schema files change
 
-#### Changed
+### Changed
 
 - Demo banner uses floating pill overlay instead of sticky bar
 - Account classification priority: Credit Cards > Investments > Loans > Bank Accounts > Cash > Other
 
-### [0.8.0] - 2026-03-14
+---
 
-#### Added
+## 1.7.0 - 2026-03-14
+
+### Added
 
 - Code quality rules in CLAUDE.md (200-line file limit, import conventions, design system constraints)
 - `CHART_TEXT`, `CHART_SURFACE`, `CHART_INPUT` constants for centralized chart styling
 
-#### Changed
+### Changed
 
 - Split 4 oversized pages into focused components: SettingsPage (20 files), SubscriptionTrackerPage (13), GoalsPage (13), ComparisonPage (13)
 - Chart styling migrated from raw hex values to shared constants
 
-### [0.7.0] - 2026-03-03
+---
 
-#### Added
+## 1.6.0 - 2026-03-03
+
+### Added
 
 - **Analytics V2 API** -- stored aggregations for monthly summaries, category trends, transfer flows, recurring transactions, merchant intelligence, net worth, fiscal year summaries
 - **Sidebar** -- collapsible navigation groups, user profile, search, dynamic badge counts, notification center
 - 11 new pages: Returns Analysis, Tax Planning, Cash Flow Forecast, Net Worth, Budget, Subscription Tracker, Spending Analysis, Investment Analytics, Dashboard, Profile Modal
 - Standard chart components: `StandardAreaChart`, `StandardBarChart`, `StandardPieChart`
 
-#### Changed
+### Changed
 
 - Backend restructured with FastAPI routers, middleware, and error handling
 - OAuth authentication (Google, GitHub) via authorization code flow
 
-### [0.6.0] - 2026-03-01
+---
 
-#### Added
+## 1.5.0 - 2026-03-01
+
+### Added
 
 - Settings page complete rebuild (single scrollable page with glass cards)
 - Financial Goals with savings pool allocation and smart projections
@@ -135,39 +139,43 @@ Development history from initial prototype to feature-complete dashboard.
 - User preferences API with comprehensive Pydantic models
 - OAuth fields in users table
 
-#### Changed
+### Changed
 
 - UI/UX polish across 18+ pages (hover states, visual hierarchy, animations)
 - Goal/budget/anomaly creation refreshes lists without page reload
 
-#### Fixed
+### Fixed
 
 - Goal/budget creation sent as JSON body instead of query params
 - GoalsPage vertical gaps and animation issues
 
-### [0.5.0] - 2026-02-28
+---
 
-#### Added
+## 1.4.0 - 2026-02-28
+
+### Added
 
 - Deployment configuration (GitHub Pages + Neon PostgreSQL + backend hosting)
 - `AnalyticsEngine` for post-upload data analytics
 - CI workflow with GitHub Actions (lint, type-check, build, deploy)
 
-#### Changed
+### Changed
 
 - SQLite-only `strftime` replaced with database-agnostic date formatting
 - React Router basename configured for `/ledger-sync/` subpath
 - GitHub Actions pinned to commit SHAs for security
 
-#### Fixed
+### Fixed
 
 - `email-validator` dependency for Pydantic `EmailStr`
 - `frontend/src/lib/` tracked (previously ignored by `.gitignore`)
 - TypeScript errors and SonarQube findings resolved
 
-### [0.4.0] - 2026-02-21
+---
 
-#### Added
+## 1.3.0 - 2026-02-21
+
+### Added
 
 - Core architecture: React Router, authentication, page routing, dark theme
 - iOS-inspired color palette with Framer Motion animations
@@ -177,14 +185,16 @@ Development history from initial prototype to feature-complete dashboard.
 - `useAnalyticsTimeFilter` hook for centralized time filter state
 - Command palette, comprehensive documentation
 
-#### Changed
+### Changed
 
 - Frontend rebuilt from Next.js to React + Vite SPA
 - Backend migrated to layered architecture with SQLAlchemy 2.0
 
-### [0.3.0] - 2026-02-04
+---
 
-#### Added
+## 1.2.0 - 2026-02-04
+
+### Added
 
 - Authentication flow (login, registration, protected routes)
 - ComparisonPage, Year in Review (heatmap + insights), Budget management, Anomaly review
@@ -192,15 +202,17 @@ Development history from initial prototype to feature-complete dashboard.
 - Financial Health Score (8 metrics across 4 pillars)
 - Spending Velocity Gauge
 
-#### Changed
+### Changed
 
 - Chart tooltips with glass styling, natural line types, enhanced animations
 - Date handling standardized with `getDateKey`
 - API endpoints migrated to `DatabaseSession`
 
-### [0.2.0] - 2026-01-27
+---
 
-#### Added
+## 1.1.0 - 2026-01-27
+
+### Added
 
 - PostgreSQL support
 - Recurring transaction detection, top merchants analytics
@@ -208,13 +220,15 @@ Development history from initial prototype to feature-complete dashboard.
 - Tax Planning page, Trends & Forecasts page
 - CSV export endpoint, period navigation
 
-#### Changed
+### Changed
 
 - Currency formatting refactored for consistency across all pages
 
-### [0.1.0] - 2026-01-09
+---
 
-#### Added
+## 1.0.0 - 2026-01-09
+
+### Added
 
 - Backend sync engine for Excel imports (Money Manager Pro format)
 - Data ingestion pipeline: `excel_loader` -> `normalizer` -> `validator` -> `hash_id`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versio
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **Income & tax projections** -- input your salary CTC structure (basic, HRA, special allowance, EPF, NPS, professional tax, variable pay) per fiscal year, with FY-to-FY navigation and editing
+- **RSU grant management** -- add stock grants with vesting schedules; vesting amounts auto-projected with stock appreciation
+- **Growth assumptions** -- configure annual salary hike, variable pay growth, stock appreciation, and projection horizon; projections compound from the latest salary FY
+- **Multi-year tax comparison table** -- side-by-side projected gross, tax, and net across future fiscal years
+- **Projection calculator** (`lib/projectionCalculator.ts`) -- pure functions for multi-year salary/RSU/tax projection with full TDD test coverage
+- **Salary Pydantic schemas** -- `SalaryComponents`, `RsuGrant`, `GrowthAssumptions` with backend validation
+- **Three new preference endpoints** -- `PUT /api/preferences/salary-structure`, `PUT /api/preferences/rsu-grants`, `PUT /api/preferences/growth-assumptions`
+- **Alembic migration** -- adds `salary_structure`, `rsu_grants`, `growth_assumptions` JSON columns to `user_preferences`
+
+### Changed
+
+- **Tax Planning page** -- extended with salary-based projection toggle, stacked paid-vs-projected tax bars in yearly chart, projection-aware labels throughout
+- **Settings page** -- new "Income & Salary Structure" section with salary grid, RSU grant editor, and growth assumption sliders
+- **preferencesStore** -- hydration logic extracted into standalone pure helpers to reduce cognitive complexity (SonarCloud finding)
+- **tsconfig** -- bumped `lib` from ES2022 to ES2023 for `Array.findLast()` support
+
+### Fixed
+
+- **Sticky PageHeader consistency** -- moved PageHeader outside Framer Motion containers on InsightsPage, FIRECalculatorPage, and TaxPlanningPage so `position: sticky` works correctly (CSS `transform` from animations was breaking it)
+- **Scroll-to-top on navigation** -- reset `#main-content` scroll position on route change so every page starts from the top
+- **Chart hover/tooltip standardization** -- consistent hover states and tooltip styling across all chart pages
+- **SonarCloud findings** -- `localeCompare` for string sorts, `Number.parseInt` over global `parseInt`, `findLast` over `filter().at(-1)`, extracted nested ternaries, composite keys for RSU vesting rows
+- **Projected tax bar color** -- uses orange instead of green to distinguish from paid tax
+
+---
+
 ## [1.0.0] - 2026-04-10
 
 The first stable release. Ledger Sync graduates from pre-release with multi-currency support, 23 analytics pages, demo mode, and a fully self-hosted architecture on free-tier infrastructure.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,23 +75,23 @@ Root `package.json` uses `concurrently` to coordinate both services. Backend use
 
 Layered architecture:
 
-- **`api/`** - FastAPI routers. Each file is a router module (auth, oauth, upload, transactions, analytics, analytics_v2, calculations, preferences, account_classifications, meta, reports). Routers are registered in `main.py`. All endpoints require JWT auth via `get_current_user` dependency from `deps.py`. `oauth.py` handles Google/GitHub authorization code exchange.
+- **`api/`** - FastAPI routers. Each file is a router module (auth, oauth, upload, transactions, analytics, analytics_v2, calculations, preferences, account_classifications, exchange_rates, meta, reports). Routers are registered in `main.py`. All endpoints require JWT auth via `get_current_user` dependency from `deps.py`. `oauth.py` handles Google/GitHub authorization code exchange. `preferences.py` includes salary-structure, rsu-grants, and growth-assumptions endpoints.
 - **`core/`** - Business logic. `sync_engine.py` orchestrates Excel imports. `reconciler.py` handles deduplication via SHA-256 hashing. `calculator.py` and `analytics_engine.py` compute financial metrics. `query_helpers.py` provides shared SQL aggregation helpers (`income_sum_col`, `expense_sum_col`, `build_transaction_query`) used by both `calculations.py` and `analytics.py`. `insights.py` generates smart financial insights. `report_generator.py` builds exportable reports. `time_filter.py` handles date range/fiscal year filtering logic. `core/auth/` handles JWT token creation/verification.
 - **`ingest/`** - Data ingestion pipeline: `excel_loader.py` -> `normalizer.py` -> `validator.py` -> `hash_id.py`. Processes Excel uploads into normalized transaction records.
-- **`db/`** - SQLAlchemy 2.0 models and session factory. `models.py` defines all tables (users, transactions, import_logs, user_preferences, investment_accounts, budget_goals, recurring_transactions, anomalies, account_classifications). All data is user-scoped.
-- **`schemas/`** - Pydantic models for request/response validation.
+- **`db/`** - SQLAlchemy 2.0 models and session factory. `models.py` defines all tables (users, transactions, import_logs, user_preferences, investment_accounts, budget_goals, recurring_transactions, anomalies, account_classifications). All data is user-scoped. `user_preferences` includes JSON columns for `salary_structure`, `rsu_grants`, and `growth_assumptions`.
+- **`schemas/`** - Pydantic models for request/response validation. Includes `salary.py` with `SalaryComponents`, `RsuGrant`, `GrowthAssumptions` schemas for tax projection inputs.
 - **`config/settings.py`** - Pydantic BaseSettings. All env vars prefixed with `LEDGER_SYNC_` (e.g., `LEDGER_SYNC_DATABASE_URL`, `LEDGER_SYNC_JWT_SECRET_KEY`).
 
 ### Frontend (`frontend/src/`)
 
-- **`pages/`** - 23 page components, all lazy-loaded via `React.lazy` for code splitting. Pages import directly (no barrel re-export). Includes SubscriptionTrackerPage, BillCalendarPage, InsightsPage, and YearInReviewPage.
+- **`pages/`** - 23 page components, all lazy-loaded via `React.lazy` for code splitting. Pages import directly (no barrel re-export). Includes FIRECalculatorPage, SubscriptionTrackerPage, BillCalendarPage, InsightsPage, and YearInReviewPage. `settings/SalaryStructureSection.tsx` provides salary CTC grid, RSU grant editor, and growth assumption sliders.
 - **`components/`** - Organized by domain: `analytics/` (chart components including `CategoryBreakdown` for shared category treemaps), `layout/` (AppLayout, Sidebar with ProfileModal), `shared/` (reusable components like MetricCard, AnalyticsTimeFilter, ProtectedRoute, ProfileModal, ChunkErrorBoundary, EmptyState, QuickInsights), `transactions/`, `upload/`, `ui/` (base primitives including ChartContainer, PageHeader, ConfirmDialog, CollapsibleSection).
 - **`hooks/`** - Custom React hooks. `useAnalyticsTimeFilter` encapsulates time-filter state (view mode, date range, FY) shared across all analytics pages. `useChartDimensions` provides responsive chart sizing. `hooks/api/` contains TanStack Query hooks for API calls, configured with `staleTime: Infinity` and `gcTime: 1 hour`.
 - **`services/api/`** - Axios-based API client. Axios interceptor auto-attaches JWT `Authorization` header.
 - **`store/`** - Zustand stores: `authStore` (JWT tokens with persist middleware), `accountStore`, `budgetStore`, `investmentAccountStore`, `preferencesStore`.
-- **`types/`** - Shared TypeScript type definitions.
+- **`types/`** - Shared TypeScript type definitions. `salary.ts` defines `SalaryComponents`, `RsuGrant`, `GrowthAssumptions`, and `ProjectedFYBreakdown` interfaces.
 - **`constants/`** - Colors, animations, chart configuration tokens.
-- **`lib/`** - Utility functions: formatters, date utils, tax calculator, export helpers.
+- **`lib/`** - Utility functions: formatters, date utils, tax calculator, export helpers. `projectionCalculator.ts` provides pure functions (`projectFiscalYear`, `projectMultipleYears`, `getRsuVestingsByFY`) for multi-year salary/tax projections with full TDD test coverage in `__tests__/projectionCalculator.test.ts`.
 
 ### Key Patterns
 

--- a/README.md
+++ b/README.md
@@ -49,11 +49,17 @@ No subscriptions. No data harvesting. Just 23 pages of analytics built from your
 - Income to Expenses/Savings breakdown
 - Monthly and yearly views
 
+### Tax & Retirement Planning
+
+- **India FY tax estimation** -- old vs new regime comparison, slab breakdown, surcharge, cess
+- **Salary-based projections** -- input your CTC structure, RSU grants, and growth assumptions to project multi-year tax liability
+- **FIRE Calculator** -- compute FIRE number, Coast FIRE, years to FIRE, and savings rate from your actual spending data; Lean/Standard/Fat FIRE variants with adjustable SWR, real return, and retirement horizon
+- **Retirement corpus calculator** -- inflation-adjusted corpus, monthly SIP needed, lump-sum alternative, with projection chart
+
 ### Analytics & Insights
 
 - Financial Health Score with 8 metrics across 4 pillars (Spend, Save, Borrow, Plan)
 - Income vs Expense trends and forecasting
-- Tax planning for India FY (April-March)
 - Net Worth tracking across all accounts
 - Anomaly detection and review
 - Budget tracking and goals
@@ -162,16 +168,16 @@ ledger-sync/
 ├── frontend/               # React + TypeScript frontend
 │   └── src/
 │       ├── pages/          # 23 page components (split into subdirectories)
-│       │   ├── settings/       # Settings sections (20 files)
+│       │   ├── settings/       # Settings sections (21 files, incl. SalaryStructureSection)
 │       │   ├── goals/          # Goals sub-components (13 files)
 │       │   ├── comparison/     # Comparison sub-components (13 files)
-│       │   └── subscription-tracker/  # Subscription sub-components (13 files)
+│       │   └── subscription-tracker/  # Subscription sub-components (3 files)
 │       ├── components/     # UI & analytics components (60+)
 │       ├── hooks/          # React Query hooks & custom hooks
 │       ├── constants/      # Colors, chart tokens, animations
 │       ├── store/          # Zustand global stores
 │       ├── services/       # API client (Axios)
-│       ├── lib/            # Utility functions
+│       ├── lib/            # Utility functions (formatters, tax calculator, projection calculator)
 │       │   └── demo/          # Demo mode (data generators, cache seeder)
 │       └── types/          # Shared TypeScript types
 ├── .github/workflows/      # CI pipeline
@@ -194,7 +200,8 @@ ledger-sync/
 | **Investment Analytics**   | Portfolio across 4 categories                       |
 | **Mutual Fund Projection** | SIP calculator and projections                      |
 | **Returns Analysis**       | Investment returns tracking                         |
-| **Tax Planning**           | India FY-based tax insights and slab breakdown      |
+| **Tax Planning**           | India FY tax estimation with salary-based projections |
+| **FIRE Calculator**        | FIRE number, Coast FIRE, retirement corpus planner  |
 | **Net Worth**              | Assets, liabilities, and credit card health         |
 | **Budget**                 | Budget tracking and monitoring                      |
 | **Goals**                  | Financial goal setting and progress                 |

--- a/backend/src/ledger_sync/api/preferences.py
+++ b/backend/src/ledger_sync/api/preferences.py
@@ -22,6 +22,11 @@ from sqlalchemy.orm import Session
 
 from ledger_sync.api.deps import CurrentUser, DatabaseSession
 from ledger_sync.db.models import User, UserPreferences
+from ledger_sync.schemas.salary import (
+    GrowthAssumptionsConfig,
+    RsuGrantsConfig,
+    SalaryStructureConfig,
+)
 
 router = APIRouter(prefix="/preferences", tags=["preferences"])
 
@@ -251,6 +256,11 @@ class UserPreferencesResponse(BaseModel):
     notify_upcoming_bills: bool = True
     notify_days_ahead: int = 7
 
+    # Salary & Tax Projections
+    salary_structure: dict[str, Any] = {}
+    rsu_grants: list[dict[str, Any]] = []
+    growth_assumptions: dict[str, Any] = {}
+
     # Metadata
     created_at: datetime | None = None
     updated_at: datetime | None = None
@@ -331,6 +341,11 @@ class UserPreferencesUpdate(BaseModel):
     notify_upcoming_bills: bool | None = None
     notify_days_ahead: int | None = None
 
+    # Salary & Tax Projections
+    salary_structure: dict[str, Any] | None = None
+    rsu_grants: list[dict[str, Any]] | None = None
+    growth_assumptions: dict[str, Any] | None = None
+
 
 # ----- Helper Functions -----
 
@@ -387,6 +402,9 @@ def _model_to_response(prefs: UserPreferences) -> UserPreferencesResponse:
         notify_anomalies=prefs.notify_anomalies,
         notify_upcoming_bills=prefs.notify_upcoming_bills,
         notify_days_ahead=prefs.notify_days_ahead,
+        salary_structure=_parse_json_field(prefs.salary_structure, {}),
+        rsu_grants=_parse_json_field(prefs.rsu_grants, []),
+        growth_assumptions=_parse_json_field(prefs.growth_assumptions, {}),
         created_at=prefs.created_at,
         updated_at=prefs.updated_at,
     )
@@ -652,3 +670,33 @@ def update_earning_start_date(
 ) -> UserPreferencesResponse:
     """Update earning start date configuration."""
     return _update_section(session, current_user, config)
+
+
+@router.put("/salary-structure")
+def update_salary_structure(
+    current_user: CurrentUser,
+    config: SalaryStructureConfig,
+    session: DatabaseSession,
+) -> UserPreferencesResponse:
+    """Update salary structure for one or more fiscal years."""
+    return _update_section(session, current_user, config, json_fields={"salary_structure"})
+
+
+@router.put("/rsu-grants")
+def update_rsu_grants(
+    current_user: CurrentUser,
+    config: RsuGrantsConfig,
+    session: DatabaseSession,
+) -> UserPreferencesResponse:
+    """Update RSU grants and vesting schedules."""
+    return _update_section(session, current_user, config, json_fields={"rsu_grants"})
+
+
+@router.put("/growth-assumptions")
+def update_growth_assumptions(
+    current_user: CurrentUser,
+    config: GrowthAssumptionsConfig,
+    session: DatabaseSession,
+) -> UserPreferencesResponse:
+    """Update growth assumptions for tax projections."""
+    return _update_section(session, current_user, config, json_fields={"growth_assumptions"})

--- a/backend/src/ledger_sync/api/preferences.py
+++ b/backend/src/ledger_sync/api/preferences.py
@@ -444,7 +444,7 @@ def _update_section(
 
     """
     prefs = _get_or_create_preferences(session, user)
-    for field, value in config.model_dump().items():
+    for field, value in config.model_dump(mode="json").items():
         if json_fields and field in json_fields:
             value = json.dumps(value)
         setattr(prefs, field, value)

--- a/backend/src/ledger_sync/db/migrations/versions/20260411_0726_e844a13cc445_add_salary_structure_rsu_grants_and_.py
+++ b/backend/src/ledger_sync/db/migrations/versions/20260411_0726_e844a13cc445_add_salary_structure_rsu_grants_and_.py
@@ -1,0 +1,37 @@
+"""add salary structure, RSU grants, and growth assumptions
+
+Revision ID: e844a13cc445
+Revises: e4f5a6b7c8d9
+Create Date: 2026-04-11 07:26:41.139729
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e844a13cc445"
+down_revision: str | None = "e4f5a6b7c8d9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_preferences",
+        sa.Column("salary_structure", sa.Text(), nullable=False, server_default="{}"),
+    )
+    op.add_column(
+        "user_preferences", sa.Column("rsu_grants", sa.Text(), nullable=False, server_default="[]")
+    )
+    op.add_column(
+        "user_preferences",
+        sa.Column("growth_assumptions", sa.Text(), nullable=False, server_default="{}"),
+    )
+
+
+def downgrade() -> None:
+    # Rollback requires a database backup (project convention post-2026-02-03)
+    pass

--- a/backend/src/ledger_sync/db/models.py
+++ b/backend/src/ledger_sync/db/models.py
@@ -1324,6 +1324,11 @@ class UserPreferences(Base):
     notify_upcoming_bills: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     notify_days_ahead: Mapped[int] = mapped_column(Integer, nullable=False, default=7)
 
+    # ── Salary & Tax Projections ──────────────────────────────────────────
+    salary_structure: Mapped[str] = mapped_column(Text, nullable=False, default="{}")
+    rsu_grants: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
+    growth_assumptions: Mapped[str] = mapped_column(Text, nullable=False, default="{}")
+
     # Metadata
     created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC))
     updated_at: Mapped[datetime] = mapped_column(

--- a/backend/src/ledger_sync/schemas/salary.py
+++ b/backend/src/ledger_sync/schemas/salary.py
@@ -11,8 +11,8 @@ from pydantic import BaseModel, Field
 class SalaryComponents(BaseModel):
     """Compensation breakdown for a single fiscal year."""
 
-    base_salary_monthly: Decimal = Decimal(0)
-    hra_monthly: Decimal | None = None
+    base_salary_annual: Decimal = Decimal(0)
+    hra_annual: Decimal | None = None
     bonus_annual: Decimal = Decimal(0)
     epf_monthly: Decimal = Decimal(3600)
     nps_monthly: Decimal = Decimal(0)

--- a/backend/src/ledger_sync/schemas/salary.py
+++ b/backend/src/ledger_sync/schemas/salary.py
@@ -1,0 +1,67 @@
+"""Pydantic schemas for salary structure, RSU grants, and growth assumptions."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from pydantic import BaseModel, Field
+
+
+class SalaryComponents(BaseModel):
+    """Compensation breakdown for a single fiscal year."""
+
+    base_salary_monthly: Decimal = Decimal(0)
+    hra_monthly: Decimal | None = None
+    bonus_annual: Decimal = Decimal(0)
+    epf_monthly: Decimal = Decimal(3600)
+    nps_monthly: Decimal = Decimal(0)
+    special_allowance_annual: Decimal = Decimal(0)
+    other_taxable_annual: Decimal = Decimal(0)
+
+
+class SalaryStructureConfig(BaseModel):
+    """Update payload for salary structure (keyed by FY string)."""
+
+    salary_structure: dict[str, SalaryComponents]
+
+
+class RsuVesting(BaseModel):
+    """A single vesting event within an RSU grant."""
+
+    date: date
+    quantity: int = Field(gt=0)
+
+
+class RsuGrant(BaseModel):
+    """An RSU grant with its vesting schedule."""
+
+    id: str
+    stock_name: str = Field(min_length=1)
+    stock_price: Decimal = Field(gt=0)
+    grant_date: date | None = None
+    notes: str | None = None
+    vestings: list[RsuVesting] = Field(min_length=1)
+
+
+class RsuGrantsConfig(BaseModel):
+    """Update payload for RSU grants."""
+
+    rsu_grants: list[RsuGrant]
+
+
+class GrowthAssumptions(BaseModel):
+    """Growth parameters for multi-year tax projections."""
+
+    base_salary_growth_pct: float = 0
+    bonus_growth_pct: float = 0
+    epf_scales_with_base: bool = True
+    nps_growth_pct: float = 0
+    stock_price_appreciation_pct: float = 0
+    projection_years: int = Field(default=3, ge=1, le=5)
+
+
+class GrowthAssumptionsConfig(BaseModel):
+    """Update payload for growth assumptions."""
+
+    growth_assumptions: GrowthAssumptions

--- a/backend/tests/unit/test_salary_schemas.py
+++ b/backend/tests/unit/test_salary_schemas.py
@@ -22,29 +22,29 @@ from ledger_sync.schemas.salary import (
 class TestSalaryComponents:
     def test_defaults(self):
         comp = SalaryComponents()
-        assert comp.base_salary_monthly == Decimal(0)
-        assert comp.hra_monthly is None
+        assert comp.base_salary_annual == Decimal(0)
+        assert comp.hra_annual is None
         assert comp.bonus_annual == Decimal(0)
         assert comp.epf_monthly == Decimal(3600)
         assert comp.nps_monthly == Decimal(0)
 
     def test_custom_values(self):
         comp = SalaryComponents(
-            base_salary_monthly=Decimal("80000"),
-            hra_monthly=Decimal("32000"),
+            base_salary_annual=Decimal("80000"),
+            hra_annual=Decimal("32000"),
             bonus_annual=Decimal("200000"),
         )
-        assert comp.base_salary_monthly == Decimal("80000")
-        assert comp.hra_monthly == Decimal("32000")
+        assert comp.base_salary_annual == Decimal("80000")
+        assert comp.hra_annual == Decimal("32000")
 
     def test_salary_structure_config(self):
         config = SalaryStructureConfig(
             salary_structure={
-                "2025-26": SalaryComponents(base_salary_monthly=Decimal("80000")),
+                "2025-26": SalaryComponents(base_salary_annual=Decimal("80000")),
             }
         )
         assert "2025-26" in config.salary_structure
-        assert config.salary_structure["2025-26"].base_salary_monthly == Decimal("80000")
+        assert config.salary_structure["2025-26"].base_salary_annual == Decimal("80000")
 
 
 class TestRsuGrant:

--- a/backend/tests/unit/test_salary_schemas.py
+++ b/backend/tests/unit/test_salary_schemas.py
@@ -1,0 +1,146 @@
+"""Tests for salary, RSU, and growth assumption schemas."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from ledger_sync.schemas.salary import (
+    GrowthAssumptions,
+    GrowthAssumptionsConfig,
+    RsuGrant,
+    RsuGrantsConfig,
+    RsuVesting,
+    SalaryComponents,
+    SalaryStructureConfig,
+)
+
+
+class TestSalaryComponents:
+    def test_defaults(self):
+        comp = SalaryComponents()
+        assert comp.base_salary_monthly == Decimal(0)
+        assert comp.hra_monthly is None
+        assert comp.bonus_annual == Decimal(0)
+        assert comp.epf_monthly == Decimal(3600)
+        assert comp.nps_monthly == Decimal(0)
+
+    def test_custom_values(self):
+        comp = SalaryComponents(
+            base_salary_monthly=Decimal("80000"),
+            hra_monthly=Decimal("32000"),
+            bonus_annual=Decimal("200000"),
+        )
+        assert comp.base_salary_monthly == Decimal("80000")
+        assert comp.hra_monthly == Decimal("32000")
+
+    def test_salary_structure_config(self):
+        config = SalaryStructureConfig(
+            salary_structure={
+                "2025-26": SalaryComponents(base_salary_monthly=Decimal("80000")),
+            }
+        )
+        assert "2025-26" in config.salary_structure
+        assert config.salary_structure["2025-26"].base_salary_monthly == Decimal("80000")
+
+
+class TestRsuGrant:
+    def test_valid_grant(self):
+        grant = RsuGrant(
+            id="grant-1",
+            stock_name="AMZN",
+            stock_price=Decimal("185.50"),
+            vestings=[RsuVesting(date=date(2026, 3, 15), quantity=25)],
+        )
+        assert grant.stock_name == "AMZN"
+        assert len(grant.vestings) == 1
+        assert grant.vestings[0].quantity == 25
+
+    def test_grant_requires_at_least_one_vesting(self):
+        with pytest.raises(ValidationError):
+            RsuGrant(
+                id="grant-1",
+                stock_name="AMZN",
+                stock_price=Decimal("185.50"),
+                vestings=[],
+            )
+
+    def test_vesting_quantity_must_be_positive(self):
+        with pytest.raises(ValidationError):
+            RsuVesting(date=date(2026, 3, 15), quantity=0)
+
+    def test_stock_price_must_be_positive(self):
+        with pytest.raises(ValidationError):
+            RsuGrant(
+                id="grant-1",
+                stock_name="AMZN",
+                stock_price=Decimal("0"),
+                vestings=[RsuVesting(date=date(2026, 3, 15), quantity=25)],
+            )
+
+    def test_stock_name_must_be_nonempty(self):
+        with pytest.raises(ValidationError):
+            RsuGrant(
+                id="grant-1",
+                stock_name="",
+                stock_price=Decimal("100"),
+                vestings=[RsuVesting(date=date(2026, 3, 15), quantity=25)],
+            )
+
+    def test_optional_fields(self):
+        grant = RsuGrant(
+            id="grant-1",
+            stock_name="GOOG",
+            stock_price=Decimal("150"),
+            grant_date=date(2025, 1, 1),
+            notes="Joining grant",
+            vestings=[RsuVesting(date=date(2026, 1, 1), quantity=10)],
+        )
+        assert grant.grant_date == date(2025, 1, 1)
+        assert grant.notes == "Joining grant"
+
+    def test_rsu_grants_config(self):
+        config = RsuGrantsConfig(
+            rsu_grants=[
+                RsuGrant(
+                    id="g1",
+                    stock_name="AMZN",
+                    stock_price=Decimal("185"),
+                    vestings=[RsuVesting(date=date(2026, 3, 15), quantity=25)],
+                )
+            ]
+        )
+        assert len(config.rsu_grants) == 1
+
+
+class TestGrowthAssumptions:
+    def test_defaults(self):
+        ga = GrowthAssumptions()
+        assert ga.base_salary_growth_pct == 0
+        assert ga.bonus_growth_pct == 0
+        assert ga.epf_scales_with_base is True
+        assert ga.nps_growth_pct == 0
+        assert ga.stock_price_appreciation_pct == 0
+        assert ga.projection_years == 3
+
+    def test_projection_years_bounds(self):
+        ga = GrowthAssumptions(projection_years=5)
+        assert ga.projection_years == 5
+
+        with pytest.raises(ValidationError):
+            GrowthAssumptions(projection_years=0)
+
+        with pytest.raises(ValidationError):
+            GrowthAssumptions(projection_years=6)
+
+    def test_growth_assumptions_config(self):
+        config = GrowthAssumptionsConfig(
+            growth_assumptions=GrowthAssumptions(
+                base_salary_growth_pct=10,
+                projection_years=4,
+            )
+        )
+        assert config.growth_assumptions.base_salary_growth_pct == 10

--- a/docs/API.md
+++ b/docs/API.md
@@ -782,8 +782,85 @@ User preference management. All require authentication.
 | PUT | `/api/preferences/spending-rule` | Update 50/30/20 targets |
 | PUT | `/api/preferences/credit-card-limits` | Update credit card limits |
 | PUT | `/api/preferences/earning-start-date` | Update earning start date |
+| PUT | `/api/preferences/salary-structure` | Update salary CTC structure per FY |
+| PUT | `/api/preferences/rsu-grants` | Update RSU grant list with vesting schedules |
+| PUT | `/api/preferences/growth-assumptions` | Update growth assumptions (hike %, variable growth, stock appreciation, projection years) |
 
-Preferences include 17 sections: fiscal year, essential categories, investment mappings, income classification, budget defaults, display format, anomaly settings, recurring settings, spending rule targets, credit card limits, earning start date, fixed expense categories, savings/investment targets, payday, tax regime, excluded accounts, and notification preferences.
+Preferences include 20 sections: fiscal year, essential categories, investment mappings, income classification, budget defaults, display format, anomaly settings, recurring settings, spending rule targets, credit card limits, earning start date, fixed expense categories, savings/investment targets, payday, tax regime, excluded accounts, notification preferences, salary structure, RSU grants, and growth assumptions.
+
+### Update Salary Structure
+
+**PUT** `/api/preferences/salary-structure`
+
+Update the salary CTC structure per fiscal year. Each FY key maps to a salary components object.
+
+**Request Body:**
+
+```json
+{
+  "salary_structure": {
+    "2025-26": {
+      "basic_annual": 600000,
+      "hra_annual": 300000,
+      "special_allowance_annual": 200000,
+      "epf_monthly": 1800,
+      "nps_monthly": null,
+      "professional_tax_annual": 2400,
+      "variable_pay_annual": 100000,
+      "other_annual": 0,
+      "is_new_regime": true
+    }
+  }
+}
+```
+
+### Update RSU Grants
+
+**PUT** `/api/preferences/rsu-grants`
+
+Update the list of RSU grants with vesting schedules.
+
+**Request Body:**
+
+```json
+{
+  "rsu_grants": [
+    {
+      "id": "grant-1",
+      "company": "ACME Corp",
+      "grant_date": "2025-01-15",
+      "total_shares": 100,
+      "stock_price": 1500,
+      "vesting_schedule": [
+        { "date": "2026-01-15", "quantity": 25 },
+        { "date": "2027-01-15", "quantity": 25 },
+        { "date": "2028-01-15", "quantity": 25 },
+        { "date": "2029-01-15", "quantity": 25 }
+      ]
+    }
+  ]
+}
+```
+
+### Update Growth Assumptions
+
+**PUT** `/api/preferences/growth-assumptions`
+
+Update the assumptions used for multi-year tax projections.
+
+**Request Body:**
+
+```json
+{
+  "growth_assumptions": {
+    "salary_hike_pct": 10,
+    "variable_growth_pct": 5,
+    "stock_appreciation_pct": 8,
+    "projection_years": 3,
+    "include_rsu_in_projection": true
+  }
+}
+```
 
 ---
 
@@ -898,6 +975,36 @@ Get AI-generated financial insights and recommendations.
   ]
 }
 ```
+
+---
+
+## Exchange Rate Endpoints
+
+### Get Exchange Rates
+
+**GET** `/api/exchange-rates`
+
+Fetch live exchange rates from the European Central Bank (via frankfurter.dev) with 24-hour in-memory cache.
+
+**Query Parameters:**
+
+- `base` (string, optional) - Base currency (default: `INR`)
+
+**Response (200 OK):**
+
+```json
+{
+  "base": "INR",
+  "rates": {
+    "USD": 0.01179,
+    "EUR": 0.01087,
+    "GBP": 0.00935
+  },
+  "updated_at": "2026-04-11T10:30:00Z"
+}
+```
+
+**Fallback behavior:** Fresh cache -> stale cache -> hardcoded fallback rates. Returns 502 only if all three tiers fail.
 
 ---
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Ledger Sync uses SQLite (dev) / Neon PostgreSQL (prod) with SQLAlchemy 2.0 ORM (Mapped types). The database stores financial transactions with multi-user support, and includes models for analytics, budgets, anomalies, net worth tracking, and user display preferences (including multi-currency settings).
+Ledger Sync uses SQLite (dev) / Neon PostgreSQL (prod) with SQLAlchemy 2.0 ORM (Mapped types). The database stores financial transactions with multi-user support, and includes models for analytics, budgets, anomalies, net worth tracking, user display preferences (including multi-currency settings), and salary/tax projection data.
 
 ## Database Models
 
@@ -81,7 +81,10 @@ ix_transactions_user_date_type (user_id, date, type)
 The database also includes these models (see `backend/src/ledger_sync/db/models.py`):
 
 - **User** — OAuth authentication (Google, GitHub) with JWT tokens. Fields: `email`, `full_name`, `auth_provider`, `auth_provider_id`, `is_verified`, timestamps
-- **UserPreferences** — 17 sections: fiscal year, essential categories, investment mappings, income classification, budget defaults, display format, anomaly settings, recurring settings, spending rule targets, credit card limits, earning start date, fixed expenses, savings/investment targets, payday, tax regime, excluded accounts, notification preferences
+- **UserPreferences** — 20 sections: fiscal year, essential categories, investment mappings, income classification, budget defaults, display format, anomaly settings, recurring settings, spending rule targets, credit card limits, earning start date, fixed expenses, savings/investment targets, payday, tax regime, excluded accounts, notification preferences, salary structure, RSU grants, growth assumptions. The last three are JSON columns added for income & tax projection support:
+  - `salary_structure` (JSON) — FY-keyed salary CTC breakdown (basic, HRA, special allowance, EPF, NPS, professional tax, variable pay)
+  - `rsu_grants` (JSON) — array of RSU grants with vesting schedules
+  - `growth_assumptions` (JSON) — salary hike %, variable growth %, stock appreciation %, projection years, RSU inclusion flag
 - **AccountClassification** — User-defined account type mappings (Bank, Investment, Credit Card, etc.)
 - **DailySummary** — Pre-computed daily aggregations (income, expenses, net, counts, top category per day). Unique index on (user_id, date). Used by YearInReview heatmap.
 - **MonthlySummary** — Pre-calculated monthly income/expense/savings aggregations

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -249,7 +249,7 @@ print(f"Elapsed: {end - start:.3f}s")
 ```
 frontend/
 ├── src/
-│   ├── pages/           # Page components (23 pages)
+│   ├── pages/           # 23 page components
 │   ├── components/      # UI components
 │   │   ├── analytics/   # Analytics components (25+, including CategoryBreakdown)
 │   │   ├── layout/      # Layout components
@@ -261,7 +261,7 @@ frontend/
 │   │   ├── useAnalyticsTimeFilter.ts  # Shared time-filter state for analytics pages
 │   │   ├── useChartDimensions.ts      # Responsive chart sizing
 │   │   └── api/         # API-specific hooks (TanStack Query)
-│   ├── lib/             # Utilities (cn, queryClient)
+│   ├── lib/             # Utilities (formatters, tax/projection calculators, queryClient)
 │   ├── services/        # API client
 │   │   └── api/         # API service modules
 │   ├── store/           # Zustand state stores
@@ -291,13 +291,9 @@ export default function NewPage() {
 }
 ```
 
-2. **Export from** `src/pages/index.ts`:
+2. **Add lazy import and route** in `App.tsx` (inside `pageImports` and `<Routes>`). Never eager-import pages.
 
-```tsx
-export { default as NewPage } from "./NewPage";
-```
-
-3. **Add route** in App.tsx or router configuration
+3. **Add sidebar entry** in `Sidebar.tsx` under the appropriate navigation group.
 
 ### Creating New Analytics Components
 
@@ -330,11 +326,7 @@ export default function MyAnalyticsComponent({ timeRange }: Props) {
 }
 ```
 
-2. **Export from** `src/components/analytics/index.ts`:
-
-```tsx
-export { default as MyAnalyticsComponent } from "./MyAnalyticsComponent";
-```
+2. **Import directly** from the file where needed (no barrel files / `index.ts` re-exports).
 
 ### Using the Shared Analytics Time Filter
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -18,13 +18,14 @@ Ledger Sync includes comprehensive testing for both backend and frontend to ensu
 ```
 backend/tests/
 ├── __init__.py
-├── conftest.py          # Shared fixtures
-├── fixtures/            # Test data fixtures
+├── conftest.py              # Shared fixtures
+├── fixtures/                # Test data fixtures
 │   └── README.md
-├── unit/                # Unit tests
+├── unit/                    # Unit tests
 │   ├── test_hash_id.py
-│   └── test_normalizer.py
-└── integration/         # Integration tests
+│   ├── test_normalizer.py
+│   └── test_salary_schemas.py   # Salary, RSU, growth assumption validation
+└── integration/             # Integration tests
     └── test_reconciler.py
 ```
 
@@ -276,9 +277,46 @@ frontend/
 │   ├── hooks/
 │   │   └── __tests__/      # Hook tests
 │   └── lib/
-│       └── __tests__/      # Utility tests
+│       └── __tests__/      # Utility tests (incl. projectionCalculator.test.ts)
 └── vitest.config.ts        # Vitest configuration
 ```
+
+### Projection Calculator Tests (Example)
+
+The projection calculator (`lib/projectionCalculator.ts`) uses a TDD approach with pure functions:
+
+```typescript
+// src/lib/__tests__/projectionCalculator.test.ts
+import { describe, it, expect } from 'vitest'
+import { projectFiscalYear, projectMultipleYears, getRsuVestingsByFY } from '../projectionCalculator'
+
+describe('projectFiscalYear', () => {
+  const baseSalary = {
+    '2025-26': {
+      basic_annual: 600000, hra_annual: 300000,
+      special_allowance_annual: 200000, epf_monthly: 1800,
+      nps_monthly: null, professional_tax_annual: 2400,
+      variable_pay_annual: 100000, other_annual: 0, is_new_regime: true,
+    },
+  }
+
+  it('projects future FY with salary hike', () => {
+    const result = projectFiscalYear('2026-27', baseSalary, [], {
+      salary_hike_pct: 10, variable_growth_pct: 5,
+      stock_appreciation_pct: 8, projection_years: 3,
+      include_rsu_in_projection: true,
+    }, 4)
+    expect(result.grossTaxable).toBeGreaterThan(1200000)
+  })
+
+  it('returns base FY as-is when targetFY matches', () => {
+    const result = projectFiscalYear('2025-26', baseSalary, [], defaultGrowth, 4)
+    expect(result.fy).toBe('2025-26')
+  })
+})
+```
+
+Tests cover: base FY passthrough, single-year projection, multi-year compounding, RSU vesting with appreciation, empty salary structure edge cases.
 
 ### Running Tests
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Ledger Sync is a self-hosted personal finance dashboard built as a full-stack application with clear separation between backend and frontend. The system imports Excel bank statements, reconciles transactions via SHA-256 hashing, and delivers 23 pages of financial analytics -- from spending breakdowns to investment tracking -- with multi-currency display support.
+Ledger Sync is a self-hosted personal finance dashboard built as a full-stack application with clear separation between backend and frontend. The system imports Excel bank statements, reconciles transactions via SHA-256 hashing, and delivers 23 pages of financial analytics -- from spending breakdowns to investment tracking and tax projections -- with multi-currency display support.
 
 ## High-Level Architecture
 
@@ -23,6 +23,7 @@ Ledger Sync is a self-hosted personal finance dashboard built as a full-stack ap
   - `oauth.py` - OAuth login via Google and GitHub (authorization code exchange via `httpx`)
   - `analytics.py` - Analytics endpoints (overview, KPIs, trends, behavior)
   - `calculations.py` - Financial calculation endpoints
+  - `exchange_rates.py` - Exchange rate proxy with 24h cache (frankfurter.dev)
   - `deps.py` - JWT authentication dependency (`get_current_user`)
   - Routes requests to business logic and return JSON responses
 - **Authentication**: OAuth-only (no email/password). Google/GitHub OAuth providers configured via environment variables. Backend exchanges authorization codes for user info, then issues JWT access/refresh tokens.
@@ -85,6 +86,31 @@ For each imported transaction:
 6. Mark old transactions not in import as SOFT_DELETE
 ```
 
+#### Income & Tax Projection Pipeline
+
+The projection system is entirely client-side (no backend computation). Data flows through these layers:
+
+```
+Settings (SalaryStructureSection)
+  -> preferencesStore (Zustand, persisted to API)
+     -> TaxPlanningPage reads salaryStructure, rsuGrants, growthAssumptions
+        -> projectionCalculator.ts (pure functions)
+           -> projectFiscalYear(targetFY, salary, rsus, growth, fyStartMonth)
+              -> Returns ProjectedFYBreakdown (gross, basic, variable, RSU vestings)
+           -> projectMultipleYears(salary, rsus, growth, fyStartMonth)
+              -> Returns array of projected breakdowns for comparison table
+           -> getRsuVestingsByFY(grants, fyStartMonth, appreciation)
+              -> Returns FY-keyed vesting amounts with stock appreciation
+        -> taxCalculator.ts computes tax on projected gross
+           -> Returns slab breakdown, cess, surcharge, rebate
+```
+
+Key design decisions:
+- **Pure functions**: `projectionCalculator.ts` has zero side effects, making it trivially testable
+- **FY-keyed salary**: Each fiscal year has its own salary structure, allowing users to track raises
+- **Growth compounding**: Projections compound from the latest user-entered FY (not from the current FY)
+- **RSU appreciation**: Stock price appreciates at user-configured rate from grant date to vesting date
+
 #### Financial Calculations
 
 ```python
@@ -122,7 +148,8 @@ NET Investment = Transfer-In amounts - Transfer-Out amounts
   - `InvestmentAnalyticsPage` - 4-category investment portfolio
   - `MutualFundProjectionPage` - SIP/MF projections
   - `ReturnsAnalysisPage` - Investment returns tracking
-  - `TaxPlanningPage` - Tax planning tools
+  - `TaxPlanningPage` - Tax planning with salary-based multi-year projections
+  - `FIRECalculatorPage` - FIRE number, Coast FIRE, retirement corpus planner
   - `NetWorthPage` - Net worth tracking
   - `BudgetPage` - Budget tracking and monitoring
   - `GoalsPage` - Financial goal setting with savings allocation
@@ -131,7 +158,7 @@ NET Investment = Transfer-In amounts - Transfer-Out amounts
   - `YearInReviewPage` - Annual financial summary
   - `SubscriptionTrackerPage` - Recurring expense detection and manual tracking
   - `BillCalendarPage` - Monthly calendar of upcoming bills
-  - `SettingsPage` - Single-page settings with collapsible sections
+  - `SettingsPage` - Single-page settings with collapsible sections (incl. SalaryStructureSection)
 
 #### 2. **Components Layer** (`src/components/`)
 
@@ -190,6 +217,10 @@ NET Investment = Transfer-In amounts - Transfer-Out amounts
 - **Modules**:
   - `cn.ts` - Class name utility (clsx + tailwind-merge)
   - `queryClient.ts` - TanStack Query client configuration
+  - `projectionCalculator.ts` - Pure functions for multi-year salary/RSU/tax projections
+  - `taxCalculator.ts` - India tax slab computation (old and new regime)
+  - `fireCalculator.ts` - FIRE number, Coast FIRE, retirement corpus calculations
+  - `formatters.ts` - Currency and number formatting with multi-currency conversion
 
 ### Component Hierarchy
 

--- a/docs/superpowers/plans/2026-04-11-income-tax-projections.md
+++ b/docs/superpowers/plans/2026-04-11-income-tax-projections.md
@@ -1,0 +1,2263 @@
+# Income & Tax Projections Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add salary structure input to Settings, RSU vesting schedule tracking, growth assumptions, and multi-year tax projections integrated into the existing Tax Planning page.
+
+**Architecture:** Three new JSON columns in `user_preferences` store salary_structure (per-FY dict), rsu_grants (array with inline vestings), and growth_assumptions (single object). Three new PUT endpoints extend the preferences API. A new `projectionCalculator.ts` module provides pure functions that consume this data and produce per-FY tax breakdowns using the existing `calculateTax()` from `taxCalculator.ts`. The Tax Planning page extends its FY navigator into future years and renders projection data when salary structure is configured.
+
+**Tech Stack:** Python 3.14 / FastAPI / SQLAlchemy 2.0 / Alembic (backend); React 19 / TypeScript / Zustand / TanStack Query / Recharts / Tailwind CSS 4 (frontend)
+
+---
+
+## File Map
+
+### New Files
+
+| File | Responsibility |
+|------|---------------|
+| `backend/src/ledger_sync/schemas/salary.py` | Pydantic models: SalaryComponents, RsuGrant, RsuVesting, GrowthAssumptions, config wrappers |
+| `backend/alembic/versions/xxxx_add_salary_rsu_growth_fields.py` | Migration: 3 JSON columns on user_preferences |
+| `backend/tests/unit/test_salary_schemas.py` | Pydantic validation tests |
+| `frontend/src/types/salary.ts` | TypeScript interfaces for salary, RSU, growth |
+| `frontend/src/lib/projectionCalculator.ts` | Pure projection functions: projectFiscalYear, projectMultipleYears, getRsuVestingsByFY |
+| `frontend/src/lib/__tests__/projectionCalculator.test.ts` | Unit tests for projection logic |
+| `frontend/src/pages/settings/SalaryStructureSection.tsx` | Settings UI: salary grid, RSU grant cards, growth assumptions |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `backend/src/ledger_sync/db/models.py` | Add 3 columns to UserPreferences |
+| `backend/src/ledger_sync/api/preferences.py` | Add 3 PUT endpoints, extend _model_to_response |
+| `backend/src/ledger_sync/schemas/preferences.py` | Add 3 fields to UserPreferencesResponse and UserPreferencesUpdate |
+| `frontend/src/services/api/preferences.ts` | Add 3 fields to UserPreferences interface, 3 config types, 3 service methods |
+| `frontend/src/hooks/api/usePreferences.ts` | Add 3 mutation hooks |
+| `frontend/src/store/preferencesStore.ts` | Add salary/rsu/growth state, actions, hydration, selectors |
+| `frontend/src/pages/settings/useSettingsState.ts` | Include salary/rsu/growth in local state, save flow |
+| `frontend/src/pages/SettingsPage.tsx` | Import and render SalaryStructureSection |
+| `frontend/src/pages/TaxPlanningPage.tsx` | FY nav extension, projection toggle, multi-year table, insights |
+
+---
+
+## Parallelization Guide
+
+Tasks are grouped into **3 independent tracks** that can run concurrently:
+
+- **Track A (Backend):** Tasks 1 → 2 → 3 → 4 (sequential)
+- **Track B (Frontend Infra):** Tasks 5 → 6 → 7 (sequential)
+- **Track C (Projection Logic):** Task 8 → 9 (sequential, depends only on Task 5 for types)
+
+After all tracks complete:
+- **Task 10:** Settings UI (depends on Track B + Track C)
+- **Task 11:** Tax Planning page enhancement (depends on all tracks)
+- **Task 12:** Full integration verification
+
+---
+
+## Task 1: Backend — Pydantic Schemas for Salary, RSU, Growth
+
+**Files:**
+- Create: `backend/src/ledger_sync/schemas/salary.py`
+
+- [ ] **Step 1: Create the salary schemas file**
+
+```python
+"""Pydantic schemas for salary structure, RSU grants, and growth assumptions."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from pydantic import BaseModel, Field
+
+
+class SalaryComponents(BaseModel):
+    """Compensation breakdown for a single fiscal year."""
+
+    base_salary_monthly: Decimal = Decimal(0)
+    hra_monthly: Decimal | None = None
+    bonus_annual: Decimal = Decimal(0)
+    epf_monthly: Decimal = Decimal(3600)
+    nps_monthly: Decimal = Decimal(0)
+    special_allowance_annual: Decimal = Decimal(0)
+    other_taxable_annual: Decimal = Decimal(0)
+
+
+class SalaryStructureConfig(BaseModel):
+    """Update payload for salary structure (keyed by FY string)."""
+
+    salary_structure: dict[str, SalaryComponents]
+
+
+class RsuVesting(BaseModel):
+    """A single vesting event within an RSU grant."""
+
+    date: date
+    quantity: int = Field(gt=0)
+
+
+class RsuGrant(BaseModel):
+    """An RSU grant with its vesting schedule."""
+
+    id: str
+    stock_name: str = Field(min_length=1)
+    stock_price: Decimal = Field(gt=0)
+    grant_date: date | None = None
+    notes: str | None = None
+    vestings: list[RsuVesting] = Field(min_length=1)
+
+
+class RsuGrantsConfig(BaseModel):
+    """Update payload for RSU grants."""
+
+    rsu_grants: list[RsuGrant]
+
+
+class GrowthAssumptions(BaseModel):
+    """Growth parameters for multi-year tax projections."""
+
+    base_salary_growth_pct: float = 0
+    bonus_growth_pct: float = 0
+    epf_scales_with_base: bool = True
+    nps_growth_pct: float = 0
+    stock_price_appreciation_pct: float = 0
+    projection_years: int = Field(default=3, ge=1, le=5)
+
+
+class GrowthAssumptionsConfig(BaseModel):
+    """Update payload for growth assumptions."""
+
+    growth_assumptions: GrowthAssumptions
+```
+
+Write this file to `backend/src/ledger_sync/schemas/salary.py`.
+
+- [ ] **Step 2: Verify import works**
+
+Run: `cd backend && uv run python -c "from ledger_sync.schemas.salary import SalaryComponents, RsuGrant, GrowthAssumptions; print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/ledger_sync/schemas/salary.py
+git commit -m "feat: add Pydantic schemas for salary, RSU, and growth assumptions"
+```
+
+---
+
+## Task 2: Backend — Database Model + Migration
+
+**Files:**
+- Modify: `backend/src/ledger_sync/db/models.py` (UserPreferences class)
+- Create: `backend/alembic/versions/xxxx_add_salary_rsu_growth_fields.py`
+
+- [ ] **Step 1: Add columns to UserPreferences model**
+
+In `backend/src/ledger_sync/db/models.py`, find the UserPreferences class. Add these 3 columns after the existing `notify_days_ahead` field (before `created_at`):
+
+```python
+    # ── Salary & Tax Projections ──────────────────────────────────────────
+    salary_structure: Mapped[str] = mapped_column(Text, nullable=False, default="{}")
+    rsu_grants: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
+    growth_assumptions: Mapped[str] = mapped_column(Text, nullable=False, default="{}")
+```
+
+Pattern matches existing JSON fields like `credit_card_limits` (stored as `Text`, parsed at API layer).
+
+- [ ] **Step 2: Generate Alembic migration**
+
+Run: `cd backend && uv run alembic revision --autogenerate -m "add salary structure, RSU grants, and growth assumptions"`
+
+- [ ] **Step 3: Edit the migration — set empty downgrade**
+
+Open the generated migration file. The `upgrade()` should contain 3 `op.add_column` calls. Set `downgrade()` to empty (consistent with project convention post-2026-02-03):
+
+```python
+def downgrade() -> None:
+    pass
+```
+
+- [ ] **Step 4: Apply migration**
+
+Run: `cd backend && uv run alembic upgrade head`
+Expected: Migration applies successfully.
+
+- [ ] **Step 5: Verify columns exist**
+
+Run: `cd backend && uv run python -c "from ledger_sync.db.models import UserPreferences; print([c.name for c in UserPreferences.__table__.columns if 'salary' in c.name or 'rsu' in c.name or 'growth' in c.name])"`
+Expected: `['salary_structure', 'rsu_grants', 'growth_assumptions']`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/ledger_sync/db/models.py backend/alembic/versions/
+git commit -m "feat: add salary_structure, rsu_grants, growth_assumptions columns to user_preferences"
+```
+
+---
+
+## Task 3: Backend — API Endpoints
+
+**Files:**
+- Modify: `backend/src/ledger_sync/api/preferences.py`
+- Modify: `backend/src/ledger_sync/schemas/preferences.py`
+
+- [ ] **Step 1: Extend UserPreferencesResponse in schemas/preferences.py**
+
+Add these 3 fields to the `UserPreferencesResponse` class (after the existing `notify_days_ahead` field):
+
+```python
+    # Salary & Tax Projections
+    salary_structure: dict[str, Any] = {}
+    rsu_grants: list[dict[str, Any]] = []
+    growth_assumptions: dict[str, Any] = {}
+```
+
+Ensure `from typing import Any` is already imported (it should be — verify).
+
+Also add the same 3 fields to `UserPreferencesUpdate` (as optional):
+
+```python
+    salary_structure: dict[str, Any] | None = None
+    rsu_grants: list[dict[str, Any]] | None = None
+    growth_assumptions: dict[str, Any] | None = None
+```
+
+- [ ] **Step 2: Extend _model_to_response in api/preferences.py**
+
+Add the import at top of preferences.py:
+
+```python
+from ledger_sync.schemas.salary import (
+    GrowthAssumptionsConfig,
+    RsuGrantsConfig,
+    SalaryStructureConfig,
+)
+```
+
+In the `_model_to_response()` function, add these 3 lines (alongside existing JSON field conversions like `credit_card_limits`):
+
+```python
+        salary_structure=_parse_json_field(prefs.salary_structure, {}),
+        rsu_grants=_parse_json_field(prefs.rsu_grants, []),
+        growth_assumptions=_parse_json_field(prefs.growth_assumptions, {}),
+```
+
+- [ ] **Step 3: Add 3 new PUT endpoints**
+
+Add these endpoints to `backend/src/ledger_sync/api/preferences.py`, after the existing section endpoints (e.g., after `update_earning_start_date`):
+
+```python
+@router.put("/salary-structure")
+def update_salary_structure(
+    current_user: CurrentUser,
+    config: SalaryStructureConfig,
+    session: DatabaseSession,
+) -> UserPreferencesResponse:
+    """Update salary structure for one or more fiscal years."""
+    return _update_section(session, current_user, config, json_fields={"salary_structure"})
+
+
+@router.put("/rsu-grants")
+def update_rsu_grants(
+    current_user: CurrentUser,
+    config: RsuGrantsConfig,
+    session: DatabaseSession,
+) -> UserPreferencesResponse:
+    """Update RSU grants and vesting schedules."""
+    return _update_section(session, current_user, config, json_fields={"rsu_grants"})
+
+
+@router.put("/growth-assumptions")
+def update_growth_assumptions(
+    current_user: CurrentUser,
+    config: GrowthAssumptionsConfig,
+    session: DatabaseSession,
+) -> UserPreferencesResponse:
+    """Update growth assumptions for tax projections."""
+    return _update_section(session, current_user, config, json_fields={"growth_assumptions"})
+```
+
+- [ ] **Step 4: Verify endpoints register**
+
+Run: `cd backend && uv run python -c "from ledger_sync.main import app; routes = [r.path for r in app.routes]; print([r for r in routes if 'salary' in r or 'rsu' in r or 'growth' in r])"`
+Expected: List containing the 3 new endpoint paths.
+
+- [ ] **Step 5: Run existing tests to ensure no regressions**
+
+Run: `cd backend && uv run pytest tests/ -v`
+Expected: All 38 existing tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/ledger_sync/api/preferences.py backend/src/ledger_sync/schemas/preferences.py
+git commit -m "feat: add salary-structure, rsu-grants, growth-assumptions API endpoints"
+```
+
+---
+
+## Task 4: Backend — Unit Tests for Schemas
+
+**Files:**
+- Create: `backend/tests/unit/test_salary_schemas.py`
+
+- [ ] **Step 1: Write schema validation tests**
+
+```python
+"""Tests for salary, RSU, and growth assumption schemas."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from ledger_sync.schemas.salary import (
+    GrowthAssumptions,
+    GrowthAssumptionsConfig,
+    RsuGrant,
+    RsuGrantsConfig,
+    RsuVesting,
+    SalaryComponents,
+    SalaryStructureConfig,
+)
+
+
+class TestSalaryComponents:
+    def test_defaults(self):
+        comp = SalaryComponents()
+        assert comp.base_salary_monthly == Decimal(0)
+        assert comp.hra_monthly is None
+        assert comp.bonus_annual == Decimal(0)
+        assert comp.epf_monthly == Decimal(3600)
+        assert comp.nps_monthly == Decimal(0)
+
+    def test_custom_values(self):
+        comp = SalaryComponents(
+            base_salary_monthly=Decimal("80000"),
+            hra_monthly=Decimal("32000"),
+            bonus_annual=Decimal("200000"),
+        )
+        assert comp.base_salary_monthly == Decimal("80000")
+        assert comp.hra_monthly == Decimal("32000")
+
+    def test_salary_structure_config(self):
+        config = SalaryStructureConfig(
+            salary_structure={
+                "2025-26": SalaryComponents(base_salary_monthly=Decimal("80000")),
+            }
+        )
+        assert "2025-26" in config.salary_structure
+        assert config.salary_structure["2025-26"].base_salary_monthly == Decimal("80000")
+
+
+class TestRsuGrant:
+    def test_valid_grant(self):
+        grant = RsuGrant(
+            id="grant-1",
+            stock_name="AMZN",
+            stock_price=Decimal("185.50"),
+            vestings=[RsuVesting(date=date(2026, 3, 15), quantity=25)],
+        )
+        assert grant.stock_name == "AMZN"
+        assert len(grant.vestings) == 1
+        assert grant.vestings[0].quantity == 25
+
+    def test_grant_requires_at_least_one_vesting(self):
+        with pytest.raises(ValidationError):
+            RsuGrant(
+                id="grant-1",
+                stock_name="AMZN",
+                stock_price=Decimal("185.50"),
+                vestings=[],
+            )
+
+    def test_vesting_quantity_must_be_positive(self):
+        with pytest.raises(ValidationError):
+            RsuVesting(date=date(2026, 3, 15), quantity=0)
+
+    def test_stock_price_must_be_positive(self):
+        with pytest.raises(ValidationError):
+            RsuGrant(
+                id="grant-1",
+                stock_name="AMZN",
+                stock_price=Decimal("0"),
+                vestings=[RsuVesting(date=date(2026, 3, 15), quantity=25)],
+            )
+
+    def test_stock_name_must_be_nonempty(self):
+        with pytest.raises(ValidationError):
+            RsuGrant(
+                id="grant-1",
+                stock_name="",
+                stock_price=Decimal("100"),
+                vestings=[RsuVesting(date=date(2026, 3, 15), quantity=25)],
+            )
+
+    def test_optional_fields(self):
+        grant = RsuGrant(
+            id="grant-1",
+            stock_name="GOOG",
+            stock_price=Decimal("150"),
+            grant_date=date(2025, 1, 1),
+            notes="Joining grant",
+            vestings=[RsuVesting(date=date(2026, 1, 1), quantity=10)],
+        )
+        assert grant.grant_date == date(2025, 1, 1)
+        assert grant.notes == "Joining grant"
+
+    def test_rsu_grants_config(self):
+        config = RsuGrantsConfig(
+            rsu_grants=[
+                RsuGrant(
+                    id="g1",
+                    stock_name="AMZN",
+                    stock_price=Decimal("185"),
+                    vestings=[RsuVesting(date=date(2026, 3, 15), quantity=25)],
+                )
+            ]
+        )
+        assert len(config.rsu_grants) == 1
+
+
+class TestGrowthAssumptions:
+    def test_defaults(self):
+        ga = GrowthAssumptions()
+        assert ga.base_salary_growth_pct == 0
+        assert ga.bonus_growth_pct == 0
+        assert ga.epf_scales_with_base is True
+        assert ga.nps_growth_pct == 0
+        assert ga.stock_price_appreciation_pct == 0
+        assert ga.projection_years == 3
+
+    def test_projection_years_bounds(self):
+        ga = GrowthAssumptions(projection_years=5)
+        assert ga.projection_years == 5
+
+        with pytest.raises(ValidationError):
+            GrowthAssumptions(projection_years=0)
+
+        with pytest.raises(ValidationError):
+            GrowthAssumptions(projection_years=6)
+
+    def test_growth_assumptions_config(self):
+        config = GrowthAssumptionsConfig(
+            growth_assumptions=GrowthAssumptions(
+                base_salary_growth_pct=10,
+                projection_years=4,
+            )
+        )
+        assert config.growth_assumptions.base_salary_growth_pct == 10
+```
+
+Write this file to `backend/tests/unit/test_salary_schemas.py`.
+
+- [ ] **Step 2: Run the tests**
+
+Run: `cd backend && uv run pytest tests/unit/test_salary_schemas.py -v`
+Expected: All tests pass.
+
+- [ ] **Step 3: Run full backend test suite**
+
+Run: `cd backend && uv run pytest tests/ -v`
+Expected: All tests pass (38 existing + new schema tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/tests/unit/test_salary_schemas.py
+git commit -m "test: add unit tests for salary, RSU, and growth assumption schemas"
+```
+
+---
+
+## Task 5: Frontend — TypeScript Types
+
+**Files:**
+- Create: `frontend/src/types/salary.ts`
+
+- [ ] **Step 1: Create salary types file**
+
+```typescript
+/** Compensation breakdown for a single fiscal year. */
+export interface SalaryComponents {
+  base_salary_monthly: number
+  hra_monthly: number | null
+  bonus_annual: number
+  epf_monthly: number
+  nps_monthly: number
+  special_allowance_annual: number
+  other_taxable_annual: number
+}
+
+/** A single vesting event within an RSU grant. */
+export interface RsuVesting {
+  date: string // YYYY-MM-DD
+  quantity: number
+}
+
+/** An RSU grant with its vesting schedule. */
+export interface RsuGrant {
+  id: string
+  stock_name: string
+  stock_price: number
+  grant_date: string | null
+  notes: string | null
+  vestings: RsuVesting[]
+}
+
+/** Growth parameters for multi-year projections. */
+export interface GrowthAssumptions {
+  base_salary_growth_pct: number
+  bonus_growth_pct: number
+  epf_scales_with_base: boolean
+  nps_growth_pct: number
+  stock_price_appreciation_pct: number
+  projection_years: number
+}
+
+/** Default salary components for a new FY entry. */
+export const DEFAULT_SALARY_COMPONENTS: SalaryComponents = {
+  base_salary_monthly: 0,
+  hra_monthly: null,
+  bonus_annual: 0,
+  epf_monthly: 3600,
+  nps_monthly: 0,
+  special_allowance_annual: 0,
+  other_taxable_annual: 0,
+}
+
+/** Default growth assumptions. */
+export const DEFAULT_GROWTH_ASSUMPTIONS: GrowthAssumptions = {
+  base_salary_growth_pct: 0,
+  bonus_growth_pct: 0,
+  epf_scales_with_base: true,
+  nps_growth_pct: 0,
+  stock_price_appreciation_pct: 0,
+  projection_years: 3,
+}
+
+/** Projected breakdown for a single fiscal year. */
+export interface ProjectedFYBreakdown {
+  fy: string
+  baseSalary: number
+  hra: number
+  bonus: number
+  epf: number
+  nps: number
+  specialAllowance: number
+  otherTaxable: number
+  rsuIncome: number
+  rsuDetails: Array<{ stock_name: string; shares: number; value: number }>
+  grossTaxable: number
+  standardDeduction: number
+  netTaxable: number
+  totalTax: number
+  takeHome: number
+  effectiveTaxRate: number
+  isProjected: boolean // true if computed from growth assumptions, false if from explicit FY data
+}
+```
+
+Write this file to `frontend/src/types/salary.ts`.
+
+- [ ] **Step 2: Verify TypeScript compilation**
+
+Run: `cd frontend && pnpm run type-check`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/types/salary.ts
+git commit -m "feat: add TypeScript types for salary, RSU, and growth projections"
+```
+
+---
+
+## Task 6: Frontend — API Service & Query Hooks
+
+**Files:**
+- Modify: `frontend/src/services/api/preferences.ts`
+- Modify: `frontend/src/hooks/api/usePreferences.ts`
+
+- [ ] **Step 1: Extend the UserPreferences interface**
+
+In `frontend/src/services/api/preferences.ts`, add the import at the top:
+
+```typescript
+import type { SalaryComponents, RsuGrant, GrowthAssumptions } from '@/types/salary'
+```
+
+Add these 3 fields to the `UserPreferences` interface (after `notify_days_ahead`):
+
+```typescript
+  // Salary & Tax Projections
+  salary_structure: Record<string, SalaryComponents>
+  rsu_grants: RsuGrant[]
+  growth_assumptions: GrowthAssumptions
+```
+
+- [ ] **Step 2: Add config types and service methods**
+
+Add these config types (after existing config types like `CreditCardLimitsConfig`):
+
+```typescript
+export interface SalaryStructureConfig {
+  salary_structure: Record<string, SalaryComponents>
+}
+
+export interface RsuGrantsConfig {
+  rsu_grants: RsuGrant[]
+}
+
+export interface GrowthAssumptionsConfig {
+  growth_assumptions: GrowthAssumptions
+}
+```
+
+Add these methods to the `preferencesService` object:
+
+```typescript
+  updateSalaryStructure: createSectionUpdater<SalaryStructureConfig>('salary-structure'),
+  updateRsuGrants: createSectionUpdater<RsuGrantsConfig>('rsu-grants'),
+  updateGrowthAssumptions: createSectionUpdater<GrowthAssumptionsConfig>('growth-assumptions'),
+```
+
+- [ ] **Step 3: Add mutation hooks**
+
+In `frontend/src/hooks/api/usePreferences.ts`, add the import:
+
+```typescript
+import type { SalaryStructureConfig, RsuGrantsConfig, GrowthAssumptionsConfig } from '@/services/api/preferences'
+```
+
+Add these 3 mutation hooks (after existing section mutation hooks):
+
+```typescript
+export function useUpdateSalaryStructure() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (config: SalaryStructureConfig) =>
+      preferencesService.updateSalaryStructure(config),
+    onSuccess: () => invalidatePreferenceDependents(queryClient),
+  })
+}
+
+export function useUpdateRsuGrants() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (config: RsuGrantsConfig) =>
+      preferencesService.updateRsuGrants(config),
+    onSuccess: () => invalidatePreferenceDependents(queryClient),
+  })
+}
+
+export function useUpdateGrowthAssumptions() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (config: GrowthAssumptionsConfig) =>
+      preferencesService.updateGrowthAssumptions(config),
+    onSuccess: () => invalidatePreferenceDependents(queryClient),
+  })
+}
+```
+
+- [ ] **Step 4: Verify TypeScript compilation**
+
+Run: `cd frontend && pnpm run type-check`
+Expected: No errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/services/api/preferences.ts frontend/src/hooks/api/usePreferences.ts
+git commit -m "feat: add salary, RSU, growth API service methods and query hooks"
+```
+
+---
+
+## Task 7: Frontend — Zustand Store Extensions
+
+**Files:**
+- Modify: `frontend/src/store/preferencesStore.ts`
+
+- [ ] **Step 1: Add imports and state**
+
+Add the import at the top:
+
+```typescript
+import type { SalaryComponents, RsuGrant, GrowthAssumptions } from '@/types/salary'
+import { DEFAULT_GROWTH_ASSUMPTIONS } from '@/types/salary'
+```
+
+Add these fields to the `PreferencesState` interface:
+
+```typescript
+  // Salary & Tax Projections
+  salaryStructure: Record<string, SalaryComponents>
+  rsuGrants: RsuGrant[]
+  growthAssumptions: GrowthAssumptions
+
+  // Actions
+  setSalaryStructure: (structure: Record<string, SalaryComponents>) => void
+  setRsuGrants: (grants: RsuGrant[]) => void
+  setGrowthAssumptions: (assumptions: GrowthAssumptions) => void
+```
+
+- [ ] **Step 2: Add defaults, actions, and hydration**
+
+Add defaults in the store initializer (alongside existing defaults):
+
+```typescript
+      salaryStructure: {},
+      rsuGrants: [],
+      growthAssumptions: { ...DEFAULT_GROWTH_ASSUMPTIONS },
+```
+
+Add setter actions:
+
+```typescript
+      setSalaryStructure: (structure) => set({ salaryStructure: structure }),
+      setRsuGrants: (grants) => set({ rsuGrants: grants }),
+      setGrowthAssumptions: (assumptions) => set({ growthAssumptions: assumptions }),
+```
+
+In `hydrateFromApi`, add hydration logic (follow existing validation patterns):
+
+```typescript
+        salaryStructure:
+          apiPrefs.salary_structure && typeof apiPrefs.salary_structure === 'object'
+            ? apiPrefs.salary_structure
+            : {},
+        rsuGrants: Array.isArray(apiPrefs.rsu_grants) ? apiPrefs.rsu_grants : [],
+        growthAssumptions:
+          apiPrefs.growth_assumptions && typeof apiPrefs.growth_assumptions === 'object'
+            ? { ...DEFAULT_GROWTH_ASSUMPTIONS, ...apiPrefs.growth_assumptions }
+            : { ...DEFAULT_GROWTH_ASSUMPTIONS },
+```
+
+- [ ] **Step 3: Add to partialize and add selectors**
+
+Add to the `partialize` object:
+
+```typescript
+        salaryStructure: state.salaryStructure,
+        rsuGrants: state.rsuGrants,
+        growthAssumptions: state.growthAssumptions,
+```
+
+Add selectors at the bottom of the file:
+
+```typescript
+export const selectSalaryStructure = (state: PreferencesState) => state.salaryStructure
+export const selectRsuGrants = (state: PreferencesState) => state.rsuGrants
+export const selectGrowthAssumptions = (state: PreferencesState) => state.growthAssumptions
+```
+
+- [ ] **Step 4: Verify TypeScript compilation**
+
+Run: `cd frontend && pnpm run type-check`
+Expected: No errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/store/preferencesStore.ts
+git commit -m "feat: add salary, RSU, growth state to preferences store"
+```
+
+---
+
+## Task 8: Frontend — Projection Calculator
+
+**Files:**
+- Create: `frontend/src/lib/projectionCalculator.ts`
+- Create: `frontend/src/lib/__tests__/projectionCalculator.test.ts`
+
+- [ ] **Step 1: Write the failing tests first**
+
+```typescript
+import { describe, expect, it } from 'vitest'
+import {
+  getRsuVestingsByFY,
+  projectFiscalYear,
+  projectMultipleYears,
+} from '../projectionCalculator'
+import type { SalaryComponents, RsuGrant, GrowthAssumptions } from '@/types/salary'
+import { DEFAULT_GROWTH_ASSUMPTIONS } from '@/types/salary'
+
+const baseSalary: SalaryComponents = {
+  base_salary_monthly: 80000,
+  hra_monthly: null,
+  bonus_annual: 200000,
+  epf_monthly: 3600,
+  nps_monthly: 0,
+  special_allowance_annual: 0,
+  other_taxable_annual: 50000,
+}
+
+const testGrant: RsuGrant = {
+  id: 'g1',
+  stock_name: 'AMZN',
+  stock_price: 100, // simplified for testing
+  grant_date: null,
+  notes: null,
+  vestings: [
+    { date: '2026-03-15', quantity: 25 },
+    { date: '2027-03-15', quantity: 25 },
+    { date: '2028-03-15', quantity: 30 },
+  ],
+}
+
+describe('getRsuVestingsByFY', () => {
+  it('groups vestings by fiscal year (April start)', () => {
+    const result = getRsuVestingsByFY([testGrant], 4, 0)
+    // 2026-03-15 falls in FY 2025-26 (Apr 2025 - Mar 2026)
+    expect(result['2025-26']).toBeDefined()
+    expect(result['2025-26'].shares).toBe(25)
+    expect(result['2025-26'].value).toBe(2500) // 25 * 100
+    // 2027-03-15 falls in FY 2026-27
+    expect(result['2026-27'].shares).toBe(25)
+    // 2028-03-15 falls in FY 2027-28
+    expect(result['2027-28'].shares).toBe(30)
+    expect(result['2027-28'].value).toBe(3000)
+  })
+
+  it('applies stock appreciation', () => {
+    // 10% appreciation, base year 2025-26
+    const result = getRsuVestingsByFY([testGrant], 4, 10, 2025)
+    // FY 2025-26 (year 0): no appreciation
+    expect(result['2025-26'].value).toBe(2500)
+    // FY 2026-27 (year 1): 10% appreciation on price
+    expect(result['2026-27'].value).toBeCloseTo(25 * 110, 0) // 2750
+    // FY 2027-28 (year 2): 21% appreciation on price (1.1^2)
+    expect(result['2027-28'].value).toBeCloseTo(30 * 121, 0) // 3630
+  })
+
+  it('returns empty for no grants', () => {
+    const result = getRsuVestingsByFY([], 4, 0)
+    expect(Object.keys(result)).toHaveLength(0)
+  })
+})
+
+describe('projectFiscalYear', () => {
+  it('returns explicit FY data without growth applied', () => {
+    const structure = { '2025-26': baseSalary }
+    const result = projectFiscalYear(
+      '2025-26',
+      structure,
+      [],
+      DEFAULT_GROWTH_ASSUMPTIONS,
+      4,
+    )
+    expect(result.fy).toBe('2025-26')
+    expect(result.baseSalary).toBe(960000) // 80000 * 12
+    expect(result.bonus).toBe(200000)
+    expect(result.epf).toBe(43200) // 3600 * 12
+    expect(result.isProjected).toBe(false)
+  })
+
+  it('projects future FY with base salary growth', () => {
+    const structure = { '2025-26': baseSalary }
+    const growth: GrowthAssumptions = {
+      ...DEFAULT_GROWTH_ASSUMPTIONS,
+      base_salary_growth_pct: 10,
+    }
+    const result = projectFiscalYear(
+      '2026-27',
+      structure,
+      [],
+      growth,
+      4,
+    )
+    expect(result.fy).toBe('2026-27')
+    expect(result.baseSalary).toBeCloseTo(1056000, 0) // 80000 * 1.1 * 12
+    expect(result.isProjected).toBe(true)
+  })
+
+  it('sets bonus to 0 for future years when growth is 0', () => {
+    const structure = { '2025-26': baseSalary }
+    const result = projectFiscalYear(
+      '2026-27',
+      structure,
+      [],
+      DEFAULT_GROWTH_ASSUMPTIONS,
+      4,
+    )
+    expect(result.bonus).toBe(0)
+  })
+
+  it('scales EPF with base when enabled', () => {
+    const structure = { '2025-26': baseSalary }
+    const growth: GrowthAssumptions = {
+      ...DEFAULT_GROWTH_ASSUMPTIONS,
+      base_salary_growth_pct: 10,
+      epf_scales_with_base: true,
+    }
+    const result = projectFiscalYear(
+      '2026-27',
+      structure,
+      [],
+      growth,
+      4,
+    )
+    expect(result.epf).toBeCloseTo(47520, 0) // 3600 * 1.1 * 12
+  })
+
+  it('includes RSU income for the target FY', () => {
+    const structure = { '2025-26': baseSalary }
+    const result = projectFiscalYear(
+      '2025-26',
+      structure,
+      [testGrant],
+      DEFAULT_GROWTH_ASSUMPTIONS,
+      4,
+    )
+    expect(result.rsuIncome).toBe(2500) // 25 shares * 100
+    expect(result.rsuDetails).toHaveLength(1)
+    expect(result.rsuDetails[0].stock_name).toBe('AMZN')
+  })
+
+  it('computes tax using calculateTax', () => {
+    const structure = { '2025-26': baseSalary }
+    const result = projectFiscalYear(
+      '2025-26',
+      structure,
+      [],
+      DEFAULT_GROWTH_ASSUMPTIONS,
+      4,
+    )
+    expect(result.totalTax).toBeGreaterThan(0)
+    expect(result.takeHome).toBeLessThan(result.grossTaxable)
+    expect(result.effectiveTaxRate).toBeGreaterThan(0)
+    expect(result.effectiveTaxRate).toBeLessThan(100)
+  })
+})
+
+describe('projectMultipleYears', () => {
+  it('returns correct number of projected years', () => {
+    const structure = { '2025-26': baseSalary }
+    const growth: GrowthAssumptions = {
+      ...DEFAULT_GROWTH_ASSUMPTIONS,
+      projection_years: 3,
+    }
+    const results = projectMultipleYears(structure, [], growth, 4)
+    expect(results).toHaveLength(4) // base year + 3 projected
+  })
+
+  it('returns empty array when no salary structure', () => {
+    const results = projectMultipleYears({}, [], DEFAULT_GROWTH_ASSUMPTIONS, 4)
+    expect(results).toHaveLength(0)
+  })
+})
+```
+
+Write this to `frontend/src/lib/__tests__/projectionCalculator.test.ts`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && pnpm test -- --run src/lib/__tests__/projectionCalculator.test.ts`
+Expected: FAIL (module not found)
+
+- [ ] **Step 3: Implement the projection calculator**
+
+```typescript
+/**
+ * Pure projection functions for multi-year tax planning.
+ *
+ * Takes salary structure + growth assumptions and produces per-FY
+ * tax breakdowns using calculateTax() from taxCalculator.ts.
+ */
+
+import {
+  calculateTax,
+  getStandardDeduction,
+  getTaxSlabs,
+  parseFYStartYear,
+} from '@/lib/taxCalculator'
+import type {
+  GrowthAssumptions,
+  ProjectedFYBreakdown,
+  RsuGrant,
+  SalaryComponents,
+} from '@/types/salary'
+
+/** Increment a FY string by N years: "2025-26" + 1 → "2026-27" */
+function offsetFY(fy: string, offset: number): string {
+  const startYear = parseFYStartYear(fy) + offset
+  const endYear = (startYear + 1) % 100
+  return `${startYear}-${String(endYear).padStart(2, '0')}`
+}
+
+/** Get the FY string a date falls into given a fiscal year start month. */
+function dateToFY(dateStr: string, fyStartMonth: number): string {
+  const d = new Date(dateStr)
+  const month = d.getMonth() + 1 // 1-12
+  const year = d.getFullYear()
+  const fyStartYear = month >= fyStartMonth ? year : year - 1
+  const endYear = (fyStartYear + 1) % 100
+  return `${fyStartYear}-${String(endYear).padStart(2, '0')}`
+}
+
+/** Group RSU vestings by fiscal year with optional stock appreciation. */
+export function getRsuVestingsByFY(
+  grants: RsuGrant[],
+  fyStartMonth: number,
+  stockAppreciationPct: number,
+  baseStartYear?: number,
+): Record<string, { shares: number; value: number; details: Array<{ stock_name: string; shares: number; value: number }> }> {
+  const result: Record<string, { shares: number; value: number; details: Array<{ stock_name: string; shares: number; value: number }> }> = {}
+
+  for (const grant of grants) {
+    for (const vesting of grant.vestings) {
+      const fy = dateToFY(vesting.date, fyStartMonth)
+      const fyStart = parseFYStartYear(fy)
+      const yearsFromBase = baseStartYear != null ? fyStart - baseStartYear : 0
+      const appreciationFactor = Math.pow(1 + stockAppreciationPct / 100, Math.max(0, yearsFromBase))
+      const adjustedPrice = grant.stock_price * appreciationFactor
+      const vestingValue = vesting.quantity * adjustedPrice
+
+      if (!result[fy]) {
+        result[fy] = { shares: 0, value: 0, details: [] }
+      }
+      result[fy].shares += vesting.quantity
+      result[fy].value += vestingValue
+
+      const existing = result[fy].details.find((d) => d.stock_name === grant.stock_name)
+      if (existing) {
+        existing.shares += vesting.quantity
+        existing.value += vestingValue
+      } else {
+        result[fy].details.push({
+          stock_name: grant.stock_name,
+          shares: vesting.quantity,
+          value: vestingValue,
+        })
+      }
+    }
+  }
+
+  return result
+}
+
+/** Project a single fiscal year's income and tax breakdown. */
+export function projectFiscalYear(
+  targetFY: string,
+  salaryStructure: Record<string, SalaryComponents>,
+  rsuGrants: RsuGrant[],
+  growth: GrowthAssumptions,
+  fyStartMonth: number,
+): ProjectedFYBreakdown {
+  // Find the base FY (most recent FY with explicit salary data at or before target)
+  const sortedFYs = Object.keys(salaryStructure).sort()
+  const baseFY = sortedFYs.filter((fy) => fy <= targetFY).at(-1) ?? sortedFYs[0]
+  if (!baseFY || !salaryStructure[baseFY]) {
+    return emptyBreakdown(targetFY)
+  }
+
+  const base = salaryStructure[baseFY]
+  const isExplicit = targetFY in salaryStructure
+  const yearsOffset = parseFYStartYear(targetFY) - parseFYStartYear(baseFY)
+
+  // Apply growth for projected years
+  const baseGrowthFactor = Math.pow(1 + growth.base_salary_growth_pct / 100, yearsOffset)
+
+  const baseSalaryAnnual = (isExplicit ? salaryStructure[targetFY].base_salary_monthly : base.base_salary_monthly * baseGrowthFactor) * 12
+  const hraAnnual = (() => {
+    const src = isExplicit ? salaryStructure[targetFY] : base
+    if (src.hra_monthly == null) return 0
+    return (isExplicit ? src.hra_monthly : src.hra_monthly * baseGrowthFactor) * 12
+  })()
+
+  const bonusAnnual = (() => {
+    if (isExplicit) return salaryStructure[targetFY].bonus_annual
+    if (yearsOffset === 0) return base.bonus_annual
+    if (growth.bonus_growth_pct === 0) return 0
+    return base.bonus_annual * Math.pow(1 + growth.bonus_growth_pct / 100, yearsOffset)
+  })()
+
+  const epfAnnual = (() => {
+    if (isExplicit) return salaryStructure[targetFY].epf_monthly * 12
+    if (growth.epf_scales_with_base) return base.epf_monthly * baseGrowthFactor * 12
+    return base.epf_monthly * 12
+  })()
+
+  const npsAnnual = (() => {
+    if (isExplicit) return salaryStructure[targetFY].nps_monthly * 12
+    const npsFactor = Math.pow(1 + growth.nps_growth_pct / 100, yearsOffset)
+    return base.nps_monthly * npsFactor * 12
+  })()
+
+  const specialAllowanceAnnual = isExplicit
+    ? salaryStructure[targetFY].special_allowance_annual
+    : base.special_allowance_annual
+
+  const otherTaxableAnnual = isExplicit
+    ? salaryStructure[targetFY].other_taxable_annual
+    : base.other_taxable_annual
+
+  // RSU income for this FY
+  const baseStartYear = parseFYStartYear(baseFY)
+  const rsuByFY = getRsuVestingsByFY(
+    rsuGrants,
+    fyStartMonth,
+    growth.stock_price_appreciation_pct,
+    baseStartYear,
+  )
+  const rsuData = rsuByFY[targetFY] ?? { shares: 0, value: 0, details: [] }
+
+  // Gross taxable income
+  const grossTaxable =
+    baseSalaryAnnual + hraAnnual + bonusAnnual + specialAllowanceAnnual + otherTaxableAnnual + rsuData.value - epfAnnual
+
+  const fyStartYear = parseFYStartYear(targetFY)
+  const standardDeduction = getStandardDeduction(fyStartYear)
+  const netTaxable = Math.max(0, grossTaxable - standardDeduction)
+
+  // Calculate tax using existing taxCalculator
+  const slabs = getTaxSlabs(fyStartYear, 'new')
+  const taxResult = calculateTax(
+    grossTaxable,
+    slabs,
+    standardDeduction,
+    true,
+    12,
+    true,
+    fyStartYear,
+  )
+
+  const takeHome = grossTaxable - taxResult.totalTax
+  const effectiveTaxRate = grossTaxable > 0 ? (taxResult.totalTax / grossTaxable) * 100 : 0
+
+  return {
+    fy: targetFY,
+    baseSalary: baseSalaryAnnual,
+    hra: hraAnnual,
+    bonus: bonusAnnual,
+    epf: epfAnnual,
+    nps: npsAnnual,
+    specialAllowance: specialAllowanceAnnual,
+    otherTaxable: otherTaxableAnnual,
+    rsuIncome: rsuData.value,
+    rsuDetails: rsuData.details,
+    grossTaxable,
+    standardDeduction,
+    netTaxable,
+    totalTax: taxResult.totalTax,
+    takeHome,
+    effectiveTaxRate,
+    isProjected: !isExplicit || yearsOffset > 0,
+  }
+}
+
+/** Project multiple years starting from the latest FY with explicit salary data. */
+export function projectMultipleYears(
+  salaryStructure: Record<string, SalaryComponents>,
+  rsuGrants: RsuGrant[],
+  growth: GrowthAssumptions,
+  fyStartMonth: number,
+): ProjectedFYBreakdown[] {
+  const sortedFYs = Object.keys(salaryStructure).sort()
+  if (sortedFYs.length === 0) return []
+
+  const latestFY = sortedFYs.at(-1)!
+  const results: ProjectedFYBreakdown[] = []
+
+  for (let i = 0; i <= growth.projection_years; i++) {
+    const targetFY = offsetFY(latestFY, i)
+    results.push(projectFiscalYear(targetFY, salaryStructure, rsuGrants, growth, fyStartMonth))
+  }
+
+  return results
+}
+
+function emptyBreakdown(fy: string): ProjectedFYBreakdown {
+  return {
+    fy,
+    baseSalary: 0,
+    hra: 0,
+    bonus: 0,
+    epf: 0,
+    nps: 0,
+    specialAllowance: 0,
+    otherTaxable: 0,
+    rsuIncome: 0,
+    rsuDetails: [],
+    grossTaxable: 0,
+    standardDeduction: 0,
+    netTaxable: 0,
+    totalTax: 0,
+    takeHome: 0,
+    effectiveTaxRate: 0,
+    isProjected: true,
+  }
+}
+```
+
+Write this to `frontend/src/lib/projectionCalculator.ts`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && pnpm test -- --run src/lib/__tests__/projectionCalculator.test.ts`
+Expected: All tests pass.
+
+- [ ] **Step 5: Run full frontend checks**
+
+Run: `cd frontend && pnpm run type-check && pnpm test`
+Expected: No type errors, all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/lib/projectionCalculator.ts frontend/src/lib/__tests__/projectionCalculator.test.ts
+git commit -m "feat: add projection calculator with TDD tests for multi-year tax projections"
+```
+
+---
+
+## Task 9: Frontend — Settings Page Integration (useSettingsState + SettingsPage)
+
+**Files:**
+- Modify: `frontend/src/pages/settings/useSettingsState.ts`
+- Modify: `frontend/src/pages/SettingsPage.tsx`
+
+- [ ] **Step 1: Extend useSettingsState with salary/RSU/growth local state**
+
+In `useSettingsState.ts`, add the import:
+
+```typescript
+import type { SalaryComponents, RsuGrant, GrowthAssumptions } from '@/types/salary'
+import { DEFAULT_GROWTH_ASSUMPTIONS } from '@/types/salary'
+```
+
+Add local state for the 3 new fields (alongside existing `localPrefs` state):
+
+```typescript
+  const [localSalaryStructure, setLocalSalaryStructure] = useState<Record<string, SalaryComponents>>({})
+  const [localRsuGrants, setLocalRsuGrants] = useState<RsuGrant[]>([])
+  const [localGrowthAssumptions, setLocalGrowthAssumptions] = useState<GrowthAssumptions>({ ...DEFAULT_GROWTH_ASSUMPTIONS })
+```
+
+Initialize from preferences (in the existing `useEffect` that sets `localPrefs`):
+
+```typescript
+    if (preferences?.salary_structure) setLocalSalaryStructure(preferences.salary_structure)
+    if (preferences?.rsu_grants) setLocalRsuGrants(preferences.rsu_grants)
+    if (preferences?.growth_assumptions) {
+      setLocalGrowthAssumptions({ ...DEFAULT_GROWTH_ASSUMPTIONS, ...preferences.growth_assumptions })
+    }
+```
+
+Track changes — update `setHasChanges(true)` whenever these setters are called. Create wrapper setters:
+
+```typescript
+  const updateSalaryStructure = useCallback((structure: Record<string, SalaryComponents>) => {
+    setLocalSalaryStructure(structure)
+    setHasChanges(true)
+  }, [])
+
+  const updateRsuGrants = useCallback((grants: RsuGrant[]) => {
+    setLocalRsuGrants(grants)
+    setHasChanges(true)
+  }, [])
+
+  const updateGrowthAssumptions = useCallback((assumptions: GrowthAssumptions) => {
+    setLocalGrowthAssumptions(assumptions)
+    setHasChanges(true)
+  }, [])
+```
+
+- [ ] **Step 2: Extend handleSave to persist the 3 new fields**
+
+In the `handleSave` function, after `await updatePreferences.mutateAsync(localPrefs)`, add:
+
+```typescript
+      // Save salary/RSU/growth via dedicated endpoints
+      await Promise.all([
+        preferencesService.updateSalaryStructure({ salary_structure: localSalaryStructure }),
+        preferencesService.updateRsuGrants({ rsu_grants: localRsuGrants }),
+        preferencesService.updateGrowthAssumptions({ growth_assumptions: localGrowthAssumptions }),
+      ])
+```
+
+Add the import for `preferencesService`:
+
+```typescript
+import { preferencesService } from '@/services/api/preferences'
+```
+
+- [ ] **Step 3: Return new state from the hook**
+
+Add to the return object:
+
+```typescript
+    localSalaryStructure,
+    localRsuGrants,
+    localGrowthAssumptions,
+    updateSalaryStructure,
+    updateRsuGrants,
+    updateGrowthAssumptions,
+```
+
+- [ ] **Step 4: Add SalaryStructureSection to SettingsPage**
+
+In `SettingsPage.tsx`, add the import:
+
+```typescript
+import SalaryStructureSection from './settings/SalaryStructureSection'
+```
+
+Add the section rendering after IncomeClassificationSection and before FinancialSettingsSection. Find the FinancialSettingsSection render and add before it:
+
+```tsx
+        {s.localPrefs && (
+          <SalaryStructureSection
+            index={sectionIndex++}
+            localSalaryStructure={s.localSalaryStructure}
+            localRsuGrants={s.localRsuGrants}
+            localGrowthAssumptions={s.localGrowthAssumptions}
+            updateSalaryStructure={s.updateSalaryStructure}
+            updateRsuGrants={s.updateRsuGrants}
+            updateGrowthAssumptions={s.updateGrowthAssumptions}
+            fiscalYearStartMonth={s.localPrefs.fiscal_year_start_month}
+          />
+        )}
+```
+
+- [ ] **Step 5: Verify TypeScript compilation**
+
+Run: `cd frontend && pnpm run type-check`
+Expected: Will fail because SalaryStructureSection doesn't exist yet — that's Task 10. If running in parallel, this task can be committed with a temporary `// @ts-expect-error` or the component can be a stub. Otherwise, proceed to Task 10 before committing.
+
+- [ ] **Step 6: Commit (after Task 10 creates the component)**
+
+```bash
+git add frontend/src/pages/settings/useSettingsState.ts frontend/src/pages/SettingsPage.tsx
+git commit -m "feat: integrate salary/RSU/growth into settings state management"
+```
+
+---
+
+## Task 10: Frontend — SalaryStructureSection Component
+
+**Files:**
+- Create: `frontend/src/pages/settings/SalaryStructureSection.tsx`
+
+- [ ] **Step 1: Create the SalaryStructureSection component**
+
+This is the largest new file. It contains 3 subsections: Salary Grid (per FY), RSU Grants, and Growth Assumptions. Write to `frontend/src/pages/settings/SalaryStructureSection.tsx`:
+
+```tsx
+import { useState, useMemo, useCallback } from 'react'
+import { motion } from 'framer-motion'
+import {
+  Banknote,
+  ChevronLeft,
+  ChevronRight,
+  Plus,
+  Trash2,
+  TrendingUp,
+  X,
+} from 'lucide-react'
+import { fadeUpItem } from '@/constants/animations'
+import { formatCurrency } from '@/lib/formatters'
+import { CollapsibleSection } from '@/components/ui'
+import type { SalaryComponents, RsuGrant, RsuVesting, GrowthAssumptions } from '@/types/salary'
+import { DEFAULT_SALARY_COMPONENTS, DEFAULT_GROWTH_ASSUMPTIONS } from '@/types/salary'
+import { getFYFromDate, parseFYStartYear } from '@/lib/taxCalculator'
+
+interface Props {
+  index: number
+  localSalaryStructure: Record<string, SalaryComponents>
+  localRsuGrants: RsuGrant[]
+  localGrowthAssumptions: GrowthAssumptions
+  updateSalaryStructure: (structure: Record<string, SalaryComponents>) => void
+  updateRsuGrants: (grants: RsuGrant[]) => void
+  updateGrowthAssumptions: (assumptions: GrowthAssumptions) => void
+  fiscalYearStartMonth: number
+}
+
+/** Get the current FY string based on today's date. */
+function currentFYLabel(fyStartMonth: number): string {
+  const now = new Date()
+  const month = now.getMonth() + 1
+  const year = now.getFullYear()
+  const startYear = month >= fyStartMonth ? year : year - 1
+  const endYear = (startYear + 1) % 100
+  return `${startYear}-${String(endYear).padStart(2, '0')}`
+}
+
+function nextFY(fy: string): string {
+  const start = parseFYStartYear(fy) + 1
+  const end = (start + 1) % 100
+  return `${start}-${String(end).padStart(2, '0')}`
+}
+
+function prevFY(fy: string): string {
+  const start = parseFYStartYear(fy) - 1
+  const end = (start + 1) % 100
+  return `${start}-${String(end).padStart(2, '0')}`
+}
+
+const inputClass =
+  'w-full px-3 py-2 bg-white/5 border border-border rounded-lg text-sm text-white placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary'
+
+export default function SalaryStructureSection({
+  index,
+  localSalaryStructure,
+  localRsuGrants,
+  localGrowthAssumptions,
+  updateSalaryStructure,
+  updateRsuGrants,
+  updateGrowthAssumptions,
+  fiscalYearStartMonth,
+}: Readonly<Props>) {
+  const fyKeys = useMemo(() => Object.keys(localSalaryStructure).sort(), [localSalaryStructure])
+  const defaultFY = currentFYLabel(fiscalYearStartMonth)
+  const [activeFY, setActiveFY] = useState(fyKeys[0] ?? defaultFY)
+
+  const currentComp = localSalaryStructure[activeFY] ?? DEFAULT_SALARY_COMPONENTS
+
+  const updateField = useCallback(
+    (field: keyof SalaryComponents, value: number | null) => {
+      updateSalaryStructure({
+        ...localSalaryStructure,
+        [activeFY]: { ...currentComp, [field]: value },
+      })
+    },
+    [activeFY, currentComp, localSalaryStructure, updateSalaryStructure],
+  )
+
+  const addFY = useCallback(() => {
+    const newFY = fyKeys.length > 0 ? nextFY(fyKeys.at(-1)!) : defaultFY
+    if (!localSalaryStructure[newFY]) {
+      updateSalaryStructure({
+        ...localSalaryStructure,
+        [newFY]: { ...DEFAULT_SALARY_COMPONENTS },
+      })
+      setActiveFY(newFY)
+    }
+  }, [fyKeys, defaultFY, localSalaryStructure, updateSalaryStructure])
+
+  const annualCTC = useMemo(() => {
+    const c = currentComp
+    return (
+      c.base_salary_monthly * 12 +
+      (c.hra_monthly ?? 0) * 12 +
+      c.bonus_annual +
+      c.epf_monthly * 12 +
+      c.nps_monthly * 12 +
+      c.special_allowance_annual +
+      c.other_taxable_annual
+    )
+  }, [currentComp])
+
+  // RSU helpers
+  const addGrant = useCallback(() => {
+    const newGrant: RsuGrant = {
+      id: crypto.randomUUID(),
+      stock_name: '',
+      stock_price: 0,
+      grant_date: null,
+      notes: null,
+      vestings: [{ date: new Date().toISOString().slice(0, 10), quantity: 1 }],
+    }
+    updateRsuGrants([...localRsuGrants, newGrant])
+  }, [localRsuGrants, updateRsuGrants])
+
+  const updateGrant = useCallback(
+    (grantId: string, updates: Partial<RsuGrant>) => {
+      updateRsuGrants(
+        localRsuGrants.map((g) => (g.id === grantId ? { ...g, ...updates } : g)),
+      )
+    },
+    [localRsuGrants, updateRsuGrants],
+  )
+
+  const removeGrant = useCallback(
+    (grantId: string) => {
+      updateRsuGrants(localRsuGrants.filter((g) => g.id !== grantId))
+    },
+    [localRsuGrants, updateRsuGrants],
+  )
+
+  const addVesting = useCallback(
+    (grantId: string) => {
+      updateRsuGrants(
+        localRsuGrants.map((g) => {
+          if (g.id !== grantId) return g
+          return {
+            ...g,
+            vestings: [
+              ...g.vestings,
+              { date: new Date().toISOString().slice(0, 10), quantity: 1 },
+            ],
+          }
+        }),
+      )
+    },
+    [localRsuGrants, updateRsuGrants],
+  )
+
+  const removeVesting = useCallback(
+    (grantId: string, vestIdx: number) => {
+      updateRsuGrants(
+        localRsuGrants.map((g) => {
+          if (g.id !== grantId) return g
+          const vestings = g.vestings.filter((_, i) => i !== vestIdx)
+          return { ...g, vestings: vestings.length > 0 ? vestings : g.vestings }
+        }),
+      )
+    },
+    [localRsuGrants, updateRsuGrants],
+  )
+
+  const updateVesting = useCallback(
+    (grantId: string, vestIdx: number, updates: Partial<RsuVesting>) => {
+      updateRsuGrants(
+        localRsuGrants.map((g) => {
+          if (g.id !== grantId) return g
+          return {
+            ...g,
+            vestings: g.vestings.map((v, i) => (i === vestIdx ? { ...v, ...updates } : v)),
+          }
+        }),
+      )
+    },
+    [localRsuGrants, updateRsuGrants],
+  )
+
+  return (
+    <motion.div variants={fadeUpItem}>
+      <CollapsibleSection
+        index={index}
+        icon={Banknote}
+        title="Income & Salary Structure"
+        subtitle="Define compensation components, RSU grants, and growth projections"
+      >
+        <div className="space-y-6">
+          {/* ── Salary Structure ──────────────────────────────────── */}
+          <div>
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-sm font-medium text-white">Salary Structure</h3>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => {
+                    const prev = prevFY(activeFY)
+                    if (localSalaryStructure[prev]) setActiveFY(prev)
+                  }}
+                  disabled={!localSalaryStructure[prevFY(activeFY)]}
+                  className="p-1 rounded border border-border text-muted-foreground hover:text-white disabled:opacity-30"
+                >
+                  <ChevronLeft className="w-4 h-4" />
+                </button>
+                <span className="text-sm font-semibold text-primary min-w-[80px] text-center">
+                  FY {activeFY}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => {
+                    const next = nextFY(activeFY)
+                    if (localSalaryStructure[next]) setActiveFY(next)
+                  }}
+                  disabled={!localSalaryStructure[nextFY(activeFY)]}
+                  className="p-1 rounded border border-border text-muted-foreground hover:text-white disabled:opacity-30"
+                >
+                  <ChevronRight className="w-4 h-4" />
+                </button>
+                <button
+                  type="button"
+                  onClick={addFY}
+                  className="ml-2 flex items-center gap-1 px-3 py-1.5 text-xs bg-primary/20 text-primary border border-primary/30 rounded-lg hover:bg-primary/30"
+                >
+                  <Plus className="w-3 h-3" /> Add FY
+                </button>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              {([
+                ['base_salary_monthly', 'Base Salary (Monthly)', false],
+                ['hra_monthly', 'HRA (Monthly)', true],
+                ['bonus_annual', 'Bonus (Annual)', false],
+                ['epf_monthly', 'EPF (Monthly)', false],
+                ['nps_monthly', 'NPS (Monthly)', true],
+                ['special_allowance_annual', 'Special Allowance (Annual)', false],
+                ['other_taxable_annual', 'Other Taxable (Annual)', false],
+              ] as [keyof SalaryComponents, string, boolean][]).map(
+                ([field, label, optional]) => (
+                  <div
+                    key={field}
+                    className="bg-white/[0.03] border border-border rounded-lg p-3"
+                  >
+                    <label className="block text-xs text-muted-foreground uppercase tracking-wide mb-1.5">
+                      {label}
+                      {optional && (
+                        <span className="ml-1 text-muted-foreground/50 normal-case italic">
+                          -- optional
+                        </span>
+                      )}
+                    </label>
+                    <input
+                      type="number"
+                      min="0"
+                      step="100"
+                      value={currentComp[field] ?? ''}
+                      placeholder={optional ? 'Not set' : '0'}
+                      onChange={(e) => {
+                        const val = e.target.value
+                        updateField(
+                          field,
+                          val === '' && optional ? null : Number(val),
+                        )
+                      }}
+                      className={inputClass}
+                    />
+                  </div>
+                ),
+              )}
+            </div>
+
+            {/* Annual CTC Summary */}
+            <div className="mt-4 bg-app-card border border-primary/20 rounded-lg p-4 flex items-center justify-between">
+              <div>
+                <div className="text-xs text-muted-foreground uppercase tracking-wide">
+                  Total Annual CTC (excl. RSUs)
+                </div>
+                <div className="text-xl font-bold text-income mt-1">
+                  {formatCurrency(annualCTC)}
+                </div>
+              </div>
+              <div className="text-right">
+                <div className="text-xs text-muted-foreground">Monthly (pre-tax)</div>
+                <div className="text-lg font-semibold text-white mt-1">
+                  {formatCurrency(annualCTC / 12)}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* ── RSU Grants ────────────────────────────────────────── */}
+          <div className="pt-4 border-t border-border">
+            <div className="flex items-center justify-between mb-4">
+              <div>
+                <h3 className="text-sm font-medium text-white">RSU Grants</h3>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Track stock grants and vesting schedule
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={addGrant}
+                className="flex items-center gap-1 px-3 py-1.5 text-xs bg-primary/20 text-primary border border-primary/30 rounded-lg hover:bg-primary/30"
+              >
+                <Plus className="w-3 h-3" /> Add Grant
+              </button>
+            </div>
+
+            {localRsuGrants.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                No RSU grants configured. Add a grant to track vesting income.
+              </p>
+            ) : (
+              <div className="space-y-4">
+                {localRsuGrants.map((grant) => (
+                  <div
+                    key={grant.id}
+                    className="bg-white/[0.03] border border-border rounded-lg p-4"
+                  >
+                    {/* Grant Header */}
+                    <div className="flex items-center justify-between mb-3">
+                      <div className="flex items-center gap-3">
+                        <input
+                          type="text"
+                          value={grant.stock_name}
+                          placeholder="Stock ticker"
+                          onChange={(e) =>
+                            updateGrant(grant.id, { stock_name: e.target.value })
+                          }
+                          className="w-24 px-2 py-1 bg-primary/20 text-primary font-semibold text-sm rounded border border-primary/30 placeholder:text-primary/50"
+                        />
+                        <input
+                          type="text"
+                          value={grant.notes ?? ''}
+                          placeholder="Label (optional)"
+                          onChange={(e) =>
+                            updateGrant(grant.id, {
+                              notes: e.target.value || null,
+                            })
+                          }
+                          className="w-40 px-2 py-1 bg-white/5 border border-border rounded text-sm text-muted-foreground placeholder:text-muted-foreground/50"
+                        />
+                      </div>
+                      <div className="flex items-center gap-3">
+                        <div className="text-right">
+                          <div className="text-[10px] text-muted-foreground uppercase">
+                            Price/Share
+                          </div>
+                          <input
+                            type="number"
+                            min="0"
+                            step="0.01"
+                            value={grant.stock_price || ''}
+                            placeholder="0.00"
+                            onChange={(e) =>
+                              updateGrant(grant.id, {
+                                stock_price: Number(e.target.value),
+                              })
+                            }
+                            className="w-28 px-2 py-1 bg-white/5 border border-border rounded text-sm text-white text-right"
+                          />
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => removeGrant(grant.id)}
+                          className="p-1.5 text-red-400 hover:bg-red-400/10 rounded border border-red-400/30"
+                        >
+                          <Trash2 className="w-3.5 h-3.5" />
+                        </button>
+                      </div>
+                    </div>
+
+                    {/* Vesting Table */}
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="border-b border-border text-muted-foreground text-xs">
+                          <th className="text-left py-2 font-medium">Vesting Date</th>
+                          <th className="text-right py-2 font-medium">Shares</th>
+                          <th className="text-right py-2 font-medium">Est. Value</th>
+                          <th className="text-right py-2 font-medium">FY</th>
+                          <th className="w-8" />
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {grant.vestings.map((v, vi) => (
+                          <tr key={vi} className="border-b border-border/50">
+                            <td className="py-2">
+                              <input
+                                type="date"
+                                value={v.date}
+                                onChange={(e) =>
+                                  updateVesting(grant.id, vi, {
+                                    date: e.target.value,
+                                  })
+                                }
+                                className="bg-white/5 border border-border rounded px-2 py-1 text-white text-sm"
+                              />
+                            </td>
+                            <td className="py-2 text-right">
+                              <input
+                                type="number"
+                                min="1"
+                                value={v.quantity}
+                                onChange={(e) =>
+                                  updateVesting(grant.id, vi, {
+                                    quantity: Math.max(1, Number(e.target.value)),
+                                  })
+                                }
+                                className="w-20 bg-white/5 border border-border rounded px-2 py-1 text-white text-sm text-right"
+                              />
+                            </td>
+                            <td className="py-2 text-right text-income font-medium">
+                              {formatCurrency(v.quantity * grant.stock_price)}
+                            </td>
+                            <td className="py-2 text-right text-primary text-xs">
+                              {getFYFromDate(v.date, fiscalYearStartMonth)}
+                            </td>
+                            <td className="py-2 text-right">
+                              {grant.vestings.length > 1 && (
+                                <button
+                                  type="button"
+                                  onClick={() => removeVesting(grant.id, vi)}
+                                  className="text-muted-foreground hover:text-red-400"
+                                >
+                                  <X className="w-3.5 h-3.5" />
+                                </button>
+                              )}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+
+                    <div className="mt-2 pt-2 border-t border-border flex items-center justify-between">
+                      <button
+                        type="button"
+                        onClick={() => addVesting(grant.id)}
+                        className="text-xs text-muted-foreground border border-dashed border-border px-3 py-1 rounded hover:text-white"
+                      >
+                        + Add Vesting Date
+                      </button>
+                      <div className="text-sm text-muted-foreground">
+                        Total: {grant.vestings.reduce((s, v) => s + v.quantity, 0)} shares
+                        <span className="ml-2 text-income font-semibold">
+                          {formatCurrency(
+                            grant.vestings.reduce(
+                              (s, v) => s + v.quantity * grant.stock_price,
+                              0,
+                            ),
+                          )}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* ── Growth Assumptions ─────────────────────────────────── */}
+          <div className="pt-4 border-t border-border">
+            <div className="mb-4">
+              <h3 className="text-sm font-medium text-white flex items-center gap-2">
+                <TrendingUp className="w-4 h-4 text-primary" />
+                Growth Assumptions
+              </h3>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Used for multi-year projections on Tax Planning page
+              </p>
+            </div>
+
+            <div className="grid grid-cols-3 gap-3">
+              {([
+                ['base_salary_growth_pct', 'Base Salary Growth', '%/yr'],
+                ['stock_price_appreciation_pct', 'Stock Appreciation', '%/yr'],
+                ['projection_years', 'Projection Horizon', 'years'],
+                ['bonus_growth_pct', 'Bonus Growth', '%/yr'],
+                ['nps_growth_pct', 'NPS Growth', '%/yr'],
+              ] as [keyof GrowthAssumptions, string, string][]).map(
+                ([field, label, suffix]) => (
+                  <div
+                    key={field}
+                    className="bg-white/[0.03] border border-border rounded-lg p-3"
+                  >
+                    <label className="block text-xs text-muted-foreground uppercase tracking-wide mb-1.5">
+                      {label}
+                    </label>
+                    <div className="flex items-center gap-2">
+                      <input
+                        type="number"
+                        min={field === 'projection_years' ? 1 : 0}
+                        max={field === 'projection_years' ? 5 : undefined}
+                        step={field === 'projection_years' ? 1 : 0.5}
+                        value={localGrowthAssumptions[field] as number}
+                        onChange={(e) =>
+                          updateGrowthAssumptions({
+                            ...localGrowthAssumptions,
+                            [field]: Number(e.target.value),
+                          })
+                        }
+                        className={inputClass}
+                      />
+                      <span className="text-xs text-muted-foreground shrink-0">
+                        {suffix}
+                      </span>
+                    </div>
+                  </div>
+                ),
+              )}
+
+              {/* EPF Scales With Base toggle */}
+              <div className="bg-white/[0.03] border border-border rounded-lg p-3 flex items-center justify-between">
+                <div>
+                  <div className="text-xs text-muted-foreground uppercase tracking-wide">
+                    EPF Scales With Base
+                  </div>
+                  <div className="text-[11px] text-muted-foreground/70 mt-0.5">
+                    Auto-increase when base grows
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() =>
+                    updateGrowthAssumptions({
+                      ...localGrowthAssumptions,
+                      epf_scales_with_base: !localGrowthAssumptions.epf_scales_with_base,
+                    })
+                  }
+                  className={`relative w-11 h-6 rounded-full transition-colors ${
+                    localGrowthAssumptions.epf_scales_with_base
+                      ? 'bg-income'
+                      : 'bg-white/10'
+                  }`}
+                >
+                  <span
+                    className={`absolute top-1 w-4 h-4 rounded-full bg-white transition-transform ${
+                      localGrowthAssumptions.epf_scales_with_base
+                        ? 'translate-x-[22px]'
+                        : 'translate-x-1'
+                    }`}
+                  />
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </CollapsibleSection>
+    </motion.div>
+  )
+}
+```
+
+Write this to `frontend/src/pages/settings/SalaryStructureSection.tsx`.
+
+- [ ] **Step 2: Verify TypeScript compilation and lint**
+
+Run: `cd frontend && pnpm run type-check && pnpm run lint`
+Expected: No errors.
+
+- [ ] **Step 3: Commit (combined with Task 9)**
+
+```bash
+git add frontend/src/pages/settings/SalaryStructureSection.tsx frontend/src/pages/settings/useSettingsState.ts frontend/src/pages/SettingsPage.tsx
+git commit -m "feat: add Income & Salary Structure settings section with FY salary grid, RSU grants, and growth assumptions"
+```
+
+---
+
+## Task 11: Frontend — Tax Planning Page Enhancement
+
+**Files:**
+- Modify: `frontend/src/pages/TaxPlanningPage.tsx`
+
+This is the most complex modification. The changes are:
+1. Extend FY navigator to allow future FYs
+2. Add projection toggle
+3. Show salary-based income breakdown when projection is active
+4. Add multi-year comparison table
+5. Add projection insights
+
+- [ ] **Step 1: Add imports**
+
+Add at the top of TaxPlanningPage.tsx:
+
+```typescript
+import { projectFiscalYear, projectMultipleYears } from '@/lib/projectionCalculator'
+import { usePreferencesStore, selectSalaryStructure, selectRsuGrants, selectGrowthAssumptions } from '@/store/preferencesStore'
+import type { ProjectedFYBreakdown } from '@/types/salary'
+```
+
+- [ ] **Step 2: Add store selectors inside the component**
+
+Inside the component function, add after existing hooks:
+
+```typescript
+  const salaryStructure = usePreferencesStore(selectSalaryStructure)
+  const rsuGrants = usePreferencesStore(selectRsuGrants)
+  const growthAssumptions = usePreferencesStore(selectGrowthAssumptions)
+  const hasSalaryData = Object.keys(salaryStructure).length > 0
+
+  const [projectionSource, setProjectionSource] = useState<'transactions' | 'salary'>('transactions')
+```
+
+- [ ] **Step 3: Extend FY navigation to include future FYs**
+
+Replace the existing `fyList` and navigation logic. The key change is computing projected FY list that extends into the future when salary data exists:
+
+```typescript
+  const projectedFYList = useMemo(() => {
+    if (!hasSalaryData) return []
+    const salaryFYs = Object.keys(salaryStructure).sort()
+    const latestSalaryFY = salaryFYs.at(-1)
+    if (!latestSalaryFY) return []
+    const latestStart = parseFYStartYear(latestSalaryFY)
+    const futureFYs: string[] = []
+    for (let i = 1; i <= growthAssumptions.projection_years; i++) {
+      const yr = latestStart + i
+      const end = (yr + 1) % 100
+      futureFYs.push(`${yr}-${String(end).padStart(2, '0')}`)
+    }
+    return futureFYs
+  }, [hasSalaryData, salaryStructure, growthAssumptions.projection_years])
+
+  // Combined FY list: transaction-based + future projected
+  const combinedFYList = useMemo(() => {
+    const txFYs = Object.keys(transactionsByFY).sort().reverse()
+    const allFYs = new Set([...txFYs, ...projectedFYList])
+    return [...allFYs].sort().reverse()
+  }, [transactionsByFY, projectedFYList])
+```
+
+Update the navigation handlers to use `combinedFYList` instead of `fyList`:
+
+```typescript
+  const currentIndex = combinedFYList.indexOf(effectiveFY)
+  const canGoBack = currentIndex < combinedFYList.length - 1
+  const canGoForward = currentIndex > 0
+
+  const goToPreviousFY = () => {
+    if (canGoBack) setSelectedFY(combinedFYList[currentIndex + 1])
+  }
+  const goToNextFY = () => {
+    if (canGoForward) setSelectedFY(combinedFYList[currentIndex - 1])
+  }
+```
+
+- [ ] **Step 4: Compute projection data**
+
+Add the salary-based projection memo:
+
+```typescript
+  const salaryProjection = useMemo<ProjectedFYBreakdown | null>(() => {
+    if (!hasSalaryData || projectionSource !== 'salary') return null
+    return projectFiscalYear(effectiveFY, salaryStructure, rsuGrants, growthAssumptions, fiscalYearStartMonth)
+  }, [hasSalaryData, projectionSource, effectiveFY, salaryStructure, rsuGrants, growthAssumptions, fiscalYearStartMonth])
+
+  const multiYearProjections = useMemo<ProjectedFYBreakdown[]>(() => {
+    if (!hasSalaryData) return []
+    return projectMultipleYears(salaryStructure, rsuGrants, growthAssumptions, fiscalYearStartMonth)
+  }, [hasSalaryData, salaryStructure, rsuGrants, growthAssumptions, fiscalYearStartMonth])
+
+  // Auto-switch to salary source for future FYs
+  const isFutureFY = projectedFYList.includes(effectiveFY) && !transactionsByFY[effectiveFY]
+  const effectiveSource = isFutureFY ? 'salary' : projectionSource
+```
+
+- [ ] **Step 5: Add projection source toggle to JSX**
+
+After the existing FY navigation buttons and before the main content, add the toggle:
+
+```tsx
+          {hasSalaryData && (
+            <div className="flex gap-1 bg-white/5 rounded-lg p-1">
+              <button
+                type="button"
+                onClick={() => setProjectionSource('transactions')}
+                disabled={isFutureFY}
+                className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+                  effectiveSource === 'transactions'
+                    ? 'bg-white/10 text-white'
+                    : 'text-muted-foreground hover:text-white'
+                } disabled:opacity-30`}
+              >
+                From Transactions
+              </button>
+              <button
+                type="button"
+                onClick={() => setProjectionSource('salary')}
+                className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+                  effectiveSource === 'salary'
+                    ? 'bg-white/10 text-white'
+                    : 'text-muted-foreground hover:text-white'
+                }`}
+              >
+                {isFutureFY ? 'Projection' : 'From Salary Structure'}
+              </button>
+            </div>
+          )}
+```
+
+- [ ] **Step 6: Add salary-based income breakdown panel**
+
+When `effectiveSource === 'salary'` and `salaryProjection` is available, render an income component breakdown and tax computation. Add this section conditionally within the main content area (after the toggle, before or alongside the existing slab breakdown):
+
+```tsx
+          {effectiveSource === 'salary' && salaryProjection && (
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+              {/* Income Components */}
+              <div className="bg-app-card rounded-xl border border-border p-5">
+                <h3 className="text-xs text-muted-foreground uppercase tracking-wide mb-3">
+                  Annual Income Components
+                </h3>
+                <div className="space-y-2">
+                  {[
+                    ['Base Salary', salaryProjection.baseSalary],
+                    ['HRA', salaryProjection.hra],
+                    ['Bonus & Extras', salaryProjection.bonus],
+                    ['RSU Vesting', salaryProjection.rsuIncome],
+                    ['Special Allowance', salaryProjection.specialAllowance],
+                    ['Other Taxable', salaryProjection.otherTaxable],
+                    ['EPF (deducted)', -salaryProjection.epf],
+                  ].filter(([, val]) => val !== 0).map(([label, val]) => (
+                    <div key={label as string} className="flex justify-between text-sm">
+                      <span className="text-muted-foreground">{label as string}</span>
+                      <span className={`font-medium ${(val as number) < 0 ? 'text-muted-foreground' : 'text-white'}`}>
+                        {formatCurrency(val as number)}
+                      </span>
+                    </div>
+                  ))}
+                  <div className="pt-2 mt-2 border-t border-border flex justify-between">
+                    <span className="text-white font-semibold">Gross Taxable</span>
+                    <span className="text-income font-bold text-lg">
+                      {formatCurrency(salaryProjection.grossTaxable)}
+                    </span>
+                  </div>
+                  <div className="flex justify-between text-sm">
+                    <span className="text-muted-foreground">Less: Standard Deduction</span>
+                    <span className="text-muted-foreground">
+                      -{formatCurrency(salaryProjection.standardDeduction)}
+                    </span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-white font-semibold">Net Taxable</span>
+                    <span className="text-primary font-bold text-lg">
+                      {formatCurrency(salaryProjection.netTaxable)}
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              {/* Tax Computation */}
+              <div className="bg-app-card rounded-xl border border-border p-5">
+                <h3 className="text-xs text-muted-foreground uppercase tracking-wide mb-3">
+                  Projected Tax
+                </h3>
+                <div className="space-y-2">
+                  <div className="flex justify-between text-sm">
+                    <span className="text-muted-foreground">Total Tax</span>
+                    <span className="text-expense font-bold text-lg">
+                      {formatCurrency(salaryProjection.totalTax)}
+                    </span>
+                  </div>
+                  <div className="flex justify-between text-sm">
+                    <span className="text-muted-foreground">Effective Tax Rate</span>
+                    <span className="text-app-yellow font-semibold">
+                      {salaryProjection.effectiveTaxRate.toFixed(1)}%
+                    </span>
+                  </div>
+                  <div className="flex justify-between text-sm">
+                    <span className="text-muted-foreground">Monthly TDS (approx)</span>
+                    <span className="text-white font-medium">
+                      {formatCurrency(salaryProjection.totalTax / 12)}
+                    </span>
+                  </div>
+                  <div className="pt-3 mt-3 border-t border-border">
+                    <div className="flex justify-between">
+                      <span className="text-income font-semibold">Annual Take-Home</span>
+                      <span className="text-income font-bold text-lg">
+                        {formatCurrency(salaryProjection.takeHome)}
+                      </span>
+                    </div>
+                    <div className="flex justify-between text-sm mt-1">
+                      <span className="text-muted-foreground">Monthly Take-Home</span>
+                      <span className="text-white font-medium">
+                        {formatCurrency(salaryProjection.takeHome / 12)}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+```
+
+- [ ] **Step 7: Add multi-year projection table**
+
+Add a collapsible section after the main tax content area:
+
+```tsx
+          {hasSalaryData && multiYearProjections.length > 1 && (
+            <div className="bg-app-card rounded-xl border border-border p-5">
+              <h3 className="text-sm font-semibold text-white mb-4">
+                Multi-Year Projection
+              </h3>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm min-w-[500px]">
+                  <thead>
+                    <tr className="border-b border-border">
+                      <th className="text-left py-2 text-muted-foreground font-medium">Component</th>
+                      {multiYearProjections.map((p) => (
+                        <th key={p.fy} className="text-right py-2 text-primary font-semibold">
+                          FY {p.fy}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {[
+                      ['Base Salary', (p: ProjectedFYBreakdown) => p.baseSalary],
+                      ['Bonus', (p: ProjectedFYBreakdown) => p.bonus],
+                      ['RSU Vesting', (p: ProjectedFYBreakdown) => p.rsuIncome],
+                      ['EPF', (p: ProjectedFYBreakdown) => -p.epf],
+                      ['Other', (p: ProjectedFYBreakdown) => p.otherTaxable + p.specialAllowance],
+                    ].map(([label, getter]) => (
+                      <tr key={label as string} className="border-b border-border/50">
+                        <td className="py-2 text-muted-foreground">{label as string}</td>
+                        {multiYearProjections.map((p) => (
+                          <td key={p.fy} className="py-2 text-right text-white">
+                            {formatCurrency((getter as (p: ProjectedFYBreakdown) => number)(p))}
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                    <tr className="border-b border-border bg-white/[0.02]">
+                      <td className="py-2 text-white font-semibold">Gross Taxable</td>
+                      {multiYearProjections.map((p) => (
+                        <td key={p.fy} className="py-2 text-right text-income font-bold">
+                          {formatCurrency(p.grossTaxable)}
+                        </td>
+                      ))}
+                    </tr>
+                    <tr className="bg-white/[0.02]">
+                      <td className="py-2 text-expense font-semibold">Total Tax</td>
+                      {multiYearProjections.map((p) => (
+                        <td key={p.fy} className="py-2 text-right text-expense font-bold">
+                          {formatCurrency(p.totalTax)}
+                        </td>
+                      ))}
+                    </tr>
+                    <tr className="border-t border-income/30 bg-income/5">
+                      <td className="py-2 text-income font-semibold">Take-Home</td>
+                      {multiYearProjections.map((p) => (
+                        <td key={p.fy} className="py-2 text-right text-income font-bold">
+                          {formatCurrency(p.takeHome)}
+                        </td>
+                      ))}
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+```
+
+- [ ] **Step 8: Verify compilation and lint**
+
+Run: `cd frontend && pnpm run type-check && pnpm run lint`
+Expected: No errors. Some adjustments may be needed based on exact existing JSX structure — adapt the insertion points to match the actual file.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add frontend/src/pages/TaxPlanningPage.tsx
+git commit -m "feat: extend Tax Planning page with salary-based projections and multi-year comparison"
+```
+
+---
+
+## Task 12: Full Integration Verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full check suite**
+
+Run: `cd /c/Code/GitHub/projects/ledger-sync && pnpm run check`
+Expected: All lint, type-check, and tests pass for both backend and frontend.
+
+- [ ] **Step 2: Fix any issues**
+
+If any failures, fix them. Common issues:
+- Import paths that need adjustment
+- Type mismatches between store and component props
+- Missing `type` keyword in import statements
+
+- [ ] **Step 3: Final commit if fixes were needed**
+
+```bash
+git add -u
+git commit -m "fix: resolve integration issues from income tax projections feature"
+```
+
+- [ ] **Step 4: Push branch**
+
+```bash
+git push -u origin feat/income-tax-projections
+```

--- a/docs/superpowers/specs/2026-04-11-income-tax-projections-design.md
+++ b/docs/superpowers/specs/2026-04-11-income-tax-projections-design.md
@@ -1,0 +1,515 @@
+# Income & Tax Projections Design Spec
+
+**Date:** 2026-04-11
+**Branch:** `feat/income-tax-projections`
+**Status:** Approved
+
+## Overview
+
+Add forward-looking income and tax projection capabilities to Ledger Sync. Users define their salary structure (base, bonus, RSUs, EPF, NPS, etc.) in Settings, configure growth assumptions, and the Tax Planning page projects tax liability, take-home pay, and optimization suggestions for current and future fiscal years.
+
+## Goals
+
+1. Let users input structured salary components per fiscal year in Settings
+2. Track RSU grants with full vesting schedules (stock name, price, multiple vesting dates/quantities)
+3. Define growth assumptions (base raise %, stock appreciation, etc.) for multi-year projections
+4. Enhance Tax Planning page to show salary-based tax projections alongside transaction-based calculations
+5. Extend FY navigation into future years with automatic projection mode
+6. Provide smart insights (slab jumps, missing data warnings, tax-saving suggestions)
+
+## Non-Goals
+
+- Server-side projection computation (stays client-side in taxCalculator.ts)
+- Live stock price fetching (user manually updates price per share)
+- Old Regime deduction optimization (already handled by existing regime comparison widget)
+- Payslip/Form 16 import
+
+---
+
+## 1. Data Model
+
+All data stored as JSON fields in the existing `user_preferences` table. No new tables.
+
+### 1.1 `salary_structure` (JSON column, default `{}`)
+
+Dict keyed by fiscal year string. Each value is a salary component breakdown.
+
+```json
+{
+  "2025-26": {
+    "base_salary_monthly": 80000,
+    "hra_monthly": null,
+    "bonus_annual": 200000,
+    "epf_monthly": 3600,
+    "nps_monthly": 0,
+    "special_allowance_annual": 0,
+    "other_taxable_annual": 50000
+  }
+}
+```
+
+**Field definitions:**
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `base_salary_monthly` | Decimal | 0 | Monthly gross base |
+| `hra_monthly` | Decimal or null | null | Optional; used for old regime HRA deduction calc |
+| `bonus_annual` | Decimal | 0 | All taxable extras beyond base (bonus, food card, etc.) |
+| `epf_monthly` | Decimal | 3600 | Employer EPF contribution |
+| `nps_monthly` | Decimal | 0 | Employer NPS contribution (Section 80CCD(2)) |
+| `special_allowance_annual` | Decimal | 0 | Other taxable allowances |
+| `other_taxable_annual` | Decimal | 0 | Rental income, freelance, etc. |
+
+### 1.2 `rsu_grants` (JSON column, default `[]`)
+
+Array of RSU grant objects, each with inline vesting entries.
+
+```json
+[
+  {
+    "id": "grant-abc123",
+    "stock_name": "AMZN",
+    "stock_price": 185.50,
+    "grant_date": "2025-03-15",
+    "notes": "Joining grant",
+    "vestings": [
+      { "date": "2026-03-15", "quantity": 25 },
+      { "date": "2027-03-15", "quantity": 25 },
+      { "date": "2028-03-15", "quantity": 30 },
+      { "date": "2029-03-15", "quantity": 20 }
+    ]
+  }
+]
+```
+
+**Grant fields:**
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `id` | string | yes | Client-generated UUID for keying |
+| `stock_name` | string | yes | Ticker or display name |
+| `stock_price` | Decimal | yes | Current/estimated price per share (user's currency) |
+| `grant_date` | date string or null | no | When the grant was awarded |
+| `notes` | string or null | no | User label |
+| `vestings` | array | yes | At least 1 entry |
+
+**Vesting entry fields:**
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `date` | date string | yes | YYYY-MM-DD vesting date |
+| `quantity` | int (> 0) | yes | Number of shares vesting |
+
+### 1.3 `growth_assumptions` (JSON column, default `{}`)
+
+Single object with projection parameters.
+
+```json
+{
+  "base_salary_growth_pct": 0,
+  "bonus_growth_pct": 0,
+  "epf_scales_with_base": true,
+  "nps_growth_pct": 0,
+  "stock_price_appreciation_pct": 0,
+  "projection_years": 3
+}
+```
+
+**Field definitions:**
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `base_salary_growth_pct` | float | 0 | Annual base salary raise %. 0 = no growth until user sets it. |
+| `bonus_growth_pct` | float | 0 | 0 = bonus does NOT carry forward to future years (treated as one-time per FY). |
+| `epf_scales_with_base` | bool | true | If true, EPF monthly scales proportionally when base grows. |
+| `nps_growth_pct` | float | 0 | Annual NPS increase %. 0 = stays same. |
+| `stock_price_appreciation_pct` | float | 0 | Annual stock price growth for RSU value projections. 0 = use current price. |
+| `projection_years` | int (1-5) | 3 | How many future FYs to project. |
+
+### 1.4 Migration
+
+Single Alembic migration adding 3 JSON columns to `user_preferences`:
+
+```python
+op.add_column('user_preferences', sa.Column('salary_structure', sa.JSON(), server_default='{}', nullable=False))
+op.add_column('user_preferences', sa.Column('rsu_grants', sa.JSON(), server_default='[]', nullable=False))
+op.add_column('user_preferences', sa.Column('growth_assumptions', sa.JSON(), server_default='{}', nullable=False))
+```
+
+Empty `downgrade()` (consistent with existing migration pattern post-2026-02-03).
+
+---
+
+## 2. API Layer
+
+Extends existing preferences router (`backend/src/ledger_sync/api/preferences.py`).
+
+### 2.1 New Endpoints
+
+| Method | Endpoint | Body Schema | Purpose |
+|--------|----------|-------------|---------|
+| `PUT` | `/preferences/salary-structure` | `SalaryStructureConfig` | Update salary structure for one or more FYs |
+| `PUT` | `/preferences/rsu-grants` | `RsuGrantsConfig` | Replace full RSU grants array |
+| `PUT` | `/preferences/growth-assumptions` | `GrowthAssumptionsConfig` | Update growth projection parameters |
+
+All endpoints follow the existing `_update_section()` helper pattern: validate via Pydantic, persist JSON to column, return full preferences response.
+
+### 2.2 Pydantic Schemas
+
+New file: `backend/src/ledger_sync/schemas/salary.py`
+
+```python
+class SalaryComponents(BaseModel):
+    base_salary_monthly: Decimal = Decimal(0)
+    hra_monthly: Decimal | None = None
+    bonus_annual: Decimal = Decimal(0)
+    epf_monthly: Decimal = Decimal(3600)
+    nps_monthly: Decimal = Decimal(0)
+    special_allowance_annual: Decimal = Decimal(0)
+    other_taxable_annual: Decimal = Decimal(0)
+
+class SalaryStructureConfig(BaseModel):
+    salary_structure: dict[str, SalaryComponents]  # keyed by FY string e.g. "2025-26"
+
+class RsuVesting(BaseModel):
+    date: date
+    quantity: int = Field(gt=0)
+
+class RsuGrant(BaseModel):
+    id: str
+    stock_name: str = Field(min_length=1)
+    stock_price: Decimal = Field(gt=0)
+    grant_date: date | None = None
+    notes: str | None = None
+    vestings: list[RsuVesting] = Field(min_length=1)
+
+class RsuGrantsConfig(BaseModel):
+    rsu_grants: list[RsuGrant]
+
+class GrowthAssumptionsConfig(BaseModel):
+    base_salary_growth_pct: float = 0
+    bonus_growth_pct: float = 0
+    epf_scales_with_base: bool = True
+    nps_growth_pct: float = 0
+    stock_price_appreciation_pct: float = 0
+    projection_years: int = Field(default=3, ge=1, le=5)
+```
+
+### 2.3 Response Changes
+
+`UserPreferencesResponse` extended with 3 new fields:
+
+```python
+salary_structure: dict[str, Any] = {}
+rsu_grants: list[dict[str, Any]] = []
+growth_assumptions: dict[str, Any] = {}
+```
+
+Existing `GET /preferences` and `PUT /preferences` endpoints automatically include the new fields.
+
+---
+
+## 3. Frontend: Preferences Store
+
+### 3.1 Store Changes (`frontend/src/store/preferencesStore.ts`)
+
+New state fields:
+
+```typescript
+salaryStructure: Record<string, SalaryComponents>  // keyed by FY
+rsuGrants: RsuGrant[]
+growthAssumptions: GrowthAssumptions
+```
+
+New actions:
+
+```typescript
+setSalaryStructure(structure: Record<string, SalaryComponents>): void
+setRsuGrants(grants: RsuGrant[]): void
+setGrowthAssumptions(assumptions: GrowthAssumptions): void
+```
+
+`hydrateFromApi()` extended to populate new fields. New selectors for each.
+
+### 3.2 TypeScript Types (`frontend/src/types/salary.ts`)
+
+```typescript
+interface SalaryComponents {
+  base_salary_monthly: number
+  hra_monthly: number | null
+  bonus_annual: number
+  epf_monthly: number
+  nps_monthly: number
+  special_allowance_annual: number
+  other_taxable_annual: number
+}
+
+interface RsuVesting {
+  date: string  // YYYY-MM-DD
+  quantity: number
+}
+
+interface RsuGrant {
+  id: string
+  stock_name: string
+  stock_price: number
+  grant_date: string | null
+  notes: string | null
+  vestings: RsuVesting[]
+}
+
+interface GrowthAssumptions {
+  base_salary_growth_pct: number
+  bonus_growth_pct: number
+  epf_scales_with_base: boolean
+  nps_growth_pct: number
+  stock_price_appreciation_pct: number
+  projection_years: number
+}
+```
+
+### 3.3 API Hooks (`frontend/src/hooks/api/`)
+
+New mutations (TanStack Query):
+
+```typescript
+useSalaryStructureMutation()   // PUT /preferences/salary-structure
+useRsuGrantsMutation()         // PUT /preferences/rsu-grants
+useGrowthAssumptionsMutation() // PUT /preferences/growth-assumptions
+```
+
+Follow existing pattern: invalidate preferences query on success, update Zustand store.
+
+---
+
+## 4. Frontend: Settings Page — Income & Salary Structure Section
+
+### 4.1 Placement
+
+New section at position 5 (after "Income Classification", before "Financial Settings"):
+
+1. Account Classifications
+2. Investment Mappings
+3. Expense Categories
+4. Income Classification
+5. **Income & Salary Structure (NEW)**
+6. Financial Settings
+7. Display Preferences
+8. Notifications
+9. Advanced
+10. Dashboard Widgets
+
+### 4.2 Component: `SalaryStructureSection.tsx`
+
+Located at `frontend/src/pages/settings/SalaryStructureSection.tsx`
+
+**Sub-sections:**
+
+#### A. Salary Structure (per FY)
+
+- FY selector: left/right arrows + "Add FY" button (pre-fills from growth assumptions if available)
+- 2-column grid of labeled inputs: Base Salary (monthly), HRA (monthly, optional), Bonus (annual), EPF (monthly, default 3600), NPS (monthly, default 0), Special Allowance (annual), Other Taxable (annual)
+- Live summary card: Total Annual CTC (excluding RSUs), estimated Monthly Take-Home
+- Currency symbol from preferences store
+
+#### B. RSU Grants
+
+- "Add Grant" button opens inline form: stock name, price per share, optional grant date and notes
+- Each grant renders as a card with:
+  - Stock ticker badge + notes
+  - Price per share (editable)
+  - Vesting table: date, quantity, estimated value (quantity x price, auto-calculated), FY (auto-detected from date)
+  - "Add Vesting Date" button per grant
+  - Delete per vesting row, delete per grant
+  - Total shares and total estimated value in footer
+
+#### C. Growth Assumptions
+
+- 3x2 grid of inputs:
+  - Base Salary Growth (%/yr, default 0)
+  - Stock Price Appreciation (%/yr, default 0)
+  - Projection Horizon (years, default 3, max 5)
+  - Bonus Future Years (fixed amount, default 0 — meaning bonus doesn't carry forward)
+  - NPS Growth (%/yr, default 0)
+  - EPF Scales With Base (toggle, default on)
+
+### 4.3 State Management
+
+Follows existing pattern: `useSettingsState.ts` manages local copies of salary_structure, rsu_grants, and growth_assumptions. Changes are persisted on "Save" via the 3 new PUT endpoints (batched with existing preferences save).
+
+---
+
+## 5. Frontend: Tax Planning Page Enhancement
+
+### 5.1 FY Navigation Extension
+
+The existing FY left/right arrows currently only navigate historical FYs (where transaction data exists). Change:
+
+- **Allow navigating forward** up to `projection_years` FYs past the current FY
+- When a future FY is selected and salary structure exists: automatically enter projection mode
+- When the current FY is selected and salary structure exists: show toggle between "From Transactions" / "From Salary Structure"
+- When no salary structure exists for a FY: show prompt to configure in Settings
+
+### 5.2 Projection Data Source Toggle
+
+Pill-style toggle at top of the tax calculation section:
+
+- **"From Transactions"** (default for current/past FY): existing behavior, unchanged
+- **"From Salary Structure"**: calculates tax from salary_structure + RSU vestings for that FY
+- **"Projection"** (auto-selected for future FYs): same as salary structure but label indicates forward-looking
+
+### 5.3 Salary-Based Tax Breakdown (current FY)
+
+When "From Salary Structure" is active, replace the income classification breakdown with:
+
+**Left panel — Income Components:**
+- Base Salary (annual)
+- Bonus & Extras
+- RSU Vesting (shares x price, with share count annotation)
+- EPF (negative, deducted)
+- NPS (if applicable)
+- Special Allowance
+- Other Taxable
+- **Gross Taxable Income** (sum)
+- Less: Standard Deduction
+- **Net Taxable Income**
+
+**Right panel — Tax Computation** (existing slab breakdown, unchanged logic):
+- Tax on slabs
+- Section 87A Rebate
+- Surcharge
+- Health & Education Cess (4%)
+- Professional Tax
+- **Total Projected Tax**
+- Effective Tax Rate
+- Monthly TDS (approx)
+
+**TDS Progress Bar** (current FY only):
+- Compare projected tax vs actual tax paid so far (from transaction data classified as taxable)
+- Show percentage paid, remaining amount, remaining months
+
+### 5.4 Multi-Year Comparison Table
+
+Collapsible section below the main tax view. Visible when salary structure + growth assumptions are configured.
+
+**Table structure:**
+- One column per projected FY
+- Rows: Base Salary, Bonus, RSU Vesting (with share count), EPF, Other, Gross Taxable, Standard Deduction, Net Taxable, Total Tax, Annual Take-Home, Monthly Take-Home
+- Growth annotations per cell (+10%, "scaled", "not set")
+- Color coding: income green, tax red, take-home purple
+
+**Grouped bar chart** (Recharts):
+- Three bars per FY: Gross Income, Tax, Take-Home
+- Wrapped in ChartContainer per existing pattern
+
+### 5.5 Projection Insights
+
+Added to existing suggestions section. Contextual based on projection data:
+
+- **Missing data warnings**: "Bonus not set for FY 2027-28 — take-home projection may be understated"
+- **Slab jump alerts**: "RSU vesting in FY 2028-29 pushes income into 20% slab — consider NPS 80CCD(2)"
+- **Tax-saving suggestions**: "Employer NPS contribution could save up to X/yr" (calculated from actual numbers)
+- **YoY comparison**: "Effective tax rate increases from 11.5% to 13.2% over projection period"
+
+---
+
+## 6. Frontend: Projection Logic
+
+### 6.1 New Module: `frontend/src/lib/projectionCalculator.ts`
+
+Pure functions that take salary structure, RSU grants, growth assumptions, and produce per-FY projections.
+
+```typescript
+// Core projection function
+function projectFiscalYear(
+  baseFY: string,                        // The FY with user-defined salary
+  targetFY: string,                      // The FY to project
+  salaryStructure: Record<string, SalaryComponents>,
+  rsuGrants: RsuGrant[],
+  growthAssumptions: GrowthAssumptions,
+  fiscalYearStartMonth: number,
+): ProjectedFYBreakdown
+
+// Multi-year projection
+function projectMultipleYears(
+  salaryStructure: Record<string, SalaryComponents>,
+  rsuGrants: RsuGrant[],
+  growthAssumptions: GrowthAssumptions,
+  fiscalYearStartMonth: number,
+): ProjectedFYBreakdown[]
+
+// RSU vestings grouped by FY
+function getRsuVestingsByFY(
+  rsuGrants: RsuGrant[],
+  fiscalYearStartMonth: number,
+  stockAppreciationPct: number,
+  yearsFromBase: number,
+): Record<string, { shares: number; value: number; details: VestingDetail[] }>
+```
+
+**Projection algorithm for a future FY (N years from base):**
+
+1. Start from the most recent FY with explicit salary data (base FY)
+2. Apply `base_salary_growth_pct` compounding: `base * (1 + rate/100)^N`
+3. HRA: if set, scale proportionally with base
+4. Bonus: if `bonus_growth_pct` is 0, set to 0 for future years (one-time). If > 0, apply growth.
+5. EPF: if `epf_scales_with_base`, recalculate as `epf_monthly * (new_base / old_base)`. Otherwise keep same.
+6. NPS: apply `nps_growth_pct` compounding
+7. RSU vestings: sum all vestings falling within that FY's date range, multiply quantity by `stock_price * (1 + appreciation/100)^N`
+8. Other taxable: carry forward unchanged
+9. Compute gross taxable, apply standard deduction, run through existing `calculateTax()` from taxCalculator.ts
+10. Return full breakdown with component values, tax computation, and take-home
+
+### 6.2 Integration with Existing `taxCalculator.ts`
+
+No changes to existing functions. `projectionCalculator.ts` calls `calculateTax()` and `getTaxSlabs()` as-is. This keeps the tax logic single-sourced.
+
+---
+
+## 7. Testing Strategy
+
+### 7.1 Backend
+
+- **Unit tests** for Pydantic schema validation (salary components, RSU grants with edge cases like empty vestings)
+- **Integration tests** for the 3 new PUT endpoints (happy path, validation errors, partial updates)
+- **Migration test**: verify columns exist with correct defaults after migration
+
+### 7.2 Frontend
+
+- **Unit tests** for `projectionCalculator.ts`: growth compounding, RSU FY grouping, edge cases (0% growth, no RSUs, missing FY data)
+- **Hook tests** for the 3 new mutations (mock API calls)
+- **Component rendering**: SalaryStructureSection renders correctly with empty state, populated state
+
+---
+
+## 8. File Changes Summary
+
+### New Files
+| File | Purpose |
+|------|---------|
+| `backend/src/ledger_sync/schemas/salary.py` | Pydantic models for salary, RSU, growth |
+| `backend/alembic/versions/xxx_add_salary_structure.py` | Migration adding 3 JSON columns |
+| `frontend/src/types/salary.ts` | TypeScript interfaces |
+| `frontend/src/lib/projectionCalculator.ts` | Projection computation (pure functions) |
+| `frontend/src/pages/settings/SalaryStructureSection.tsx` | Settings UI section |
+
+### Modified Files
+| File | Changes |
+|------|---------|
+| `backend/src/ledger_sync/db/models.py` | Add 3 JSON columns to UserPreferences |
+| `backend/src/ledger_sync/api/preferences.py` | Add 3 PUT endpoints |
+| `backend/src/ledger_sync/schemas/preferences.py` | Extend response model |
+| `frontend/src/store/preferencesStore.ts` | Add salary/RSU/growth state + actions |
+| `frontend/src/pages/SettingsPage.tsx` | Import and render SalaryStructureSection |
+| `frontend/src/pages/settings/useSettingsState.ts` | Manage local salary/RSU/growth state |
+| `frontend/src/pages/settings/types.ts` | Add salary-related constants |
+| `frontend/src/pages/TaxPlanningPage.tsx` | FY nav extension, projection toggle, multi-year table, insights |
+| `frontend/src/services/api/preferences.ts` | Add 3 API call functions |
+| `frontend/src/hooks/api/usePreferences.ts` | Add 3 mutation hooks |
+
+### Test Files
+| File | Purpose |
+|------|---------|
+| `backend/tests/unit/test_salary_schemas.py` | Pydantic validation tests |
+| `backend/tests/integration/test_salary_preferences.py` | API endpoint tests |
+| `frontend/src/lib/__tests__/projectionCalculator.test.ts` | Projection logic tests |

--- a/frontend/src/components/analytics/TaxSlabBreakdown.tsx
+++ b/frontend/src/components/analytics/TaxSlabBreakdown.tsx
@@ -15,6 +15,7 @@ interface TaxSlabBreakdownProps {
   cess: number
   professionalTax: number
   totalTax: number
+  isProjecting?: boolean
 }
 
 export default function TaxSlabBreakdown({
@@ -30,6 +31,7 @@ export default function TaxSlabBreakdown({
   cess,
   professionalTax,
   totalTax,
+  isProjecting = false,
 }: Readonly<TaxSlabBreakdownProps>) {
   return (
     <motion.div
@@ -140,7 +142,7 @@ export default function TaxSlabBreakdown({
             </tr>
             <tr className="border-t-2 border-primary/30">
               <td colSpan={3} className="py-4 px-4 text-right text-lg font-bold text-white">
-                Total Tax Already Paid:
+                {isProjecting ? 'Total Estimated Tax:' : 'Total Tax Already Paid:'}
               </td>
               <td className="py-4 px-4 text-right text-2xl font-bold text-primary">
                 {formatCurrency(totalTax)}

--- a/frontend/src/components/analytics/TaxSummaryCards.tsx
+++ b/frontend/src/components/analytics/TaxSummaryCards.tsx
@@ -7,6 +7,7 @@ interface TaxSummaryCardsProps {
   netTaxableIncome: number
   grossTaxableIncome: number
   taxAlreadyPaid: number
+  isProjecting?: boolean
 }
 
 export default function TaxSummaryCards({
@@ -14,6 +15,7 @@ export default function TaxSummaryCards({
   netTaxableIncome,
   grossTaxableIncome,
   taxAlreadyPaid,
+  isProjecting = false,
 }: Readonly<TaxSummaryCardsProps>) {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
@@ -32,7 +34,9 @@ export default function TaxSummaryCards({
             <p className="text-2xl font-bold">
               {isLoading ? '...' : formatCurrency(netTaxableIncome)}
             </p>
-            <p className="text-xs text-muted-foreground mt-1">Received after TDS</p>
+            <p className="text-xs text-muted-foreground mt-1">
+              {isProjecting ? 'Projected take-home' : 'Received after TDS'}
+            </p>
           </div>
         </div>
       </motion.div>
@@ -68,11 +72,15 @@ export default function TaxSummaryCards({
             <Calculator className="w-6 h-6 text-primary" />
           </div>
           <div>
-            <p className="text-sm text-muted-foreground">Tax Already Paid</p>
+            <p className="text-sm text-muted-foreground">
+              {isProjecting ? 'Estimated Tax' : 'Tax Already Paid'}
+            </p>
             <p className="text-2xl font-bold">
               {isLoading ? '...' : formatCurrency(taxAlreadyPaid)}
             </p>
-            <p className="text-xs text-muted-foreground mt-1">Deducted at source</p>
+            <p className="text-xs text-muted-foreground mt-1">
+              {isProjecting ? 'Projected tax liability' : 'Deducted at source'}
+            </p>
           </div>
         </div>
       </motion.div>

--- a/frontend/src/components/analytics/TaxSummaryGrid.tsx
+++ b/frontend/src/components/analytics/TaxSummaryGrid.tsx
@@ -8,6 +8,7 @@ interface TaxSummaryGridProps {
   netTaxableIncome: number
   totalIncome: number
   totalExpense: number
+  isProjecting?: boolean
 }
 
 export default function TaxSummaryGrid({
@@ -17,6 +18,7 @@ export default function TaxSummaryGrid({
   netTaxableIncome,
   totalIncome,
   totalExpense,
+  isProjecting = false,
 }: Readonly<TaxSummaryGridProps>) {
   const effectiveTaxRate =
     grossTaxableIncome > 0 ? (taxAlreadyPaid / grossTaxableIncome) * 100 : 0
@@ -29,7 +31,7 @@ export default function TaxSummaryGrid({
       className="glass rounded-2xl border border-border p-6"
     >
       <h3 className="text-lg font-semibold text-white mb-6">Tax Summary for {selectedFY}</h3>
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <div className={`grid grid-cols-2 ${isProjecting ? 'md:grid-cols-3' : 'md:grid-cols-4'} gap-4`}>
         <div className="p-4 bg-white/5 rounded-lg border border-border">
           <p className="text-sm text-muted-foreground mb-2">Effective Tax Rate</p>
           <p className="text-2xl font-bold text-primary">{formatPercent(effectiveTaxRate)}</p>
@@ -46,12 +48,14 @@ export default function TaxSummaryGrid({
             {formatCurrency(netTaxableIncome)}
           </p>
         </div>
-        <div className="p-4 bg-white/5 rounded-lg border border-border">
-          <p className="text-sm text-muted-foreground mb-2">Net Savings</p>
-          <p className="text-2xl font-bold text-app-purple">
-            {formatCurrency(totalIncome - totalExpense)}
-          </p>
-        </div>
+        {!isProjecting && (
+          <div className="p-4 bg-white/5 rounded-lg border border-border">
+            <p className="text-sm text-muted-foreground mb-2">Net Savings</p>
+            <p className="text-2xl font-bold text-app-purple">
+              {formatCurrency(totalIncome - totalExpense)}
+            </p>
+          </div>
+        )}
       </div>
     </motion.div>
   )

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -46,10 +46,11 @@ export default function AppLayout() {
   // Fetch exchange rate when display currency changes (pushes to store for formatters)
   useExchangeRate()
 
-  // Dynamic page title
+  // Dynamic page title + scroll reset on navigation
   useEffect(() => {
     const title = PAGE_TITLES[location.pathname]
     document.title = title ? `${title} | Ledger Sync` : 'Ledger Sync'
+    document.getElementById('main-content')?.scrollTo(0, 0)
   }, [location.pathname])
 
   return (

--- a/frontend/src/hooks/api/usePreferences.ts
+++ b/frontend/src/hooks/api/usePreferences.ts
@@ -16,6 +16,9 @@ import {
   type DisplayPreferencesConfig,
   type AnomalySettingsConfig,
   type RecurringSettingsConfig,
+  type SalaryStructureConfig,
+  type RsuGrantsConfig,
+  type GrowthAssumptionsConfig,
 } from '@/services/api/preferences'
 import { usePreferencesStore } from '@/store/preferencesStore'
 import { useAuthStore } from '@/store/authStore'
@@ -151,6 +154,33 @@ export function useUpdateRecurringSettings() {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: (config: RecurringSettingsConfig) => preferencesService.updateRecurringSettings(config),
+    onSuccess: () => invalidatePreferenceDependents(queryClient),
+  })
+}
+
+export function useUpdateSalaryStructure() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (config: SalaryStructureConfig) =>
+      preferencesService.updateSalaryStructure(config),
+    onSuccess: () => invalidatePreferenceDependents(queryClient),
+  })
+}
+
+export function useUpdateRsuGrants() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (config: RsuGrantsConfig) =>
+      preferencesService.updateRsuGrants(config),
+    onSuccess: () => invalidatePreferenceDependents(queryClient),
+  })
+}
+
+export function useUpdateGrowthAssumptions() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (config: GrowthAssumptionsConfig) =>
+      preferencesService.updateGrowthAssumptions(config),
     onSuccess: () => invalidatePreferenceDependents(queryClient),
   })
 }

--- a/frontend/src/lib/__tests__/projectionCalculator.test.ts
+++ b/frontend/src/lib/__tests__/projectionCalculator.test.ts
@@ -8,8 +8,8 @@ import type { SalaryComponents, RsuGrant, GrowthAssumptions } from '@/types/sala
 import { DEFAULT_GROWTH_ASSUMPTIONS } from '@/types/salary'
 
 const baseSalary: SalaryComponents = {
-  base_salary_monthly: 80000,
-  hra_monthly: null,
+  base_salary_annual: 960000,
+  hra_annual: null,
   bonus_annual: 200000,
   epf_monthly: 3600,
   nps_monthly: 0,

--- a/frontend/src/lib/__tests__/projectionCalculator.test.ts
+++ b/frontend/src/lib/__tests__/projectionCalculator.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getRsuVestingsByFY,
+  projectFiscalYear,
+  projectMultipleYears,
+} from '../projectionCalculator'
+import type { SalaryComponents, RsuGrant, GrowthAssumptions } from '@/types/salary'
+import { DEFAULT_GROWTH_ASSUMPTIONS } from '@/types/salary'
+
+const baseSalary: SalaryComponents = {
+  base_salary_monthly: 80000,
+  hra_monthly: null,
+  bonus_annual: 200000,
+  epf_monthly: 3600,
+  nps_monthly: 0,
+  special_allowance_annual: 0,
+  other_taxable_annual: 50000,
+}
+
+const testGrant: RsuGrant = {
+  id: 'g1',
+  stock_name: 'AMZN',
+  stock_price: 100,
+  grant_date: null,
+  notes: null,
+  vestings: [
+    { date: '2026-03-15', quantity: 25 },
+    { date: '2027-03-15', quantity: 25 },
+    { date: '2028-03-15', quantity: 30 },
+  ],
+}
+
+describe('getRsuVestingsByFY', () => {
+  it('groups vestings by fiscal year (April start)', () => {
+    const result = getRsuVestingsByFY([testGrant], 4, 0)
+    expect(result['2025-26']).toBeDefined()
+    expect(result['2025-26'].shares).toBe(25)
+    expect(result['2025-26'].value).toBe(2500)
+    expect(result['2026-27'].shares).toBe(25)
+    expect(result['2027-28'].shares).toBe(30)
+    expect(result['2027-28'].value).toBe(3000)
+  })
+
+  it('applies stock appreciation', () => {
+    const result = getRsuVestingsByFY([testGrant], 4, 10, 2025)
+    expect(result['2025-26'].value).toBe(2500)
+    expect(result['2026-27'].value).toBeCloseTo(25 * 110, 0)
+    expect(result['2027-28'].value).toBeCloseTo(30 * 121, 0)
+  })
+
+  it('returns empty for no grants', () => {
+    const result = getRsuVestingsByFY([], 4, 0)
+    expect(Object.keys(result)).toHaveLength(0)
+  })
+})
+
+describe('projectFiscalYear', () => {
+  it('returns explicit FY data without growth applied', () => {
+    const structure = { '2025-26': baseSalary }
+    const result = projectFiscalYear(
+      '2025-26',
+      structure,
+      [],
+      DEFAULT_GROWTH_ASSUMPTIONS,
+      4,
+    )
+    expect(result.fy).toBe('2025-26')
+    expect(result.baseSalary).toBe(960000)
+    expect(result.bonus).toBe(200000)
+    expect(result.epf).toBe(43200)
+    expect(result.isProjected).toBe(false)
+  })
+
+  it('projects future FY with base salary growth', () => {
+    const structure = { '2025-26': baseSalary }
+    const growth: GrowthAssumptions = {
+      ...DEFAULT_GROWTH_ASSUMPTIONS,
+      base_salary_growth_pct: 10,
+    }
+    const result = projectFiscalYear(
+      '2026-27',
+      structure,
+      [],
+      growth,
+      4,
+    )
+    expect(result.fy).toBe('2026-27')
+    expect(result.baseSalary).toBeCloseTo(1056000, 0)
+    expect(result.isProjected).toBe(true)
+  })
+
+  it('sets bonus to 0 for future years when growth is 0', () => {
+    const structure = { '2025-26': baseSalary }
+    const result = projectFiscalYear(
+      '2026-27',
+      structure,
+      [],
+      DEFAULT_GROWTH_ASSUMPTIONS,
+      4,
+    )
+    expect(result.bonus).toBe(0)
+  })
+
+  it('scales EPF with base when enabled', () => {
+    const structure = { '2025-26': baseSalary }
+    const growth: GrowthAssumptions = {
+      ...DEFAULT_GROWTH_ASSUMPTIONS,
+      base_salary_growth_pct: 10,
+      epf_scales_with_base: true,
+    }
+    const result = projectFiscalYear(
+      '2026-27',
+      structure,
+      [],
+      growth,
+      4,
+    )
+    expect(result.epf).toBeCloseTo(47520, 0)
+  })
+
+  it('includes RSU income for the target FY', () => {
+    const structure = { '2025-26': baseSalary }
+    const result = projectFiscalYear(
+      '2025-26',
+      structure,
+      [testGrant],
+      DEFAULT_GROWTH_ASSUMPTIONS,
+      4,
+    )
+    expect(result.rsuIncome).toBe(2500)
+    expect(result.rsuDetails).toHaveLength(1)
+    expect(result.rsuDetails[0].stock_name).toBe('AMZN')
+  })
+
+  it('computes tax using calculateTax', () => {
+    const structure = { '2025-26': baseSalary }
+    const result = projectFiscalYear(
+      '2025-26',
+      structure,
+      [],
+      DEFAULT_GROWTH_ASSUMPTIONS,
+      4,
+    )
+    expect(result.totalTax).toBeGreaterThan(0)
+    expect(result.takeHome).toBeLessThan(result.grossTaxable)
+    expect(result.effectiveTaxRate).toBeGreaterThan(0)
+    expect(result.effectiveTaxRate).toBeLessThan(100)
+  })
+})
+
+describe('projectMultipleYears', () => {
+  it('returns correct number of projected years', () => {
+    const structure = { '2025-26': baseSalary }
+    const growth: GrowthAssumptions = {
+      ...DEFAULT_GROWTH_ASSUMPTIONS,
+      projection_years: 3,
+    }
+    const results = projectMultipleYears(structure, [], growth, 4)
+    expect(results).toHaveLength(4)
+  })
+
+  it('returns empty array when no salary structure', () => {
+    const results = projectMultipleYears({}, [], DEFAULT_GROWTH_ASSUMPTIONS, 4)
+    expect(results).toHaveLength(0)
+  })
+})

--- a/frontend/src/lib/demo/generateDerivedData.ts
+++ b/frontend/src/lib/demo/generateDerivedData.ts
@@ -52,7 +52,74 @@ const ESSENTIAL_CATEGORIES = [
 // Preferences
 // ---------------------------------------------------------------------------
 
+/** Build FY label like "2025-26" from the start year */
+function fyLabel(startYear: number): string {
+  return `${startYear}-${String((startYear + 1) % 100).padStart(2, '0')}`
+}
+
+/** Get demo salary structure keyed by current and previous FY */
+function buildDemoSalaryStructure(): Record<string, {
+  base_salary_annual: number; hra_annual: number | null; bonus_annual: number;
+  epf_monthly: number; nps_monthly: number; special_allowance_annual: number;
+  other_taxable_annual: number;
+}> {
+  const now = new Date()
+  const month = now.getMonth() + 1
+  const year = now.getFullYear()
+  const currentFYStart = month >= 4 ? year : year - 1
+
+  return {
+    [fyLabel(currentFYStart)]: {
+      base_salary_annual: 960000,
+      hra_annual: 480000,
+      bonus_annual: 150000,
+      epf_monthly: 1800,
+      nps_monthly: 0,
+      special_allowance_annual: 320000,
+      other_taxable_annual: 0,
+    },
+    [fyLabel(currentFYStart - 1)]: {
+      base_salary_annual: 840000,
+      hra_annual: 420000,
+      bonus_annual: 120000,
+      epf_monthly: 1800,
+      nps_monthly: 0,
+      special_allowance_annual: 280000,
+      other_taxable_annual: 0,
+    },
+  }
+}
+
+/** Build demo RSU grants */
+function buildDemoRsuGrants(): Array<{
+  id: string; stock_name: string; stock_price: number;
+  grant_date: string | null; notes: string | null;
+  vestings: Array<{ date: string; quantity: number }>;
+}> {
+  const now = new Date()
+  const grantDate = new Date(now.getFullYear() - 1, now.getMonth() - 6, 15)
+  const fmt = (d: Date) => d.toISOString().slice(0, 10)
+
+  return [{
+    id: 'demo-rsu-1',
+    stock_name: 'TechCorp Inc.',
+    stock_price: 2800,
+    grant_date: fmt(grantDate),
+    notes: 'Joining grant -- 4-year vest',
+    vestings: [
+      { date: fmt(new Date(grantDate.getFullYear() + 1, grantDate.getMonth(), 15)), quantity: 25 },
+      { date: fmt(new Date(grantDate.getFullYear() + 2, grantDate.getMonth(), 15)), quantity: 25 },
+      { date: fmt(new Date(grantDate.getFullYear() + 3, grantDate.getMonth(), 15)), quantity: 25 },
+      { date: fmt(new Date(grantDate.getFullYear() + 4, grantDate.getMonth(), 15)), quantity: 25 },
+    ],
+  }]
+}
+
 export function generateDemoPreferences(): UserPreferences {
+  const now = new Date()
+  // earning_start_date: ~2 years before demo window
+  const earningStart = new Date(now.getFullYear() - 2, now.getMonth(), 1).toISOString().slice(0, 10)
+
   return {
     id: 0,
     fiscal_year_start_month: 4,
@@ -89,8 +156,8 @@ export function generateDemoPreferences(): UserPreferences {
       'Amazon Pay ICICI Credit Card': 150000,
       'Flipkart Axis Credit Card': 100000,
     },
-    earning_start_date: null,
-    use_earning_start_date: false,
+    earning_start_date: earningStart,
+    use_earning_start_date: true,
     fixed_expense_categories: ['Housing', 'Family'],
     savings_goal_percent: 20,
     monthly_investment_target: 50000,
@@ -101,14 +168,14 @@ export function generateDemoPreferences(): UserPreferences {
     notify_anomalies: true,
     notify_upcoming_bills: true,
     notify_days_ahead: 7,
-    salary_structure: {},
-    rsu_grants: [],
+    salary_structure: buildDemoSalaryStructure(),
+    rsu_grants: buildDemoRsuGrants(),
     growth_assumptions: {
-      base_salary_growth_pct: 0,
-      bonus_growth_pct: 0,
+      base_salary_growth_pct: 10,
+      bonus_growth_pct: 8,
       epf_scales_with_base: true,
       nps_growth_pct: 0,
-      stock_price_appreciation_pct: 0,
+      stock_price_appreciation_pct: 12,
       projection_years: 3,
     },
     created_at: null,
@@ -153,8 +220,37 @@ export function generateDemoMonthlyAggregation(
   return result
 }
 
+// Opening balances representing account history before the 24-month demo window
+const OPENING_BALANCES: Record<string, number> = {
+  'SBI Savings': 280000,
+  'HDFC Salary': 95000,
+  'Axis Bank': 45000,
+  'Cash': 8000,
+  'EPF Account': 180000,
+  'PPF Account': 120000,
+  'Groww Stocks': 150000,
+  'Groww Mutual Funds': 200000,
+  'SBI FD': 100000,
+  'GPay UPI': 2000,
+  'Pluxee Wallet': 1500,
+  'Amazon Wallet': 500,
+  // Credit cards, social accounts start at 0
+}
+
+// Accounts that should never show a negative balance (banks, wallets, investments)
+const NON_NEGATIVE_ACCOUNTS = new Set([
+  'SBI Savings', 'HDFC Salary', 'Axis Bank', 'Cash',
+  'GPay UPI', 'Pluxee Wallet', 'Amazon Wallet',
+  'EPF Account', 'PPF Account', 'Groww Stocks', 'Groww Mutual Funds', 'SBI FD',
+])
+
 export function generateDemoAccountBalances(txs: Transaction[]): AccountBalances {
   const accounts: Record<string, { balance: number; transactions: number; last_transaction: string | null }> = {}
+
+  // Seed opening balances
+  for (const [name, balance] of Object.entries(OPENING_BALANCES)) {
+    accounts[name] = { balance, transactions: 0, last_transaction: null }
+  }
 
   for (const tx of txs) {
     const acct = tx.account
@@ -179,6 +275,13 @@ export function generateDemoAccountBalances(txs: Transaction[]): AccountBalances
       if (!dest.last_transaction || tx.date > dest.last_transaction) {
         dest.last_transaction = tx.date
       }
+    }
+  }
+
+  // Clamp bank/wallet/investment accounts to zero minimum (no overdrafts)
+  for (const [name, data] of Object.entries(accounts)) {
+    if (NON_NEGATIVE_ACCOUNTS.has(name) && data.balance < 0) {
+      data.balance = 0
     }
   }
 

--- a/frontend/src/lib/demo/generateDerivedData.ts
+++ b/frontend/src/lib/demo/generateDerivedData.ts
@@ -101,6 +101,16 @@ export function generateDemoPreferences(): UserPreferences {
     notify_anomalies: true,
     notify_upcoming_bills: true,
     notify_days_ahead: 7,
+    salary_structure: {},
+    rsu_grants: [],
+    growth_assumptions: {
+      base_salary_growth_pct: 0,
+      bonus_growth_pct: 0,
+      epf_scales_with_base: true,
+      nps_growth_pct: 0,
+      stock_price_appreciation_pct: 0,
+      projection_years: 3,
+    },
     created_at: null,
     updated_at: null,
   }

--- a/frontend/src/lib/demo/generateTransactions.ts
+++ b/frontend/src/lib/demo/generateTransactions.ts
@@ -393,11 +393,11 @@ export function generateDemoTransactions(): Transaction[] {
 
     // ─── TRANSFERS ──────────────────────────────────────────────────────
 
-    // Salary account -> savings (monthly sweep)
+    // Salary account -> savings (monthly sweep, enough to cover SBI outflows)
     txs.push({
       id: txId(idx++),
       date: formatDate(new Date(year, month, 2)),
-      amount: rng.int(30000, 60000),
+      amount: rng.int(50000, 70000),
       type: 'Transfer',
       category: 'Transfer',
       subcategory: 'Bank Transfer',
@@ -425,18 +425,18 @@ export function generateDemoTransactions(): Transaction[] {
       currency: 'INR',
     })
 
-    // Stock investments (1-3 per month)
-    const stockTxCount = rng.int(1, 3)
+    // Stock investments (0-2 per month, capped to keep bank balances healthy)
+    const stockTxCount = rng.int(0, 2)
     for (let s = 0; s < stockTxCount; s++) {
       txs.push({
         id: txId(idx++),
         date: formatDate(new Date(year, month, rng.int(1, daysInMonth))),
-        amount: rng.int(2000, 50000),
+        amount: rng.int(2000, 15000),
         type: 'Transfer',
         category: 'Investment',
         subcategory: 'Stocks',
         account: ACCOUNTS.sbi,
-        from_account: rng.pick([ACCOUNTS.sbi, ACCOUNTS.hdfc]),
+        from_account: ACCOUNTS.sbi,
         to_account: ACCOUNTS.growStocks,
         note: rng.pick(['NIFTY Bees', 'HDFC Bank Shares', 'Reliance Stock', 'TCS Stock', 'Infosys Stock']),
         is_transfer: true,
@@ -483,7 +483,7 @@ export function generateDemoTransactions(): Transaction[] {
       txs.push({
         id: txId(idx++),
         date: formatDate(new Date(year, month, rng.int(20, 28))),
-        amount: rng.int(25000, 100000),
+        amount: rng.int(15000, 40000),
         type: 'Transfer',
         category: 'Investment',
         subcategory: 'Fixed Deposit',
@@ -602,23 +602,20 @@ export function generateDemoTransactions(): Transaction[] {
       currency: 'INR',
     })
 
-    // Credit card bill payments (25th)
+    // Credit card bill payments (25th) -- pay off full balance so CC resets to 0
+    const monthPrefix = `${year}-${String(month + 1).padStart(2, '0')}`
     const ccAccounts = [ACCOUNTS.swiggyCC, ACCOUNTS.amazonCC, ACCOUNTS.axisCC]
     for (const cc of ccAccounts) {
-      const ccSpend = txs
-        .filter(
-          (t) =>
-            t.account === cc &&
-            t.type === 'Expense' &&
-            t.date.startsWith(`${year}-${String(month + 1).padStart(2, '0')}`),
-        )
-        .reduce((s, t) => s + t.amount, 0)
+      const monthlyOnCC = txs.filter((t) => t.account === cc && t.date.startsWith(monthPrefix))
+      const ccExpenses = monthlyOnCC.filter((t) => t.type === 'Expense').reduce((s, t) => s + t.amount, 0)
+      const ccRefunds = monthlyOnCC.filter((t) => t.type === 'Income').reduce((s, t) => s + t.amount, 0)
+      const ccBillAmount = ccExpenses - ccRefunds
 
-      if (ccSpend > 0) {
+      if (ccBillAmount > 0) {
         txs.push({
           id: txId(idx++),
           date: formatDate(new Date(year, month, 25)),
-          amount: ccSpend,
+          amount: ccBillAmount,
           type: 'Transfer',
           category: 'Transfer',
           subcategory: 'Credit Card Payment',

--- a/frontend/src/lib/projectionCalculator.ts
+++ b/frontend/src/lib/projectionCalculator.ts
@@ -43,6 +43,11 @@ function dateToFY(dateStr: string, fyStartMonth: number): string {
   return `${fyStartYear}-${String(endYear).padStart(2, '0')}`
 }
 
+/** Safely coerce a value (possibly string from JSON) to number. */
+function N(v: number | string | null | undefined): number {
+  return Number(v) || 0
+}
+
 interface RsuFYData {
   shares: number
   value: number
@@ -68,7 +73,7 @@ export function getRsuVestingsByFY(
         1 + stockAppreciationPct / 100,
         Math.max(0, yearsFromBase),
       )
-      const adjustedPrice = grant.stock_price * appreciationFactor
+      const adjustedPrice = N(grant.stock_price) * appreciationFactor
       const vestingValue = vesting.quantity * adjustedPrice
 
       if (!result[fy]) {
@@ -121,45 +126,45 @@ export function projectFiscalYear(
   )
 
   const baseSalaryAnnual = isExplicit
-    ? salaryStructure[targetFY].base_salary_annual
-    : base.base_salary_annual * baseGrowthFactor
+    ? N(salaryStructure[targetFY].base_salary_annual)
+    : N(base.base_salary_annual) * baseGrowthFactor
 
   const hraAnnual = (() => {
     const src = isExplicit ? salaryStructure[targetFY] : base
     if (src.hra_annual == null) return 0
-    return isExplicit ? src.hra_annual : src.hra_annual * baseGrowthFactor
+    return isExplicit ? N(src.hra_annual) : N(src.hra_annual) * baseGrowthFactor
   })()
 
   const bonusAnnual = (() => {
-    if (isExplicit) return salaryStructure[targetFY].bonus_annual
-    if (yearsOffset === 0) return base.bonus_annual
+    if (isExplicit) return N(salaryStructure[targetFY].bonus_annual)
+    if (yearsOffset === 0) return N(base.bonus_annual)
     if (growth.bonus_growth_pct === 0) return 0
     return (
-      base.bonus_annual *
+      N(base.bonus_annual) *
       Math.pow(1 + growth.bonus_growth_pct / 100, yearsOffset)
     )
   })()
 
   const epfAnnual = (() => {
-    if (isExplicit) return salaryStructure[targetFY].epf_monthly * 12
+    if (isExplicit) return N(salaryStructure[targetFY].epf_monthly) * 12
     if (growth.epf_scales_with_base)
-      return base.epf_monthly * baseGrowthFactor * 12
-    return base.epf_monthly * 12
+      return N(base.epf_monthly) * baseGrowthFactor * 12
+    return N(base.epf_monthly) * 12
   })()
 
   const npsAnnual = (() => {
-    if (isExplicit) return salaryStructure[targetFY].nps_monthly * 12
+    if (isExplicit) return N(salaryStructure[targetFY].nps_monthly) * 12
     const npsFactor = Math.pow(1 + growth.nps_growth_pct / 100, yearsOffset)
-    return base.nps_monthly * npsFactor * 12
+    return N(base.nps_monthly) * npsFactor * 12
   })()
 
   const specialAllowanceAnnual = isExplicit
-    ? salaryStructure[targetFY].special_allowance_annual
-    : base.special_allowance_annual
+    ? N(salaryStructure[targetFY].special_allowance_annual)
+    : N(base.special_allowance_annual)
 
   const otherTaxableAnnual = isExplicit
-    ? salaryStructure[targetFY].other_taxable_annual
-    : base.other_taxable_annual
+    ? N(salaryStructure[targetFY].other_taxable_annual)
+    : N(base.other_taxable_annual)
 
   const baseStartYear = parseFYStart(baseFY)
   const rsuByFY = getRsuVestingsByFY(

--- a/frontend/src/lib/projectionCalculator.ts
+++ b/frontend/src/lib/projectionCalculator.ts
@@ -68,7 +68,7 @@ export function getRsuVestingsByFY(
       const fy = dateToFY(vesting.date, fyStartMonth)
       const fyStart = parseFYStart(fy)
       const yearsFromBase =
-        baseStartYear != null ? fyStart - baseStartYear : 0
+        baseStartYear === undefined ? 0 : fyStart - baseStartYear
       const appreciationFactor = Math.pow(
         1 + stockAppreciationPct / 100,
         Math.max(0, yearsFromBase),
@@ -109,9 +109,9 @@ export function projectFiscalYear(
   growth: GrowthAssumptions,
   fyStartMonth: number,
 ): ProjectedFYBreakdown {
-  const sortedFYs = Object.keys(salaryStructure).sort()
+  const sortedFYs = Object.keys(salaryStructure).sort((a, b) => a.localeCompare(b))
   const baseFY =
-    sortedFYs.filter((fy) => fy <= targetFY).at(-1) ?? sortedFYs[0]
+    sortedFYs.findLast((fy) => fy <= targetFY) ?? sortedFYs[0]
   if (!baseFY || !salaryStructure[baseFY]) {
     return emptyBreakdown(targetFY)
   }
@@ -231,7 +231,7 @@ export function projectMultipleYears(
   growth: GrowthAssumptions,
   fyStartMonth: number,
 ): ProjectedFYBreakdown[] {
-  const sortedFYs = Object.keys(salaryStructure).sort()
+  const sortedFYs = Object.keys(salaryStructure).sort((a, b) => a.localeCompare(b))
   if (sortedFYs.length === 0) return []
 
   const latestFY = sortedFYs.at(-1)!

--- a/frontend/src/lib/projectionCalculator.ts
+++ b/frontend/src/lib/projectionCalculator.ts
@@ -1,0 +1,266 @@
+/**
+ * Pure projection functions for multi-year tax planning.
+ *
+ * Takes salary structure + growth assumptions and produces per-FY
+ * tax breakdowns using calculateTax() from taxCalculator.ts.
+ */
+
+import {
+  calculateTax,
+  getStandardDeduction,
+  getTaxSlabs,
+} from '@/lib/taxCalculator'
+import type {
+  GrowthAssumptions,
+  ProjectedFYBreakdown,
+  RsuGrant,
+  SalaryComponents,
+} from '@/types/salary'
+
+/**
+ * Parse the numeric start year from an FY string.
+ * Handles both "2025-26" and "FY 2025-26" formats.
+ */
+function parseFYStart(fy: string): number {
+  const stripped = fy.replace(/^FY\s+/i, '')
+  return Number.parseInt(stripped.split('-')[0], 10)
+}
+
+/** Increment a FY string by N years: "2025-26" + 1 -> "2026-27" */
+function offsetFY(fy: string, offset: number): string {
+  const startYear = parseFYStart(fy) + offset
+  const endYear = (startYear + 1) % 100
+  return `${startYear}-${String(endYear).padStart(2, '0')}`
+}
+
+/** Get the FY string a date falls into given a fiscal year start month. */
+function dateToFY(dateStr: string, fyStartMonth: number): string {
+  const d = new Date(dateStr)
+  const month = d.getMonth() + 1
+  const year = d.getFullYear()
+  const fyStartYear = month >= fyStartMonth ? year : year - 1
+  const endYear = (fyStartYear + 1) % 100
+  return `${fyStartYear}-${String(endYear).padStart(2, '0')}`
+}
+
+interface RsuFYData {
+  shares: number
+  value: number
+  details: Array<{ stock_name: string; shares: number; value: number }>
+}
+
+/** Group RSU vestings by fiscal year with optional stock appreciation. */
+export function getRsuVestingsByFY(
+  grants: RsuGrant[],
+  fyStartMonth: number,
+  stockAppreciationPct: number,
+  baseStartYear?: number,
+): Record<string, RsuFYData> {
+  const result: Record<string, RsuFYData> = {}
+
+  for (const grant of grants) {
+    for (const vesting of grant.vestings) {
+      const fy = dateToFY(vesting.date, fyStartMonth)
+      const fyStart = parseFYStart(fy)
+      const yearsFromBase =
+        baseStartYear != null ? fyStart - baseStartYear : 0
+      const appreciationFactor = Math.pow(
+        1 + stockAppreciationPct / 100,
+        Math.max(0, yearsFromBase),
+      )
+      const adjustedPrice = grant.stock_price * appreciationFactor
+      const vestingValue = vesting.quantity * adjustedPrice
+
+      if (!result[fy]) {
+        result[fy] = { shares: 0, value: 0, details: [] }
+      }
+      result[fy].shares += vesting.quantity
+      result[fy].value += vestingValue
+
+      const existing = result[fy].details.find(
+        (d) => d.stock_name === grant.stock_name,
+      )
+      if (existing) {
+        existing.shares += vesting.quantity
+        existing.value += vestingValue
+      } else {
+        result[fy].details.push({
+          stock_name: grant.stock_name,
+          shares: vesting.quantity,
+          value: vestingValue,
+        })
+      }
+    }
+  }
+
+  return result
+}
+
+/** Project a single fiscal year's income and tax breakdown. */
+export function projectFiscalYear(
+  targetFY: string,
+  salaryStructure: Record<string, SalaryComponents>,
+  rsuGrants: RsuGrant[],
+  growth: GrowthAssumptions,
+  fyStartMonth: number,
+): ProjectedFYBreakdown {
+  const sortedFYs = Object.keys(salaryStructure).sort()
+  const baseFY =
+    sortedFYs.filter((fy) => fy <= targetFY).at(-1) ?? sortedFYs[0]
+  if (!baseFY || !salaryStructure[baseFY]) {
+    return emptyBreakdown(targetFY)
+  }
+
+  const base = salaryStructure[baseFY]
+  const isExplicit = targetFY in salaryStructure
+  const yearsOffset = parseFYStart(targetFY) - parseFYStart(baseFY)
+
+  const baseGrowthFactor = Math.pow(
+    1 + growth.base_salary_growth_pct / 100,
+    yearsOffset,
+  )
+
+  const baseSalaryAnnual =
+    (isExplicit
+      ? salaryStructure[targetFY].base_salary_monthly
+      : base.base_salary_monthly * baseGrowthFactor) * 12
+
+  const hraAnnual = (() => {
+    const src = isExplicit ? salaryStructure[targetFY] : base
+    if (src.hra_monthly == null) return 0
+    return (isExplicit ? src.hra_monthly : src.hra_monthly * baseGrowthFactor) * 12
+  })()
+
+  const bonusAnnual = (() => {
+    if (isExplicit) return salaryStructure[targetFY].bonus_annual
+    if (yearsOffset === 0) return base.bonus_annual
+    if (growth.bonus_growth_pct === 0) return 0
+    return (
+      base.bonus_annual *
+      Math.pow(1 + growth.bonus_growth_pct / 100, yearsOffset)
+    )
+  })()
+
+  const epfAnnual = (() => {
+    if (isExplicit) return salaryStructure[targetFY].epf_monthly * 12
+    if (growth.epf_scales_with_base)
+      return base.epf_monthly * baseGrowthFactor * 12
+    return base.epf_monthly * 12
+  })()
+
+  const npsAnnual = (() => {
+    if (isExplicit) return salaryStructure[targetFY].nps_monthly * 12
+    const npsFactor = Math.pow(1 + growth.nps_growth_pct / 100, yearsOffset)
+    return base.nps_monthly * npsFactor * 12
+  })()
+
+  const specialAllowanceAnnual = isExplicit
+    ? salaryStructure[targetFY].special_allowance_annual
+    : base.special_allowance_annual
+
+  const otherTaxableAnnual = isExplicit
+    ? salaryStructure[targetFY].other_taxable_annual
+    : base.other_taxable_annual
+
+  const baseStartYear = parseFYStart(baseFY)
+  const rsuByFY = getRsuVestingsByFY(
+    rsuGrants,
+    fyStartMonth,
+    growth.stock_price_appreciation_pct,
+    baseStartYear,
+  )
+  const rsuData = rsuByFY[targetFY] ?? { shares: 0, value: 0, details: [] }
+
+  const grossTaxable =
+    baseSalaryAnnual +
+    hraAnnual +
+    bonusAnnual +
+    specialAllowanceAnnual +
+    otherTaxableAnnual +
+    rsuData.value -
+    epfAnnual
+
+  const fyStartYear = parseFYStart(targetFY)
+  const standardDeduction = getStandardDeduction(fyStartYear)
+  const netTaxable = Math.max(0, grossTaxable - standardDeduction)
+
+  const slabs = getTaxSlabs(fyStartYear, 'new')
+  const taxResult = calculateTax(
+    grossTaxable,
+    slabs,
+    standardDeduction,
+    true,
+    12,
+    true,
+    fyStartYear,
+  )
+
+  const takeHome = grossTaxable - taxResult.totalTax
+  const effectiveTaxRate =
+    grossTaxable > 0 ? (taxResult.totalTax / grossTaxable) * 100 : 0
+
+  return {
+    fy: targetFY,
+    baseSalary: baseSalaryAnnual,
+    hra: hraAnnual,
+    bonus: bonusAnnual,
+    epf: epfAnnual,
+    nps: npsAnnual,
+    specialAllowance: specialAllowanceAnnual,
+    otherTaxable: otherTaxableAnnual,
+    rsuIncome: rsuData.value,
+    rsuDetails: rsuData.details,
+    grossTaxable,
+    standardDeduction,
+    netTaxable,
+    totalTax: taxResult.totalTax,
+    takeHome,
+    effectiveTaxRate,
+    isProjected: !isExplicit || yearsOffset > 0,
+  }
+}
+
+/** Project multiple years starting from the latest FY with explicit salary data. */
+export function projectMultipleYears(
+  salaryStructure: Record<string, SalaryComponents>,
+  rsuGrants: RsuGrant[],
+  growth: GrowthAssumptions,
+  fyStartMonth: number,
+): ProjectedFYBreakdown[] {
+  const sortedFYs = Object.keys(salaryStructure).sort()
+  if (sortedFYs.length === 0) return []
+
+  const latestFY = sortedFYs.at(-1)!
+  const results: ProjectedFYBreakdown[] = []
+
+  for (let i = 0; i <= growth.projection_years; i++) {
+    const targetFY = offsetFY(latestFY, i)
+    results.push(
+      projectFiscalYear(targetFY, salaryStructure, rsuGrants, growth, fyStartMonth),
+    )
+  }
+
+  return results
+}
+
+function emptyBreakdown(fy: string): ProjectedFYBreakdown {
+  return {
+    fy,
+    baseSalary: 0,
+    hra: 0,
+    bonus: 0,
+    epf: 0,
+    nps: 0,
+    specialAllowance: 0,
+    otherTaxable: 0,
+    rsuIncome: 0,
+    rsuDetails: [],
+    grossTaxable: 0,
+    standardDeduction: 0,
+    netTaxable: 0,
+    totalTax: 0,
+    takeHome: 0,
+    effectiveTaxRate: 0,
+    isProjected: true,
+  }
+}

--- a/frontend/src/lib/projectionCalculator.ts
+++ b/frontend/src/lib/projectionCalculator.ts
@@ -120,15 +120,14 @@ export function projectFiscalYear(
     yearsOffset,
   )
 
-  const baseSalaryAnnual =
-    (isExplicit
-      ? salaryStructure[targetFY].base_salary_monthly
-      : base.base_salary_monthly * baseGrowthFactor) * 12
+  const baseSalaryAnnual = isExplicit
+    ? salaryStructure[targetFY].base_salary_annual
+    : base.base_salary_annual * baseGrowthFactor
 
   const hraAnnual = (() => {
     const src = isExplicit ? salaryStructure[targetFY] : base
-    if (src.hra_monthly == null) return 0
-    return (isExplicit ? src.hra_monthly : src.hra_monthly * baseGrowthFactor) * 12
+    if (src.hra_annual == null) return 0
+    return isExplicit ? src.hra_annual : src.hra_annual * baseGrowthFactor
   })()
 
   const bonusAnnual = (() => {

--- a/frontend/src/pages/FIRECalculatorPage.tsx
+++ b/frontend/src/pages/FIRECalculatorPage.tsx
@@ -94,34 +94,33 @@ export default function FIRECalculatorPage() {
 
   return (
     <div className="min-h-screen p-4 md:p-6 lg:p-8">
+      <div className="max-w-7xl mx-auto space-y-6 md:space-y-8">
+        <PageHeader
+          title="FIRE & Retirement Calculator"
+          subtitle="Plan your financial independence using your actual spending data"
+          action={
+            <div className="flex gap-1 p-1 rounded-lg bg-muted/20">
+              <button
+                onClick={() => setActiveTab('fire')}
+                className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${activeTab === 'fire' ? 'bg-white/10 text-white' : 'text-muted-foreground hover:text-white'}`}
+              >
+                <Flame className="w-4 h-4 inline mr-1.5" />FIRE
+              </button>
+              <button
+                onClick={() => setActiveTab('retirement')}
+                className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${activeTab === 'retirement' ? 'bg-white/10 text-white' : 'text-muted-foreground hover:text-white'}`}
+              >
+                <Calculator className="w-4 h-4 inline mr-1.5" />Retirement
+              </button>
+            </div>
+          }
+        />
       <motion.div
-        className="max-w-7xl mx-auto space-y-6 md:space-y-8"
         initial="hidden"
         animate="visible"
         variants={staggerContainer}
+        className="space-y-6 md:space-y-8"
       >
-        <motion.div variants={fadeUpItem}>
-          <PageHeader
-            title="FIRE & Retirement Calculator"
-            subtitle="Plan your financial independence using your actual spending data"
-            action={
-              <div className="flex gap-1 p-1 rounded-lg bg-muted/20">
-                <button
-                  onClick={() => setActiveTab('fire')}
-                  className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${activeTab === 'fire' ? 'bg-white/10 text-white' : 'text-muted-foreground hover:text-white'}`}
-                >
-                  <Flame className="w-4 h-4 inline mr-1.5" />FIRE
-                </button>
-                <button
-                  onClick={() => setActiveTab('retirement')}
-                  className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${activeTab === 'retirement' ? 'bg-white/10 text-white' : 'text-muted-foreground hover:text-white'}`}
-                >
-                  <Calculator className="w-4 h-4 inline mr-1.5" />Retirement
-                </button>
-              </div>
-            }
-          />
-        </motion.div>
 
         {activeTab === 'fire' ? (
           <>
@@ -220,6 +219,7 @@ export default function FIRECalculatorPage() {
           </>
         )}
       </motion.div>
+      </div>
     </div>
   )
 }

--- a/frontend/src/pages/FIRECalculatorPage.tsx
+++ b/frontend/src/pages/FIRECalculatorPage.tsx
@@ -10,7 +10,7 @@ import { computeFIRE, computeRetirementCorpus } from '@/lib/fireCalculator'
 import { rawColors } from '@/constants/colors'
 import MetricCard from '@/components/shared/MetricCard'
 import { PageHeader, ChartContainer } from '@/components/ui'
-import { GRID_DEFAULTS, xAxisDefaults, yAxisDefaults, shouldAnimate, areaGradient, areaGradientUrl } from '@/components/ui/chartDefaults'
+import { GRID_DEFAULTS, xAxisDefaults, yAxisDefaults, shouldAnimate, areaGradient, areaGradientUrl, ACTIVE_DOT } from '@/components/ui/chartDefaults'
 import { chartTooltipProps } from '@/components/ui/ChartTooltip'
 import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts'
 
@@ -198,8 +198,8 @@ export default function FIRECalculatorPage() {
                         name === 'corpus' ? 'Total Corpus' : 'Contributed',
                       ]}
                     />
-                    <Area type="monotone" dataKey="corpus" stroke={rawColors.app.blue} fill={areaGradientUrl('corpus')} strokeWidth={2} isAnimationActive={shouldAnimate(retirementResult.projectionData.length)} />
-                    <Area type="monotone" dataKey="contributed" stroke={rawColors.app.green} fill={areaGradientUrl('contributed')} strokeWidth={2} strokeDasharray="4 4" isAnimationActive={shouldAnimate(retirementResult.projectionData.length)} />
+                    <Area type="monotone" dataKey="corpus" stroke={rawColors.app.blue} fill={areaGradientUrl('corpus')} strokeWidth={2} dot={false} activeDot={{ ...ACTIVE_DOT, fill: rawColors.app.blue }} isAnimationActive={shouldAnimate(retirementResult.projectionData.length)} />
+                    <Area type="monotone" dataKey="contributed" stroke={rawColors.app.green} fill={areaGradientUrl('contributed')} strokeWidth={2} strokeDasharray="4 4" dot={false} activeDot={{ ...ACTIVE_DOT, fill: rawColors.app.green }} isAnimationActive={shouldAnimate(retirementResult.projectionData.length)} />
                   </AreaChart>
                 </ChartContainer>
               </motion.div>

--- a/frontend/src/pages/InsightsPage.tsx
+++ b/frontend/src/pages/InsightsPage.tsx
@@ -26,18 +26,17 @@ function SectionHeader({ icon: Icon, title }: Readonly<{ icon: typeof Gauge; tit
 export default function InsightsPage() {
   return (
     <div className="min-h-screen p-4 md:p-6 lg:p-8">
+    <div className="max-w-7xl mx-auto space-y-6 md:space-y-8">
+      <PageHeader
+        title="Financial Insights"
+        subtitle="Advanced analytics computed from your transaction history"
+      />
     <motion.div
-      className="max-w-7xl mx-auto space-y-6 md:space-y-8"
       variants={staggerContainer}
       initial="hidden"
       animate="visible"
+      className="space-y-6 md:space-y-8"
     >
-      <motion.div variants={fadeUpItem}>
-        <PageHeader
-          title="Financial Insights"
-          subtitle="Advanced analytics computed from your transaction history"
-        />
-      </motion.div>
       <motion.div variants={fadeUpItem}>
         <SectionHeader icon={Gauge} title="Spending Velocity" />
         <SpendingVelocityGauge />
@@ -74,6 +73,7 @@ export default function InsightsPage() {
         <MonthlyFinancialReportCard />
       </motion.div>
     </motion.div>
+    </div>
     </div>
   )
 }

--- a/frontend/src/pages/NetWorthPage.tsx
+++ b/frontend/src/pages/NetWorthPage.tsx
@@ -7,7 +7,8 @@ import { useChartDimensions } from '@/hooks/useChartDimensions'
 import { useTransactions } from '@/hooks/api/useTransactions'
 import { usePreferences } from '@/hooks/api/usePreferences'
 import { AreaChart, Area, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts'
-import { chartTooltipProps, PageHeader, ChartContainer, GRID_DEFAULTS, xAxisDefaults, yAxisDefaults, areaGradient, areaGradientUrl, shouldAnimate, LEGEND_DEFAULTS } from '@/components/ui'
+import { chartTooltipProps, PageHeader, ChartContainer, GRID_DEFAULTS, xAxisDefaults, yAxisDefaults, areaGradient, areaGradientUrl, shouldAnimate, LEGEND_DEFAULTS, ACTIVE_DOT } from '@/components/ui'
+import { CHART_TOOLTIP_STYLE } from '@/components/ui/ChartTooltip'
 import { useState, useMemo, useEffect, useCallback } from 'react'
 import { formatCurrency, formatPercent } from '@/lib/formatters'
 import { CreditCardHealth } from '@/components/analytics'
@@ -443,7 +444,7 @@ export default function NetWorthPage() {
     if (!item) return null
     const isPositive = item.change >= 0
     return (
-      <div style={{ background: 'rgba(26, 26, 28, 0.95)', border: '1px solid rgba(255, 255, 255, 0.08)', borderRadius: '10px', padding: '12px 16px', boxShadow: '0 8px 24px rgba(0, 0, 0, 0.4)' }}>
+      <div style={CHART_TOOLTIP_STYLE}>
         <p style={{ color: '#a1a1aa', fontSize: '12px', marginBottom: '6px' }}>{label}</p>
         <p style={{ color: isPositive ? rawColors.app.green : rawColors.app.red, fontSize: '16px', fontWeight: 700 }}>
           {isPositive ? '+' : ''}{formatCurrency(item.change)}
@@ -559,6 +560,7 @@ export default function NetWorthPage() {
                               stroke={config.color}
                               strokeWidth={2}
                               dot={false}
+                              activeDot={{ ...ACTIVE_DOT, fill: config.color }}
                               fillOpacity={1}
                               fill={`url(#color-${cat.replaceAll(/\s+/g, '')})`}
                               name={config.label}
@@ -576,6 +578,7 @@ export default function NetWorthPage() {
                         stroke={rawColors.app.purple}
                         strokeWidth={2}
                         dot={false}
+                        activeDot={{ ...ACTIVE_DOT, fill: rawColors.app.purple }}
                         fillOpacity={1}
                         fill={areaGradientUrl('netWorth')}
                         name="Net Worth"

--- a/frontend/src/pages/ReturnsAnalysisPage.tsx
+++ b/frontend/src/pages/ReturnsAnalysisPage.tsx
@@ -11,8 +11,9 @@ import {
 import {
   PageHeader, ChartContainer,
   GRID_DEFAULTS, xAxisDefaults, yAxisDefaults, areaGradient, areaGradientUrl,
-  shouldAnimate, ACTIVE_DOT,
+  shouldAnimate, ACTIVE_DOT, chartTooltipProps,
 } from '@/components/ui'
+import { CHART_TOOLTIP_STYLE, CHART_TOOLTIP_LABEL_STYLE } from '@/components/ui/ChartTooltip'
 import { useMemo, useCallback } from 'react'
 import { formatCurrency, formatCurrencyShort, formatPercent } from '@/lib/formatters'
 import ChartEmptyState from '@/components/shared/ChartEmptyState'
@@ -185,8 +186,8 @@ export default function ReturnsAnalysisPage() {
   const renderComboTooltip = useCallback(({ active, payload, label }: { active?: boolean; payload?: Array<{ dataKey?: string; value?: number; color?: string }>; label?: string }) => {
     if (!active || !payload?.length) return null
     return (
-      <div style={{ backgroundColor: 'rgba(26,26,28,0.95)', border: '1px solid rgba(255,255,255,0.08)', borderRadius: 10, padding: '12px 16px', boxShadow: '0 8px 24px rgba(0,0,0,0.4)' }}>
-        <p style={{ color: '#a1a1aa', fontSize: 12, marginBottom: 6 }}>{label}</p>
+      <div style={CHART_TOOLTIP_STYLE}>
+        <p style={{ ...CHART_TOOLTIP_LABEL_STYLE, fontSize: 12, marginBottom: 6 }}>{label}</p>
         {payload.map((p) => {
           const val = p.value ?? 0
           const labels: Record<string, string> = { income: 'Income', expenses: 'Expenses', net: 'Net', cumulative: 'Cumulative' }
@@ -282,7 +283,7 @@ export default function ReturnsAnalysisPage() {
                 <CartesianGrid {...GRID_DEFAULTS} />
                 <XAxis {...xAxisDefaults(monthlyComboData.length)} dataKey="month" />
                 <YAxis {...yAxisDefaults()} />
-                <Tooltip content={renderComboTooltip as never} />
+                <Tooltip content={renderComboTooltip as never} cursor={chartTooltipProps.cursor} />
                 <ReferenceLine y={0} stroke="rgba(255,255,255,0.15)" />
                 {/* Green area above zero */}
                 <Area

--- a/frontend/src/pages/ReturnsAnalysisPage.tsx
+++ b/frontend/src/pages/ReturnsAnalysisPage.tsx
@@ -118,11 +118,12 @@ function groupTransactionsByMonth(
 // ─── Component ──────────────────────────────────────────────────────────────
 
 export default function ReturnsAnalysisPage() {
-  const { data: balanceData, isLoading: balancesLoading } = useAccountBalances()
-  const { data: aggregationData, isLoading: aggregationLoading } = useMonthlyAggregation()
   const { data: allTransactions = [] } = useTransactions()
-  const isLoading = balancesLoading || aggregationLoading
   const { dateRange, timeFilterProps } = useAnalyticsTimeFilter(allTransactions)
+  const dateParams = { start_date: dateRange.start_date ?? undefined, end_date: dateRange.end_date ?? undefined }
+  const { data: balanceData, isLoading: balancesLoading } = useAccountBalances(dateParams)
+  const { data: aggregationData, isLoading: aggregationLoading } = useMonthlyAggregation(dateParams)
+  const isLoading = balancesLoading || aggregationLoading
 
   const transactions = useMemo(() => {
     const startDate = dateRange.start_date

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -14,6 +14,7 @@ import AccountClassificationsSection from './settings/AccountClassificationsSect
 import InvestmentMappingsSection from './settings/InvestmentMappingsSection'
 import ExpenseCategoriesSection from './settings/ExpenseCategoriesSection'
 import IncomeClassificationSection from './settings/IncomeClassificationSection'
+import SalaryStructureSection from './settings/SalaryStructureSection'
 import FinancialSettingsSection from './settings/FinancialSettingsSection'
 import DisplayPreferencesSection from './settings/DisplayPreferencesSection'
 import NotificationsSection from './settings/NotificationsSection'
@@ -136,6 +137,16 @@ export default function SettingsPage() {
             setHasChanges={s.setHasChanges}
           />
         )}
+
+        <SalaryStructureSection
+          index={sectionIndex++}
+          localSalaryStructure={s.localSalaryStructure}
+          updateSalaryStructure={s.updateSalaryStructure}
+          localRsuGrants={s.localRsuGrants}
+          updateRsuGrants={s.updateRsuGrants}
+          localGrowthAssumptions={s.localGrowthAssumptions}
+          updateGrowthAssumptions={s.updateGrowthAssumptions}
+        />
 
         {s.localPrefs && (
           <FinancialSettingsSection

--- a/frontend/src/pages/TaxPlanningPage.tsx
+++ b/frontend/src/pages/TaxPlanningPage.tsx
@@ -496,6 +496,7 @@ export default function TaxPlanningPage() {
             cess={displayCess}
             professionalTax={displayProfessionalTax}
             totalTax={displayTotalTax}
+            isProjecting={useSalaryProjection}
           />
         </motion.div>
 

--- a/frontend/src/pages/TaxPlanningPage.tsx
+++ b/frontend/src/pages/TaxPlanningPage.tsx
@@ -583,23 +583,50 @@ export default function TaxPlanningPage() {
                 <TrendingUp className="w-5 h-5 text-blue-400" />
               </div>
               <div>
-                <h3 className="text-lg font-semibold">Tax Paid Per Year</h3>
-                <p className="text-xs text-muted-foreground">Annual tax with cumulative trend</p>
+                <h3 className="text-lg font-semibold">Tax Per Year</h3>
+                <p className="text-xs text-muted-foreground">Paid (red) vs projected (green) with cumulative trend</p>
               </div>
             </div>
             {(() => {
+              // Build a map of projected tax by FY (bare format "2025-26")
+              const projectedTaxByFY: Record<string, number> = {}
+              for (const p of multiYearProjections) {
+                projectedTaxByFY[p.fy] = p.totalTax
+              }
+
               const yearlyTaxData = fyList.slice().reverse().map(fy => {
+                const bareFY = fy.replace(/^FY\s+/i, '')
                 const data = transactionsByFY[fy]
-                if (!data) return { fy, tax: 0, income: 0, cumulative: 0 }
-                // Use taxableIncome if classified, otherwise fall back to total income
-                const taxableAmt = (data.taxableIncome > 0) ? data.taxableIncome : data.income
-                const salaryMonths = data.salaryMonths?.size || 0
-                const computed = computeTaxForFY(fy, taxableAmt, salaryMonths, regimeOverride, preferredRegime)
-                return { fy, tax: Math.round(computed.taxAlreadyPaid), income: Math.round(computed.grossTaxableIncome), cumulative: 0 }
+                const hasTxData = !!data
+                const projTotal = Math.round(projectedTaxByFY[bareFY] ?? 0)
+
+                // Compute tax from transactions
+                let paidTax = 0
+                if (hasTxData) {
+                  const taxableAmt = (data.taxableIncome > 0) ? data.taxableIncome : data.income
+                  const salaryMonths = data.salaryMonths?.size || 0
+                  const computed = computeTaxForFY(fy, taxableAmt, salaryMonths, regimeOverride, preferredRegime)
+                  paidTax = Math.round(computed.taxAlreadyPaid)
+                }
+
+                const isCurrent = fy === currentFYLabel
+                const isFuture = !hasTxData && projTotal > 0
+
+                // Split: paid (red) vs projected remaining (green)
+                let projected = 0
+                if (isFuture) {
+                  projected = projTotal
+                } else if (isCurrent && projTotal > paidTax) {
+                  projected = projTotal - paidTax
+                }
+
+                return { fy, paidTax, projected, cumulative: 0 }
               })
+
               let cum = 0
-              for (const d of yearlyTaxData) { cum += d.tax; d.cumulative = cum }
-              if (yearlyTaxData.every(d => d.tax === 0 && d.income === 0)) return <ChartEmptyState height={280} message="No tax liability found across years" />
+              for (const d of yearlyTaxData) { cum += d.paidTax + d.projected; d.cumulative = cum }
+              if (yearlyTaxData.every(d => d.paidTax === 0 && d.projected === 0)) return <ChartEmptyState height={280} message="No tax liability found across years" />
+
               return (
                 <ChartContainer height={300}>
                   <BarChart data={yearlyTaxData} margin={{ top: 8, right: 12, bottom: 8, left: 4 }}>
@@ -609,13 +636,16 @@ export default function TaxPlanningPage() {
                     <Tooltip
                       {...chartTooltipProps}
                       formatter={(value: number | undefined, name: string | undefined) => {
-                        if (value === undefined) return ['', '']
-                        const labels: Record<string, string> = { tax: 'Tax Paid', cumulative: 'Cumulative', income: 'Income' }
+                        if (value === undefined || value === 0) return ['', '']
+                        const labels: Record<string, string> = { paidTax: 'Tax Paid', projected: 'Projected Tax', cumulative: 'Cumulative' }
                         return [formatCurrency(value), labels[name ?? ''] ?? name]
                       }}
                       cursor={{ fill: 'rgba(255,255,255,0.04)' }}
                     />
-                    <Bar dataKey="tax" name="tax" fill={rawColors.app.red} fillOpacity={0.7} radius={BAR_RADIUS} maxBarSize={40}
+                    <Bar dataKey="paidTax" name="paidTax" stackId="tax" fill={rawColors.app.red} fillOpacity={0.7} maxBarSize={40}
+                      isAnimationActive={shouldAnimate(yearlyTaxData.length)} animationDuration={600} animationEasing="ease-out"
+                    />
+                    <Bar dataKey="projected" name="projected" stackId="tax" fill={rawColors.app.green} fillOpacity={0.7} radius={BAR_RADIUS} maxBarSize={40}
                       isAnimationActive={shouldAnimate(yearlyTaxData.length)} animationDuration={600} animationEasing="ease-out"
                     />
                     <Line type="monotone" dataKey="cumulative" name="cumulative" stroke={rawColors.app.blue} strokeWidth={2} strokeDasharray="6 3"

--- a/frontend/src/pages/TaxPlanningPage.tsx
+++ b/frontend/src/pages/TaxPlanningPage.tsx
@@ -337,11 +337,11 @@ export default function TaxPlanningPage() {
   // Compute future projected FYs from salary structure + growth assumptions
   const projectedFYList = useMemo(() => {
     if (!hasSalaryData) return []
-    const salaryFYs = Object.keys(salaryStructure).sort()
+    const salaryFYs = Object.keys(salaryStructure).sort((a, b) => a.localeCompare(b))
     const latestSalaryFY = salaryFYs.at(-1)
     if (!latestSalaryFY) return []
     // Parse start year - handle both "2025-26" and "FY 2025-26" formats
-    const latestStart = parseInt(latestSalaryFY.replace(/^FY\s*/i, ''))
+    const latestStart = Number.parseInt(latestSalaryFY.replace(/^FY\s*/i, ''), 10)
     const futureFYs: string[] = []
     for (let i = 1; i <= growthAssumptions.projection_years; i++) {
       const yr = latestStart + i
@@ -409,16 +409,34 @@ export default function TaxPlanningPage() {
 
   // ── Display values: salary projection overrides transaction-based ───
 
-  const displayGross = salaryTaxResult ? salaryProjection!.grossTaxable : grossTaxableIncome
-  const displayNet = salaryTaxResult ? salaryProjection!.grossTaxable - salaryTaxResult.totalTax : netTaxableIncome
-  const displayTotalTax = salaryTaxResult ? salaryTaxResult.totalTax : taxAlreadyPaid
-  const displayBaseTax = salaryTaxResult ? salaryTaxResult.tax : baseTax
-  const displayCess = salaryTaxResult ? salaryTaxResult.cess : cess
-  const displayProfessionalTax = salaryTaxResult ? salaryTaxResult.professionalTax : professionalTax
-  const displaySlabBreakdown = salaryTaxResult ? salaryTaxResult.slabBreakdown : slabBreakdown
-  const displayRebate87A = salaryTaxResult ? salaryTaxResult.rebate87A : rebate87A
-  const displaySurcharge = salaryTaxResult ? salaryTaxResult.surcharge : surcharge
-  const displayIncome = salaryTaxResult ? salaryProjection!.grossTaxable : income
+  const display = useMemo(() => {
+    if (salaryTaxResult && salaryProjection) {
+      return {
+        gross: salaryProjection.grossTaxable,
+        net: salaryProjection.grossTaxable - salaryTaxResult.totalTax,
+        totalTax: salaryTaxResult.totalTax,
+        baseTax: salaryTaxResult.tax,
+        cess: salaryTaxResult.cess,
+        professionalTax: salaryTaxResult.professionalTax,
+        slabBreakdown: salaryTaxResult.slabBreakdown,
+        rebate87A: salaryTaxResult.rebate87A,
+        surcharge: salaryTaxResult.surcharge,
+        income: salaryProjection.grossTaxable,
+      }
+    }
+    return {
+      gross: grossTaxableIncome,
+      net: netTaxableIncome,
+      totalTax: taxAlreadyPaid,
+      baseTax,
+      cess,
+      professionalTax,
+      slabBreakdown,
+      rebate87A,
+      surcharge,
+      income,
+    }
+  }, [salaryTaxResult, salaryProjection, grossTaxableIncome, netTaxableIncome, taxAlreadyPaid, baseTax, cess, professionalTax, slabBreakdown, rebate87A, surcharge, income])
 
   // ── FY navigation ───────────────────────────────────────────────────
 
@@ -437,34 +455,33 @@ export default function TaxPlanningPage() {
 
   return (
     <div className="min-h-screen p-4 md:p-6 lg:p-8">
+      <div className="max-w-7xl mx-auto space-y-6 md:space-y-8">
+        <PageHeader
+          title="Tax Planning"
+          subtitle={`Estimate your tax liability — ${regimeLabel}`}
+          action={
+            <TaxPageActions
+              isNewRegime={isNewRegime}
+              setRegimeOverride={setRegimeOverride}
+              newRegimeAvailable={newRegimeAvailable}
+              isCurrentFY={isCurrentFY}
+              showProjection={showProjection}
+              setShowProjection={setShowProjection}
+              selectedFY={effectiveFY}
+              canGoBack={canGoBack}
+              canGoForward={canGoForward}
+              goToPreviousFY={goToPreviousFY}
+              goToNextFY={goToNextFY}
+              hasSalaryData={hasSalaryData}
+            />
+          }
+        />
       <motion.div
-        className="max-w-7xl mx-auto space-y-6 md:space-y-8"
         initial="hidden"
         animate="visible"
         variants={staggerContainer}
+        className="space-y-6 md:space-y-8"
       >
-        <motion.div variants={fadeUpItem}>
-          <PageHeader
-            title="Tax Planning"
-            subtitle={`Estimate your tax liability — ${regimeLabel}`}
-            action={
-              <TaxPageActions
-                isNewRegime={isNewRegime}
-                setRegimeOverride={setRegimeOverride}
-                newRegimeAvailable={newRegimeAvailable}
-                isCurrentFY={isCurrentFY}
-                showProjection={showProjection}
-                setShowProjection={setShowProjection}
-                selectedFY={effectiveFY}
-                canGoBack={canGoBack}
-                canGoForward={canGoForward}
-                goToPreviousFY={goToPreviousFY}
-                goToNextFY={goToNextFY}
-                hasSalaryData={hasSalaryData}
-              />
-            }
-          />
-        </motion.div>
 
         {fyList.length === 0 && !isLoading ? (
           <motion.div variants={fadeUpItem}>
@@ -475,9 +492,9 @@ export default function TaxPlanningPage() {
         <motion.div variants={fadeUpItem}>
           <TaxSummaryCards
             isLoading={isLoading}
-            netTaxableIncome={displayNet}
-            grossTaxableIncome={displayGross}
-            taxAlreadyPaid={displayTotalTax}
+            netTaxableIncome={display.net}
+            grossTaxableIncome={display.gross}
+            taxAlreadyPaid={display.totalTax}
             isProjecting={useSalaryProjection}
           />
         </motion.div>
@@ -486,16 +503,16 @@ export default function TaxPlanningPage() {
           <TaxSlabBreakdown
             isNewRegime={isNewRegime}
             taxSlabs={taxSlabs}
-            slabBreakdown={displaySlabBreakdown}
-            grossTaxableIncome={displayGross}
+            slabBreakdown={display.slabBreakdown}
+            grossTaxableIncome={display.gross}
             standardDeduction={standardDeduction}
             fyYear={fyYear}
-            baseTax={displayBaseTax}
-            rebate87A={displayRebate87A}
-            surcharge={displaySurcharge}
-            cess={displayCess}
-            professionalTax={displayProfessionalTax}
-            totalTax={displayTotalTax}
+            baseTax={display.baseTax}
+            rebate87A={display.rebate87A}
+            surcharge={display.surcharge}
+            cess={display.cess}
+            professionalTax={display.professionalTax}
+            totalTax={display.totalTax}
             isProjecting={useSalaryProjection}
           />
         </motion.div>
@@ -503,10 +520,10 @@ export default function TaxPlanningPage() {
         <motion.div variants={fadeUpItem}>
           <TaxSummaryGrid
             selectedFY={effectiveFY}
-            grossTaxableIncome={displayGross}
-            taxAlreadyPaid={displayTotalTax}
-            netTaxableIncome={displayNet}
-            totalIncome={displayIncome}
+            grossTaxableIncome={display.gross}
+            taxAlreadyPaid={display.totalTax}
+            netTaxableIncome={display.net}
+            totalIncome={display.income}
             totalExpense={expense}
             isProjecting={useSalaryProjection}
           />
@@ -518,7 +535,7 @@ export default function TaxPlanningPage() {
           isNewRegime={isNewRegime}
           fyYear={fyYear}
           standardDeduction={standardDeduction}
-          currentIncome={displayGross}
+          currentIncome={display.gross}
         />
 
         {!useSalaryProjection && (
@@ -674,13 +691,13 @@ export default function TaxPlanningPage() {
             <div>
               <h3 className="text-lg font-semibold">Which Regime Saves You More?</h3>
               <p className="text-xs text-muted-foreground">
-                Based on your income of {formatCurrency(displayGross)}
+                Based on your income of {formatCurrency(display.gross)}
               </p>
             </div>
           </div>
 
           <RegimeComparison
-            grossIncome={displayGross}
+            grossIncome={display.gross}
             fyYear={fyYear}
             standardDeduction={standardDeduction}
             salaryMonthsCount={salaryMonthsCount}
@@ -697,6 +714,7 @@ export default function TaxPlanningPage() {
         </>
         )}
       </motion.div>
+      </div>
     </div>
   )
 }

--- a/frontend/src/pages/TaxPlanningPage.tsx
+++ b/frontend/src/pages/TaxPlanningPage.tsx
@@ -16,9 +16,7 @@ import {
   getTaxSlabs,
   getNewRegimeSlabs,
 } from '@/lib/taxCalculator'
-import { computeAdvanceTaxSchedule, formatDueDate } from '@/lib/advanceTaxCalculator'
 import { projectFiscalYear, projectMultipleYears } from '@/lib/projectionCalculator'
-import type { TaxSlab, SlabBreakdownEntry } from '@/lib/taxCalculator'
 import type { Transaction } from '@/types'
 import type { ProjectedFYBreakdown } from '@/types/salary'
 import { PageHeader, ChartContainer, chartTooltipProps, GRID_DEFAULTS, xAxisDefaults, yAxisDefaults, shouldAnimate, BAR_RADIUS, ACTIVE_DOT } from '@/components/ui'
@@ -108,131 +106,6 @@ function createEmptyFYData(): FYData {
   }
 }
 
-interface ProjectionResult {
-  grossTaxableIncome: number
-  taxAlreadyPaid: number
-  baseTax: number
-  cess: number
-  professionalTax: number
-  slabBreakdown: SlabBreakdownEntry[]
-  remainingMonths: number
-  avgMonthlySalary: number
-  projectedAdditionalIncome: number
-}
-
-/** Calculate year-end projection for the current FY */
-function calculateProjection(
-  currentFYData: FYData | null,
-  netTaxableIncome: number,
-  salaryMonthsCount: number,
-  taxSlabs: TaxSlab[],
-  standardDeduction: number,
-  isNewRegime: boolean = true,
-  fyYear: number = 2025,
-): ProjectionResult {
-  const today = new Date()
-  const currentMonth = today.getMonth()
-  const remainingMonths = currentMonth >= 3 ? 12 - (currentMonth - 3) : 3 - currentMonth
-
-  const salaryStipendTxs = currentFYData?.incomeGroups?.['Salary & Stipend']?.transactions || []
-
-  if (salaryStipendTxs.length === 0 || remainingMonths <= 0) {
-    return {
-      grossTaxableIncome: 0,
-      taxAlreadyPaid: 0,
-      baseTax: 0,
-      cess: 0,
-      professionalTax: 0,
-      slabBreakdown: [],
-      remainingMonths,
-      avgMonthlySalary: 0,
-      projectedAdditionalIncome: 0,
-    }
-  }
-
-  const sorted = [...salaryStipendTxs].sort(
-    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
-  )
-  const recentSalaries = sorted.slice(0, Math.min(3, sorted.length))
-  const totalRecentSalary = recentSalaries.reduce((sum, tx) => sum + tx.amount, 0)
-  const avgMonthlySalary = totalRecentSalary / recentSalaries.length
-
-  const projectedAdditionalIncome = avgMonthlySalary * remainingMonths
-  const projectedNetTotal = netTaxableIncome + projectedAdditionalIncome
-  const projectedSalaryMonthsCount = salaryMonthsCount + remainingMonths
-
-  // Always use New Regime slabs for gross calculation (employer deducts TDS under new regime)
-  const newSlabs = getNewRegimeSlabs(fyYear)
-  const grossTaxableIncome = calculateGrossFromNet(projectedNetTotal, {
-    slabs: newSlabs,
-    standardDeduction,
-    applyProfessionalTax: true,
-    salaryMonthsCount: projectedSalaryMonthsCount,
-    isNewRegime: true,
-    fyStartYear: fyYear,
-  })
-  // Calculate tax using the SELECTED regime's slabs
-  const projectedCalc = calculateTax(
-    grossTaxableIncome,
-    taxSlabs,
-    standardDeduction,
-    true,
-    projectedSalaryMonthsCount,
-    isNewRegime,
-    fyYear,
-  )
-
-  return {
-    grossTaxableIncome,
-    taxAlreadyPaid: projectedCalc.totalTax,
-    baseTax: projectedCalc.tax,
-    cess: projectedCalc.cess,
-    professionalTax: projectedCalc.professionalTax,
-    slabBreakdown: projectedCalc.slabBreakdown,
-    remainingMonths,
-    avgMonthlySalary,
-    projectedAdditionalIncome,
-  }
-}
-
-/** Resolve actual vs projected display values */
-function resolveDisplayValues(
-  projection: ProjectionResult | null,
-  actual: {
-    grossTaxableIncome: number
-    netTaxableIncome: number
-    taxAlreadyPaid: number
-    baseTax: number
-    cess: number
-    professionalTax: number
-    slabBreakdown: SlabBreakdownEntry[]
-    income: number
-  },
-) {
-  if (!projection) {
-    return {
-      gross: actual.grossTaxableIncome,
-      net: actual.netTaxableIncome,
-      totalTax: actual.taxAlreadyPaid,
-      baseTax: actual.baseTax,
-      cess: actual.cess,
-      professionalTax: actual.professionalTax,
-      slabBreakdown: actual.slabBreakdown,
-      income: actual.income,
-    }
-  }
-  return {
-    gross: projection.grossTaxableIncome,
-    net: actual.netTaxableIncome + projection.projectedAdditionalIncome,
-    totalTax: projection.taxAlreadyPaid,
-    baseTax: projection.baseTax,
-    cess: projection.cess,
-    professionalTax: projection.professionalTax,
-    slabBreakdown: projection.slabBreakdown,
-    income: actual.income + projection.projectedAdditionalIncome,
-  }
-}
-
 /** Determine the selected tax regime based on FY availability and user preference */
 function resolveSelectedRegime(
   newRegimeAvailable: boolean,
@@ -301,72 +174,14 @@ function computeTaxForFY(
   }
 }
 
-interface ProjectionAndDisplayInput {
-  showProjection: boolean
-  selectedFY: string
-  fiscalYearStartMonth: number
-  hasEmploymentIncome: boolean
-  currentFYData: FYData | null
-  netTaxableIncome: number
-  salaryMonthsCount: number
-  taxSlabs: TaxSlab[]
-  standardDeduction: number
-  isNewRegime: boolean
-  fyYear: number
-  actual: {
-    grossTaxableIncome: number
-    taxAlreadyPaid: number
-    baseTax: number
-    cess: number
-    professionalTax: number
-    slabBreakdown: SlabBreakdownEntry[]
-    income: number
-  }
-}
-
-/** Compute projection and resolve display values for actual vs projected */
-function computeProjectionAndDisplay(input: ProjectionAndDisplayInput) {
-  const { showProjection, selectedFY, fiscalYearStartMonth, hasEmploymentIncome,
-    currentFYData, netTaxableIncome, salaryMonthsCount, taxSlabs,
-    standardDeduction, isNewRegime, fyYear, actual } = input
-
-  const currentFYLabel = getFYFromDate(
-    new Date().toISOString().split('T')[0],
-    fiscalYearStartMonth,
-  )
-  const isCurrentFY = selectedFY === currentFYLabel
-  const useProjected = showProjection && isCurrentFY && hasEmploymentIncome
-
-  const projection = useProjected
-    ? calculateProjection(currentFYData, netTaxableIncome, salaryMonthsCount, taxSlabs, standardDeduction, isNewRegime, fyYear)
-    : null
-
-  const remainingMonths = projection?.remainingMonths ?? 0
-  const avgMonthlySalary = projection?.avgMonthlySalary ?? 0
-
-  const projectedTaxResult = useProjected && projection
-    ? calculateTax(projection.grossTaxableIncome, taxSlabs, standardDeduction, true, salaryMonthsCount + remainingMonths, isNewRegime, fyYear)
-    : null
-
-  const displayValues = resolveDisplayValues(projection, {
-    ...actual,
-    netTaxableIncome,
-  })
-
-  return { isCurrentFY, projection, projectedTaxResult, remainingMonths, avgMonthlySalary, displayValues }
-}
-
-/** Tax regime toggle, year-end projection toggle, projection source toggle, and FY navigation action bar */
+/** Tax regime toggle, projection toggle, and FY navigation action bar */
 function TaxPageActions({
   isNewRegime,
   setRegimeOverride,
   newRegimeAvailable,
   isCurrentFY,
-  hasEmploymentIncome,
   showProjection,
   setShowProjection,
-  remainingMonths,
-  avgMonthlySalary,
   selectedFY,
   canGoBack,
   canGoForward,
@@ -374,18 +189,13 @@ function TaxPageActions({
   goToNextFY,
   hasSalaryData,
   isFutureFY,
-  effectiveSource,
-  setProjectionSource,
 }: Readonly<{
   isNewRegime: boolean
   setRegimeOverride: (regime: 'new' | 'old') => void
   newRegimeAvailable: boolean
   isCurrentFY: boolean
-  hasEmploymentIncome: boolean
   showProjection: boolean
   setShowProjection: (show: boolean) => void
-  remainingMonths: number
-  avgMonthlySalary: number
   selectedFY: string
   canGoBack: boolean
   canGoForward: boolean
@@ -393,9 +203,9 @@ function TaxPageActions({
   goToNextFY: () => void
   hasSalaryData: boolean
   isFutureFY: boolean
-  effectiveSource: 'transactions' | 'salary'
-  setProjectionSource: (source: 'transactions' | 'salary') => void
 }>) {
+  const isProjecting = showProjection || isFutureFY
+
   return (
     <div className="flex items-center gap-4 flex-wrap">
       {/* Tax Regime Toggle — hidden for FYs before 2020-21 */}
@@ -424,58 +234,22 @@ function TaxPageActions({
         </button>
       </div>}
 
-      {/* Projection Source Toggle */}
-      {hasSalaryData && (
-        <div className="flex gap-1 bg-white/5 rounded-lg p-1">
-          <button
-            type="button"
-            onClick={() => setProjectionSource('transactions')}
-            disabled={isFutureFY}
-            className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
-              effectiveSource === 'transactions'
-                ? 'bg-white/10 text-white'
-                : 'text-muted-foreground hover:text-white'
-            } disabled:opacity-30`}
-          >
-            From Transactions
-          </button>
-          <button
-            type="button"
-            onClick={() => setProjectionSource('salary')}
-            className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
-              effectiveSource === 'salary'
-                ? 'bg-white/10 text-white'
-                : 'text-muted-foreground hover:text-white'
-            }`}
-          >
-            {isFutureFY ? 'Projection' : 'From Salary Structure'}
-          </button>
-        </div>
+      {/* Salary Projection Toggle */}
+      {isCurrentFY && hasSalaryData && (
+        <button
+          onClick={() => setShowProjection(!showProjection)}
+          type="button"
+          className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors whitespace-nowrap ${
+            showProjection
+              ? 'bg-primary text-white shadow-lg shadow-primary/50'
+              : 'bg-white/5 text-muted-foreground hover:bg-white/10 border border-border'
+          }`}
+        >
+          {showProjection ? 'Showing Projection' : 'Project from Salary'}
+        </button>
       )}
 
-      {/* Year-End Projection Toggle — LEFT */}
-      {isCurrentFY && hasEmploymentIncome && (
-        <div className="flex flex-col items-end gap-1">
-          <button
-            onClick={() => setShowProjection(!showProjection)}
-            type="button"
-            className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors whitespace-nowrap ${
-              showProjection
-                ? 'bg-primary text-white shadow-lg shadow-primary/50'
-                : 'bg-white/5 text-muted-foreground hover:bg-white/10 border border-border'
-            }`}
-          >
-            {showProjection ? 'Showing Projection' : 'Year-End Projection'}
-          </button>
-          {showProjection && remainingMonths > 0 && (
-            <span className="text-xs text-muted-foreground whitespace-nowrap">
-              +{remainingMonths} mo @ {formatCurrency(avgMonthlySalary)}/mo
-            </span>
-          )}
-        </div>
-      )}
-
-      {/* FY Navigation — RIGHT */}
+      {/* FY Navigation */}
       <div className="flex items-center gap-2">
         <motion.button
           onClick={goToPreviousFY}
@@ -489,7 +263,7 @@ function TaxPageActions({
 
         <span className="text-white font-medium min-w-28 text-center">
           {selectedFY || 'Select FY'}
-          {isFutureFY && <span className="text-xs text-muted-foreground ml-1">(projected)</span>}
+          {isProjecting && <span className="text-xs text-muted-foreground ml-1">(projected)</span>}
         </span>
 
         <motion.button
@@ -517,8 +291,6 @@ export default function TaxPlanningPage() {
   const rsuGrants = usePreferencesStore(selectRsuGrants)
   const growthAssumptions = usePreferencesStore(selectGrowthAssumptions)
   const hasSalaryData = Object.keys(salaryStructure).length > 0
-
-  const [projectionSource, setProjectionSource] = useState<'transactions' | 'salary'>('transactions')
 
   // Tax regime preference: default from user preferences, overridable via toggle
   const preferredRegime = preferences?.preferred_tax_regime || 'new'
@@ -590,12 +362,18 @@ export default function TaxPlanningPage() {
     return [...allFYs].sort((a, b) => a.localeCompare(b)).reverse()
   }, [txFyList, projectedFYList])
 
-  // Use first FY as default when none is explicitly selected
-  const effectiveFY = selectedFY || fyList[0] || ''
+  // Current FY label for default selection
+  const currentFYLabel = getFYFromDate(new Date().toISOString().split('T')[0], fiscalYearStartMonth)
+
+  // Default to current FY if available, otherwise latest FY
+  const effectiveFY = selectedFY || (fyList.includes(currentFYLabel) ? currentFYLabel : fyList[0]) || ''
 
   // Determine if the selected FY is a future projection (no transaction data)
   const isFutureFY = projectedFYList.includes(effectiveFY) && !(effectiveFY in transactionsByFY)
-  const effectiveSource = isFutureFY ? 'salary' : projectionSource
+  const isCurrentFY = effectiveFY === currentFYLabel
+
+  // Use salary projection when toggle is ON (current FY) or when viewing future FY
+  const useSalaryProjection = hasSalaryData && (isFutureFY || (showProjection && isCurrentFY))
 
   // ── Derived values for selected FY ──────────────────────────────────
 
@@ -605,54 +383,47 @@ export default function TaxPlanningPage() {
   const netTaxableIncome = currentFYData?.taxableIncome || 0
   const salaryMonthsCount = currentFYData?.salaryMonths?.size || 0
 
-  // ── Tax computation for selected FY ─────────────────────────────────
+  // ── Tax computation for selected FY (transaction-based) ─────────────
 
   const {
     fyYear, newRegimeAvailable, isNewRegime, taxSlabs, regimeLabel,
-    standardDeduction, hasEmploymentIncome, grossTaxableIncome,
+    standardDeduction, grossTaxableIncome,
     baseTax, slabBreakdown, rebate87A, surcharge, cess,
     professionalTax, taxAlreadyPaid,
   } = computeTaxForFY(effectiveFY, netTaxableIncome, salaryMonthsCount, regimeOverride, preferredRegime)
 
-  // ── Projection + display values ────────────────────────────────────
+  // ── Salary-based projection ────────────────────────────────────────
 
-  const {
-    isCurrentFY, projectedTaxResult, remainingMonths, avgMonthlySalary, displayValues,
-  } = computeProjectionAndDisplay({
-    showProjection, selectedFY: effectiveFY, fiscalYearStartMonth,
-    hasEmploymentIncome, currentFYData, netTaxableIncome,
-    salaryMonthsCount, taxSlabs, standardDeduction, isNewRegime, fyYear,
-    actual: { grossTaxableIncome, taxAlreadyPaid, baseTax, cess, professionalTax, slabBreakdown, income },
-  })
-
-  // ── Salary-based projection data ────────────────────────────────────
-
-  // Strip "FY " prefix for projectionCalculator which uses "2025-26" format
   const effectiveFYForProjector = effectiveFY.replace(/^FY\s+/i, '')
 
   const salaryProjection = useMemo<ProjectedFYBreakdown | null>(() => {
-    if (!hasSalaryData || effectiveSource !== 'salary') return null
+    if (!useSalaryProjection) return null
     return projectFiscalYear(effectiveFYForProjector, salaryStructure, rsuGrants, growthAssumptions, fiscalYearStartMonth)
-  }, [hasSalaryData, effectiveSource, effectiveFYForProjector, salaryStructure, rsuGrants, growthAssumptions, fiscalYearStartMonth])
+  }, [useSalaryProjection, effectiveFYForProjector, salaryStructure, rsuGrants, growthAssumptions, fiscalYearStartMonth])
+
+  // Recompute tax using the selected regime on salary gross (projection calculator always uses new regime)
+  const salaryTaxResult = useMemo(() => {
+    if (!salaryProjection) return null
+    return calculateTax(salaryProjection.grossTaxable, taxSlabs, standardDeduction, true, 12, isNewRegime, fyYear)
+  }, [salaryProjection, taxSlabs, standardDeduction, isNewRegime, fyYear])
 
   const multiYearProjections = useMemo<ProjectedFYBreakdown[]>(() => {
     if (!hasSalaryData) return []
     return projectMultipleYears(salaryStructure, rsuGrants, growthAssumptions, fiscalYearStartMonth)
   }, [hasSalaryData, salaryStructure, rsuGrants, growthAssumptions, fiscalYearStartMonth])
 
-  // When salary source is active, override display values with projection data
-  const displayGross = effectiveSource === 'salary' && salaryProjection
-    ? salaryProjection.grossTaxable : displayValues.gross
-  const displayNet = effectiveSource === 'salary' && salaryProjection
-    ? salaryProjection.netTaxable : displayValues.net
-  const displayTotalTax = effectiveSource === 'salary' && salaryProjection
-    ? salaryProjection.totalTax : displayValues.totalTax
-  const displayBaseTax = displayValues.baseTax
-  const displayCess = displayValues.cess
-  const displayProfessionalTax = displayValues.professionalTax
-  const displaySlabBreakdown = displayValues.slabBreakdown
-  const displayIncome = effectiveSource === 'salary' && salaryProjection
-    ? salaryProjection.grossTaxable : displayValues.income
+  // ── Display values: salary projection overrides transaction-based ───
+
+  const displayGross = salaryTaxResult ? salaryProjection!.grossTaxable : grossTaxableIncome
+  const displayNet = salaryTaxResult ? salaryProjection!.netTaxable : netTaxableIncome
+  const displayTotalTax = salaryTaxResult ? salaryTaxResult.totalTax : taxAlreadyPaid
+  const displayBaseTax = salaryTaxResult ? salaryTaxResult.tax : baseTax
+  const displayCess = salaryTaxResult ? salaryTaxResult.cess : cess
+  const displayProfessionalTax = salaryTaxResult ? salaryTaxResult.professionalTax : professionalTax
+  const displaySlabBreakdown = salaryTaxResult ? salaryTaxResult.slabBreakdown : slabBreakdown
+  const displayRebate87A = salaryTaxResult ? salaryTaxResult.rebate87A : rebate87A
+  const displaySurcharge = salaryTaxResult ? salaryTaxResult.surcharge : surcharge
+  const displayIncome = salaryTaxResult ? salaryProjection!.grossTaxable : income
 
   // ── FY navigation ───────────────────────────────────────────────────
 
@@ -687,11 +458,8 @@ export default function TaxPlanningPage() {
                 setRegimeOverride={setRegimeOverride}
                 newRegimeAvailable={newRegimeAvailable}
                 isCurrentFY={isCurrentFY}
-                hasEmploymentIncome={hasEmploymentIncome}
                 showProjection={showProjection}
                 setShowProjection={setShowProjection}
-                remainingMonths={remainingMonths}
-                avgMonthlySalary={avgMonthlySalary}
                 selectedFY={effectiveFY}
                 canGoBack={canGoBack}
                 canGoForward={canGoForward}
@@ -699,8 +467,6 @@ export default function TaxPlanningPage() {
                 goToNextFY={goToNextFY}
                 hasSalaryData={hasSalaryData}
                 isFutureFY={isFutureFY}
-                effectiveSource={effectiveSource}
-                setProjectionSource={setProjectionSource}
               />
             }
           />
@@ -721,20 +487,6 @@ export default function TaxPlanningPage() {
           />
         </motion.div>
 
-        {/* Salary-Based Income Breakdown */}
-        {effectiveSource === 'salary' && salaryProjection && (
-          <motion.div variants={fadeUpItem}>
-            <SalaryProjectionBreakdown projection={salaryProjection} />
-          </motion.div>
-        )}
-
-        {/* Multi-Year Salary Projection Table */}
-        {hasSalaryData && multiYearProjections.length > 1 && (
-          <motion.div variants={fadeUpItem}>
-            <MultiYearProjectionTable projections={multiYearProjections} />
-          </motion.div>
-        )}
-
         <motion.div variants={fadeUpItem}>
           <TaxSlabBreakdown
             isNewRegime={isNewRegime}
@@ -744,8 +496,8 @@ export default function TaxPlanningPage() {
             standardDeduction={standardDeduction}
             fyYear={fyYear}
             baseTax={displayBaseTax}
-            rebate87A={projectedTaxResult?.rebate87A ?? rebate87A}
-            surcharge={projectedTaxResult?.surcharge ?? surcharge}
+            rebate87A={displayRebate87A}
+            surcharge={displaySurcharge}
             cess={displayCess}
             professionalTax={displayProfessionalTax}
             totalTax={displayTotalTax}
@@ -762,13 +514,6 @@ export default function TaxPlanningPage() {
             totalExpense={expense}
           />
         </motion.div>
-
-        {/* Advance Tax Schedule */}
-        {isCurrentFY && displayTotalTax > 10000 && (
-          <motion.div variants={fadeUpItem}>
-            <AdvanceTaxScheduleSection totalTax={displayTotalTax} />
-          </motion.div>
-        )}
 
         {/* Effective Tax Rate Curve */}
         <EffectiveTaxRateChart
@@ -900,18 +645,25 @@ export default function TaxPlanningPage() {
             <div>
               <h3 className="text-lg font-semibold">Which Regime Saves You More?</h3>
               <p className="text-xs text-muted-foreground">
-                Based on your income of {formatCurrency(grossTaxableIncome)}
+                Based on your income of {formatCurrency(displayGross)}
               </p>
             </div>
           </div>
 
           <RegimeComparison
-            grossIncome={grossTaxableIncome}
+            grossIncome={displayGross}
             fyYear={fyYear}
             standardDeduction={standardDeduction}
             salaryMonthsCount={salaryMonthsCount}
           />
         </motion.div>
+        )}
+
+        {/* Multi-Year Salary Projection Table */}
+        {hasSalaryData && multiYearProjections.length > 1 && (
+          <motion.div variants={fadeUpItem}>
+            <MultiYearProjectionTable projections={multiYearProjections} />
+          </motion.div>
         )}
         </>
         )}
@@ -933,75 +685,6 @@ function TaxTip({ title, amount, description }: Readonly<{ title: string; amount
         )}
       </div>
       <p className="text-xs text-muted-foreground leading-relaxed">{description}</p>
-    </div>
-  )
-}
-
-/** Advance tax quarterly schedule section */
-function getQuarterStatusClass(status: string, isNext: boolean): string {
-  if (status === 'overdue') return 'bg-app-red/20 text-app-red'
-  if (isNext) return 'bg-app-orange/20 text-app-orange'
-  return 'bg-white/5 text-muted-foreground'
-}
-
-function AdvanceTaxScheduleSection({ totalTax }: Readonly<{ totalTax: number }>) {
-  const schedule = useMemo(() => computeAdvanceTaxSchedule(totalTax, 0), [totalTax])
-
-  return (
-    <div className="glass rounded-2xl border border-border p-4 md:p-6">
-      <div className="flex items-center gap-3 mb-4">
-        <div className="p-2.5 bg-app-orange/20 rounded-xl">
-          <ChevronRight className="w-5 h-5 text-app-orange" />
-        </div>
-        <div>
-          <h3 className="text-lg font-semibold">Advance Tax Schedule</h3>
-          <p className="text-xs text-muted-foreground">
-            Quarterly installments -- Total advance tax: {formatCurrency(schedule.advanceTaxDue)}
-          </p>
-        </div>
-      </div>
-
-      <div className="overflow-x-auto">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b border-border">
-              <th className="text-left py-2 px-3 text-muted-foreground font-medium">Quarter</th>
-              <th className="text-left py-2 px-3 text-muted-foreground font-medium">Due Date</th>
-              <th className="text-right py-2 px-3 text-muted-foreground font-medium">This Quarter</th>
-              <th className="text-right py-2 px-3 text-muted-foreground font-medium">Cumulative</th>
-              <th className="text-center py-2 px-3 text-muted-foreground font-medium">Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            {schedule.quarters.map((q) => {
-              const isNext = schedule.nextDueQuarter?.quarter === q.quarter
-              return (
-                <tr
-                  key={q.quarter}
-                  className={`border-b border-border/50 ${isNext ? 'bg-app-orange/[0.06]' : ''}`}
-                >
-                  <td className="py-2.5 px-3 font-medium">
-                    {q.quarter} ({q.cumulativePercent}%)
-                    {isNext && <span className="ml-1.5 text-xs text-app-orange font-semibold">NEXT</span>}
-                  </td>
-                  <td className="py-2.5 px-3">{formatDueDate(q.dueDate)}</td>
-                  <td className="py-2.5 px-3 text-right font-medium">{formatCurrency(q.quarterAmount)}</td>
-                  <td className="py-2.5 px-3 text-right text-muted-foreground">{formatCurrency(q.cumulativeAmount)}</td>
-                  <td className="py-2.5 px-3 text-center">
-                    <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${getQuarterStatusClass(q.status, isNext)}`}>
-                      {q.status === 'overdue' ? 'Overdue' : 'Upcoming'}
-                    </span>
-                  </td>
-                </tr>
-              )
-            })}
-          </tbody>
-        </table>
-      </div>
-
-      <p className="text-xs text-text-tertiary mt-3">
-        Advance tax applies if total tax liability exceeds Rs 10,000. Interest under Sec 234B/234C applies for late/short payment.
-      </p>
     </div>
   )
 }
@@ -1169,78 +852,6 @@ function DeductionInput({ label, sublabel, value, max, onChange }: Readonly<{
         className="w-full px-3 py-1.5 text-sm bg-white/5 border border-border rounded-lg text-foreground placeholder:text-text-quaternary focus:outline-none focus:ring-1 focus:ring-app-blue/50"
       />
       <span className="text-caption text-text-quaternary mt-0.5 block">{sublabel}</span>
-    </div>
-  )
-}
-
-/** Salary-based income breakdown panel showing projected income components and tax computation */
-function SalaryProjectionBreakdown({ projection }: Readonly<{ projection: ProjectedFYBreakdown }>) {
-  const monthlyTDS = projection.totalTax / 12
-  const annualTakeHome = projection.grossTaxable - projection.totalTax
-  const monthlyTakeHome = annualTakeHome / 12
-
-  return (
-    <div className="bg-app-card rounded-xl border border-border p-5">
-      <div className="flex items-center gap-3 mb-4">
-        <div className="p-2.5 bg-app-blue/20 rounded-xl">
-          <TrendingUp className="w-5 h-5 text-app-blue" />
-        </div>
-        <div>
-          <h3 className="text-lg font-semibold">
-            Salary-Based Projection — {projection.fy}
-            {projection.isProjected && <span className="text-xs text-muted-foreground ml-2">(projected)</span>}
-          </h3>
-          <p className="text-xs text-muted-foreground">Breakdown from salary structure and growth assumptions</p>
-        </div>
-      </div>
-
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        {/* Left: Income Components */}
-        <div className="space-y-2">
-          <h4 className="text-sm font-semibold text-muted-foreground mb-3">Income Components</h4>
-          <ProjectionRow label="Base Salary" value={projection.baseSalary} className="text-income" />
-          {projection.hra > 0 && <ProjectionRow label="HRA" value={projection.hra} className="text-income" />}
-          {projection.bonus > 0 && <ProjectionRow label="Bonus" value={projection.bonus} className="text-income" />}
-          {projection.rsuIncome > 0 && <ProjectionRow label="RSU Vesting" value={projection.rsuIncome} className="text-income" />}
-          {projection.specialAllowance > 0 && <ProjectionRow label="Special Allowance" value={projection.specialAllowance} className="text-income" />}
-          {projection.otherTaxable > 0 && <ProjectionRow label="Other Taxable" value={projection.otherTaxable} className="text-income" />}
-          {projection.epf > 0 && <ProjectionRow label="EPF Deducted" value={-projection.epf} className="text-expense" />}
-          <div className="border-t border-border pt-2 mt-2">
-            <ProjectionRow label="Gross Taxable" value={projection.grossTaxable} className="text-foreground font-semibold" />
-          </div>
-          <ProjectionRow label="Standard Deduction" value={-projection.standardDeduction} className="text-muted-foreground" />
-          <ProjectionRow label="Net Taxable" value={projection.netTaxable} className="text-foreground font-semibold" />
-        </div>
-
-        {/* Right: Tax Computation */}
-        <div className="space-y-2">
-          <h4 className="text-sm font-semibold text-muted-foreground mb-3">Tax Computation</h4>
-          <ProjectionRow label="Total Tax" value={projection.totalTax} className="text-expense" />
-          <ProjectionRow label="Effective Tax Rate" value={null} displayValue={`${projection.effectiveTaxRate.toFixed(1)}%`} />
-          <ProjectionRow label="Monthly TDS (approx)" value={monthlyTDS} className="text-expense" />
-          <div className="border-t border-border pt-2 mt-2">
-            <ProjectionRow label="Annual Take-Home" value={annualTakeHome} className="text-income font-semibold" />
-            <ProjectionRow label="Monthly Take-Home" value={monthlyTakeHome} className="text-income" />
-          </div>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-/** Single row inside the salary projection breakdown */
-function ProjectionRow({ label, value, className = '', displayValue }: Readonly<{
-  label: string
-  value: number | null
-  className?: string
-  displayValue?: string
-}>) {
-  return (
-    <div className="flex items-center justify-between py-1">
-      <span className="text-sm text-muted-foreground">{label}</span>
-      <span className={`text-sm ${className}`}>
-        {displayValue ?? formatCurrency(value ?? 0)}
-      </span>
     </div>
   )
 }

--- a/frontend/src/pages/TaxPlanningPage.tsx
+++ b/frontend/src/pages/TaxPlanningPage.tsx
@@ -188,7 +188,6 @@ function TaxPageActions({
   goToPreviousFY,
   goToNextFY,
   hasSalaryData,
-  isFutureFY,
 }: Readonly<{
   isNewRegime: boolean
   setRegimeOverride: (regime: 'new' | 'old') => void
@@ -202,10 +201,7 @@ function TaxPageActions({
   goToPreviousFY: () => void
   goToNextFY: () => void
   hasSalaryData: boolean
-  isFutureFY: boolean
 }>) {
-  const isProjecting = showProjection || isFutureFY
-
   return (
     <div className="flex items-center gap-4 flex-wrap">
       {/* Tax Regime Toggle — hidden for FYs before 2020-21 */}
@@ -263,7 +259,6 @@ function TaxPageActions({
 
         <span className="text-white font-medium min-w-28 text-center">
           {selectedFY || 'Select FY'}
-          {isProjecting && <span className="text-xs text-muted-foreground ml-1">(projected)</span>}
         </span>
 
         <motion.button
@@ -415,7 +410,7 @@ export default function TaxPlanningPage() {
   // ── Display values: salary projection overrides transaction-based ───
 
   const displayGross = salaryTaxResult ? salaryProjection!.grossTaxable : grossTaxableIncome
-  const displayNet = salaryTaxResult ? salaryProjection!.netTaxable : netTaxableIncome
+  const displayNet = salaryTaxResult ? salaryProjection!.grossTaxable - salaryTaxResult.totalTax : netTaxableIncome
   const displayTotalTax = salaryTaxResult ? salaryTaxResult.totalTax : taxAlreadyPaid
   const displayBaseTax = salaryTaxResult ? salaryTaxResult.tax : baseTax
   const displayCess = salaryTaxResult ? salaryTaxResult.cess : cess
@@ -466,7 +461,6 @@ export default function TaxPlanningPage() {
                 goToPreviousFY={goToPreviousFY}
                 goToNextFY={goToNextFY}
                 hasSalaryData={hasSalaryData}
-                isFutureFY={isFutureFY}
               />
             }
           />
@@ -521,7 +515,7 @@ export default function TaxPlanningPage() {
           isNewRegime={isNewRegime}
           fyYear={fyYear}
           standardDeduction={standardDeduction}
-          currentIncome={grossTaxableIncome}
+          currentIncome={displayGross}
         />
 
         <motion.div variants={fadeUpItem}>
@@ -870,7 +864,7 @@ function MultiYearProjectionTable({ projections }: Readonly<{ projections: Proje
   ]
 
   return (
-    <div className="bg-app-card rounded-xl border border-border p-5">
+    <div className="glass rounded-2xl border border-border p-4 md:p-6">
       <div className="flex items-center gap-3 mb-4">
         <div className="p-2.5 bg-app-purple/20 rounded-xl">
           <TrendingUp className="w-5 h-5 text-app-purple" />

--- a/frontend/src/pages/TaxPlanningPage.tsx
+++ b/frontend/src/pages/TaxPlanningPage.tsx
@@ -106,6 +106,71 @@ function createEmptyFYData(): FYData {
   }
 }
 
+/** Group transactions by fiscal year, accumulating income/expense totals */
+function groupTransactionsByFY(
+  transactions: Transaction[],
+  fiscalYearStartMonth: number,
+  incomeClassification: { taxable: string[]; investmentReturns: string[]; nonTaxable: string[]; other: string[] },
+): Record<string, FYData> {
+  const grouped: Record<string, FYData> = {}
+  for (const tx of transactions) {
+    const fy = getFYFromDate(tx.date, fiscalYearStartMonth)
+    if (!grouped[fy]) grouped[fy] = createEmptyFYData()
+    grouped[fy].transactions.push(tx)
+    if (tx.type === 'Income') {
+      grouped[fy].income += tx.amount
+      classifyAndAccumulateIncome(tx, grouped[fy], incomeClassification)
+    } else if (tx.type === 'Expense') {
+      grouped[fy].expense += tx.amount
+    }
+  }
+  return grouped
+}
+
+interface YearlyTaxDatum { fy: string; paidTax: number; projected: number; cumulative: number }
+
+/** Build yearly tax chart data from FY list and projections */
+function buildYearlyTaxData(
+  fyList: string[],
+  transactionsByFY: Record<string, FYData>,
+  multiYearProjections: ProjectedFYBreakdown[],
+  currentFYLabel: string,
+  regimeOverride: 'new' | 'old' | null,
+  preferredRegime: string,
+): YearlyTaxDatum[] {
+  const projectedTaxByFY: Record<string, number> = {}
+  for (const p of multiYearProjections) projectedTaxByFY[p.fy] = p.totalTax
+
+  const data = fyList.slice().reverse().map(fy => {
+    const bareFY = fy.replace(/^FY\s+/i, '')
+    const fyData = transactionsByFY[fy]
+    const hasTxData = !!fyData
+    const projTotal = Math.round(projectedTaxByFY[bareFY] ?? 0)
+
+    let paidTax = 0
+    if (hasTxData) {
+      const taxableAmt = (fyData.taxableIncome > 0) ? fyData.taxableIncome : fyData.income
+      const salaryMonths = fyData.salaryMonths?.size || 0
+      const computed = computeTaxForFY(fy, taxableAmt, salaryMonths, regimeOverride, preferredRegime)
+      paidTax = Math.round(computed.taxAlreadyPaid)
+    }
+
+    const isFuture = !hasTxData && projTotal > 0
+    let projected = 0
+    if (isFuture) {
+      projected = projTotal
+    } else if (fy === currentFYLabel && projTotal > paidTax) {
+      projected = projTotal - paidTax
+    }
+
+    return { fy, paidTax, projected, cumulative: 0 }
+  })
+
+  let cum = 0
+  for (const d of data) { cum += d.paidTax + d.projected; d.cumulative = cum }
+  return data
+}
+
 /** Determine the selected tax regime based on FY availability and user preference */
 function resolveSelectedRegime(
   newRegimeAvailable: boolean,
@@ -306,26 +371,10 @@ export default function TaxPlanningPage() {
   )
 
   // Group transactions by Financial Year
-  const transactionsByFY = useMemo(() => {
-    const grouped: Record<string, FYData> = {}
-
-    for (const tx of allTransactions) {
-      const fy = getFYFromDate(tx.date, fiscalYearStartMonth)
-      if (!grouped[fy]) {
-        grouped[fy] = createEmptyFYData()
-      }
-      grouped[fy].transactions.push(tx)
-
-      if (tx.type === 'Income') {
-        grouped[fy].income += tx.amount
-        classifyAndAccumulateIncome(tx, grouped[fy], incomeClassification)
-      } else if (tx.type === 'Expense') {
-        grouped[fy].expense += tx.amount
-      }
-    }
-
-    return grouped
-  }, [allTransactions, fiscalYearStartMonth, incomeClassification])
+  const transactionsByFY = useMemo(
+    () => groupTransactionsByFY(allTransactions, fiscalYearStartMonth, incomeClassification),
+    [allTransactions, fiscalYearStartMonth, incomeClassification],
+  )
 
   // Get sorted FY list from transactions
   const txFyList = useMemo(() => {
@@ -605,43 +654,7 @@ export default function TaxPlanningPage() {
               </div>
             </div>
             {(() => {
-              // Build a map of projected tax by FY (bare format "2025-26")
-              const projectedTaxByFY: Record<string, number> = {}
-              for (const p of multiYearProjections) {
-                projectedTaxByFY[p.fy] = p.totalTax
-              }
-
-              const yearlyTaxData = fyList.slice().reverse().map(fy => {
-                const bareFY = fy.replace(/^FY\s+/i, '')
-                const data = transactionsByFY[fy]
-                const hasTxData = !!data
-                const projTotal = Math.round(projectedTaxByFY[bareFY] ?? 0)
-
-                // Compute tax from transactions
-                let paidTax = 0
-                if (hasTxData) {
-                  const taxableAmt = (data.taxableIncome > 0) ? data.taxableIncome : data.income
-                  const salaryMonths = data.salaryMonths?.size || 0
-                  const computed = computeTaxForFY(fy, taxableAmt, salaryMonths, regimeOverride, preferredRegime)
-                  paidTax = Math.round(computed.taxAlreadyPaid)
-                }
-
-                const isCurrent = fy === currentFYLabel
-                const isFuture = !hasTxData && projTotal > 0
-
-                // Split: paid (red) vs projected remaining (green)
-                let projected = 0
-                if (isFuture) {
-                  projected = projTotal
-                } else if (isCurrent && projTotal > paidTax) {
-                  projected = projTotal - paidTax
-                }
-
-                return { fy, paidTax, projected, cumulative: 0 }
-              })
-
-              let cum = 0
-              for (const d of yearlyTaxData) { cum += d.paidTax + d.projected; d.cumulative = cum }
+              const yearlyTaxData = buildYearlyTaxData(fyList, transactionsByFY, multiYearProjections, currentFYLabel, regimeOverride, preferredRegime)
               if (yearlyTaxData.every(d => d.paidTax === 0 && d.projected === 0)) return <ChartEmptyState height={280} message="No tax liability found across years" />
 
               return (

--- a/frontend/src/pages/TaxPlanningPage.tsx
+++ b/frontend/src/pages/TaxPlanningPage.tsx
@@ -584,7 +584,7 @@ export default function TaxPlanningPage() {
               </div>
               <div>
                 <h3 className="text-lg font-semibold">Tax Per Year</h3>
-                <p className="text-xs text-muted-foreground">Paid (red) vs projected (green) with cumulative trend</p>
+                <p className="text-xs text-muted-foreground">Paid (red) vs projected (orange) with cumulative trend</p>
               </div>
             </div>
             {(() => {
@@ -645,7 +645,7 @@ export default function TaxPlanningPage() {
                     <Bar dataKey="paidTax" name="paidTax" stackId="tax" fill={rawColors.app.red} fillOpacity={0.7} maxBarSize={40}
                       isAnimationActive={shouldAnimate(yearlyTaxData.length)} animationDuration={600} animationEasing="ease-out"
                     />
-                    <Bar dataKey="projected" name="projected" stackId="tax" fill={rawColors.app.green} fillOpacity={0.7} radius={BAR_RADIUS} maxBarSize={40}
+                    <Bar dataKey="projected" name="projected" stackId="tax" fill={rawColors.app.orange} fillOpacity={0.5} radius={BAR_RADIUS} maxBarSize={40}
                       isAnimationActive={shouldAnimate(yearlyTaxData.length)} animationDuration={600} animationEasing="ease-out"
                     />
                     <Line type="monotone" dataKey="cumulative" name="cumulative" stroke={rawColors.app.blue} strokeWidth={2} strokeDasharray="6 3"

--- a/frontend/src/pages/TaxPlanningPage.tsx
+++ b/frontend/src/pages/TaxPlanningPage.tsx
@@ -478,6 +478,7 @@ export default function TaxPlanningPage() {
             netTaxableIncome={displayNet}
             grossTaxableIncome={displayGross}
             taxAlreadyPaid={displayTotalTax}
+            isProjecting={useSalaryProjection}
           />
         </motion.div>
 
@@ -506,6 +507,7 @@ export default function TaxPlanningPage() {
             netTaxableIncome={displayNet}
             totalIncome={displayIncome}
             totalExpense={expense}
+            isProjecting={useSalaryProjection}
           />
         </motion.div>
 
@@ -518,13 +520,15 @@ export default function TaxPlanningPage() {
           currentIncome={displayGross}
         />
 
-        <motion.div variants={fadeUpItem}>
-          <TaxableIncomeTable
-            selectedFY={effectiveFY}
-            incomeGroups={currentFYData?.incomeGroups}
-            netTaxableIncome={netTaxableIncome}
-          />
-        </motion.div>
+        {!useSalaryProjection && (
+          <motion.div variants={fadeUpItem}>
+            <TaxableIncomeTable
+              selectedFY={effectiveFY}
+              incomeGroups={currentFYData?.incomeGroups}
+              netTaxableIncome={netTaxableIncome}
+            />
+          </motion.div>
+        )}
 
         {/* ── Tax Saving Suggestions ─────────────────────────────── */}
         <motion.div variants={fadeUpItem} className="glass rounded-2xl border border-border p-4 md:p-6">

--- a/frontend/src/pages/TaxPlanningPage.tsx
+++ b/frontend/src/pages/TaxPlanningPage.tsx
@@ -17,8 +17,10 @@ import {
   getNewRegimeSlabs,
 } from '@/lib/taxCalculator'
 import { computeAdvanceTaxSchedule, formatDueDate } from '@/lib/advanceTaxCalculator'
+import { projectFiscalYear, projectMultipleYears } from '@/lib/projectionCalculator'
 import type { TaxSlab, SlabBreakdownEntry } from '@/lib/taxCalculator'
 import type { Transaction } from '@/types'
+import type { ProjectedFYBreakdown } from '@/types/salary'
 import { PageHeader, ChartContainer, chartTooltipProps, GRID_DEFAULTS, xAxisDefaults, yAxisDefaults, shouldAnimate, BAR_RADIUS, ACTIVE_DOT } from '@/components/ui'
 import { BarChart, Bar, Line, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts'
 import { rawColors } from '@/constants/colors'
@@ -28,6 +30,7 @@ import TaxSlabBreakdown from '@/components/analytics/TaxSlabBreakdown'
 import TaxSummaryGrid from '@/components/analytics/TaxSummaryGrid'
 import EffectiveTaxRateChart from '@/components/analytics/EffectiveTaxRateChart'
 import TaxableIncomeTable from '@/components/analytics/TaxableIncomeTable'
+import { usePreferencesStore, selectSalaryStructure, selectRsuGrants, selectGrowthAssumptions } from '@/store/preferencesStore'
 
 /** Result of classifying an income transaction for tax grouping */
 interface IncomeGroupAccumulator {
@@ -353,7 +356,7 @@ function computeProjectionAndDisplay(input: ProjectionAndDisplayInput) {
   return { isCurrentFY, projection, projectedTaxResult, remainingMonths, avgMonthlySalary, displayValues }
 }
 
-/** Tax regime toggle, year-end projection toggle, and FY navigation action bar */
+/** Tax regime toggle, year-end projection toggle, projection source toggle, and FY navigation action bar */
 function TaxPageActions({
   isNewRegime,
   setRegimeOverride,
@@ -369,6 +372,10 @@ function TaxPageActions({
   canGoForward,
   goToPreviousFY,
   goToNextFY,
+  hasSalaryData,
+  isFutureFY,
+  effectiveSource,
+  setProjectionSource,
 }: Readonly<{
   isNewRegime: boolean
   setRegimeOverride: (regime: 'new' | 'old') => void
@@ -384,9 +391,13 @@ function TaxPageActions({
   canGoForward: boolean
   goToPreviousFY: () => void
   goToNextFY: () => void
+  hasSalaryData: boolean
+  isFutureFY: boolean
+  effectiveSource: 'transactions' | 'salary'
+  setProjectionSource: (source: 'transactions' | 'salary') => void
 }>) {
   return (
-    <div className="flex items-center gap-4">
+    <div className="flex items-center gap-4 flex-wrap">
       {/* Tax Regime Toggle — hidden for FYs before 2020-21 */}
       {newRegimeAvailable && <div className="flex rounded-lg border border-border overflow-hidden">
         <button
@@ -412,6 +423,35 @@ function TaxPageActions({
           Old Regime
         </button>
       </div>}
+
+      {/* Projection Source Toggle */}
+      {hasSalaryData && (
+        <div className="flex gap-1 bg-white/5 rounded-lg p-1">
+          <button
+            type="button"
+            onClick={() => setProjectionSource('transactions')}
+            disabled={isFutureFY}
+            className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+              effectiveSource === 'transactions'
+                ? 'bg-white/10 text-white'
+                : 'text-muted-foreground hover:text-white'
+            } disabled:opacity-30`}
+          >
+            From Transactions
+          </button>
+          <button
+            type="button"
+            onClick={() => setProjectionSource('salary')}
+            className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+              effectiveSource === 'salary'
+                ? 'bg-white/10 text-white'
+                : 'text-muted-foreground hover:text-white'
+            }`}
+          >
+            {isFutureFY ? 'Projection' : 'From Salary Structure'}
+          </button>
+        </div>
+      )}
 
       {/* Year-End Projection Toggle — LEFT */}
       {isCurrentFY && hasEmploymentIncome && (
@@ -449,6 +489,7 @@ function TaxPageActions({
 
         <span className="text-white font-medium min-w-28 text-center">
           {selectedFY || 'Select FY'}
+          {isFutureFY && <span className="text-xs text-muted-foreground ml-1">(projected)</span>}
         </span>
 
         <motion.button
@@ -470,6 +511,14 @@ export default function TaxPlanningPage() {
   const { data: preferences } = usePreferences()
   const [selectedFY, setSelectedFY] = useState<string>('')
   const [showProjection, setShowProjection] = useState(false)
+
+  // Salary structure & projections from preferences store
+  const salaryStructure = usePreferencesStore(selectSalaryStructure)
+  const rsuGrants = usePreferencesStore(selectRsuGrants)
+  const growthAssumptions = usePreferencesStore(selectGrowthAssumptions)
+  const hasSalaryData = Object.keys(salaryStructure).length > 0
+
+  const [projectionSource, setProjectionSource] = useState<'transactions' | 'salary'>('transactions')
 
   // Tax regime preference: default from user preferences, overridable via toggle
   const preferredRegime = preferences?.preferred_tax_regime || 'new'
@@ -511,15 +560,42 @@ export default function TaxPlanningPage() {
     return grouped
   }, [allTransactions, fiscalYearStartMonth, incomeClassification])
 
-  // Get sorted FY list
-  const fyList = useMemo(() => {
+  // Get sorted FY list from transactions
+  const txFyList = useMemo(() => {
     return Object.keys(transactionsByFY)
       .sort((a, b) => a.localeCompare(b))
       .reverse()
   }, [transactionsByFY])
 
+  // Compute future projected FYs from salary structure + growth assumptions
+  const projectedFYList = useMemo(() => {
+    if (!hasSalaryData) return []
+    const salaryFYs = Object.keys(salaryStructure).sort()
+    const latestSalaryFY = salaryFYs.at(-1)
+    if (!latestSalaryFY) return []
+    // Parse start year - handle both "2025-26" and "FY 2025-26" formats
+    const latestStart = parseInt(latestSalaryFY.replace(/^FY\s*/i, ''))
+    const futureFYs: string[] = []
+    for (let i = 1; i <= growthAssumptions.projection_years; i++) {
+      const yr = latestStart + i
+      const end = (yr + 1) % 100
+      futureFYs.push(`FY ${yr}-${String(end).padStart(2, '0')}`)
+    }
+    return futureFYs
+  }, [hasSalaryData, salaryStructure, growthAssumptions.projection_years])
+
+  // Merge transaction FYs with projected FYs into a combined sorted list
+  const fyList = useMemo(() => {
+    const allFYs = new Set([...txFyList, ...projectedFYList])
+    return [...allFYs].sort((a, b) => a.localeCompare(b)).reverse()
+  }, [txFyList, projectedFYList])
+
   // Use first FY as default when none is explicitly selected
   const effectiveFY = selectedFY || fyList[0] || ''
+
+  // Determine if the selected FY is a future projection (no transaction data)
+  const isFutureFY = projectedFYList.includes(effectiveFY) && !(effectiveFY in transactionsByFY)
+  const effectiveSource = isFutureFY ? 'salary' : projectionSource
 
   // ── Derived values for selected FY ──────────────────────────────────
 
@@ -549,14 +625,34 @@ export default function TaxPlanningPage() {
     actual: { grossTaxableIncome, taxAlreadyPaid, baseTax, cess, professionalTax, slabBreakdown, income },
   })
 
-  const displayGross = displayValues.gross
-  const displayNet = displayValues.net
-  const displayTotalTax = displayValues.totalTax
+  // ── Salary-based projection data ────────────────────────────────────
+
+  // Strip "FY " prefix for projectionCalculator which uses "2025-26" format
+  const effectiveFYForProjector = effectiveFY.replace(/^FY\s+/i, '')
+
+  const salaryProjection = useMemo<ProjectedFYBreakdown | null>(() => {
+    if (!hasSalaryData || effectiveSource !== 'salary') return null
+    return projectFiscalYear(effectiveFYForProjector, salaryStructure, rsuGrants, growthAssumptions, fiscalYearStartMonth)
+  }, [hasSalaryData, effectiveSource, effectiveFYForProjector, salaryStructure, rsuGrants, growthAssumptions, fiscalYearStartMonth])
+
+  const multiYearProjections = useMemo<ProjectedFYBreakdown[]>(() => {
+    if (!hasSalaryData) return []
+    return projectMultipleYears(salaryStructure, rsuGrants, growthAssumptions, fiscalYearStartMonth)
+  }, [hasSalaryData, salaryStructure, rsuGrants, growthAssumptions, fiscalYearStartMonth])
+
+  // When salary source is active, override display values with projection data
+  const displayGross = effectiveSource === 'salary' && salaryProjection
+    ? salaryProjection.grossTaxable : displayValues.gross
+  const displayNet = effectiveSource === 'salary' && salaryProjection
+    ? salaryProjection.netTaxable : displayValues.net
+  const displayTotalTax = effectiveSource === 'salary' && salaryProjection
+    ? salaryProjection.totalTax : displayValues.totalTax
   const displayBaseTax = displayValues.baseTax
   const displayCess = displayValues.cess
   const displayProfessionalTax = displayValues.professionalTax
   const displaySlabBreakdown = displayValues.slabBreakdown
-  const displayIncome = displayValues.income
+  const displayIncome = effectiveSource === 'salary' && salaryProjection
+    ? salaryProjection.grossTaxable : displayValues.income
 
   // ── FY navigation ───────────────────────────────────────────────────
 
@@ -601,6 +697,10 @@ export default function TaxPlanningPage() {
                 canGoForward={canGoForward}
                 goToPreviousFY={goToPreviousFY}
                 goToNextFY={goToNextFY}
+                hasSalaryData={hasSalaryData}
+                isFutureFY={isFutureFY}
+                effectiveSource={effectiveSource}
+                setProjectionSource={setProjectionSource}
               />
             }
           />
@@ -620,6 +720,20 @@ export default function TaxPlanningPage() {
             taxAlreadyPaid={displayTotalTax}
           />
         </motion.div>
+
+        {/* Salary-Based Income Breakdown */}
+        {effectiveSource === 'salary' && salaryProjection && (
+          <motion.div variants={fadeUpItem}>
+            <SalaryProjectionBreakdown projection={salaryProjection} />
+          </motion.div>
+        )}
+
+        {/* Multi-Year Salary Projection Table */}
+        {hasSalaryData && multiYearProjections.length > 1 && (
+          <motion.div variants={fadeUpItem}>
+            <MultiYearProjectionTable projections={multiYearProjections} />
+          </motion.div>
+        )}
 
         <motion.div variants={fadeUpItem}>
           <TaxSlabBreakdown
@@ -1055,6 +1169,153 @@ function DeductionInput({ label, sublabel, value, max, onChange }: Readonly<{
         className="w-full px-3 py-1.5 text-sm bg-white/5 border border-border rounded-lg text-foreground placeholder:text-text-quaternary focus:outline-none focus:ring-1 focus:ring-app-blue/50"
       />
       <span className="text-caption text-text-quaternary mt-0.5 block">{sublabel}</span>
+    </div>
+  )
+}
+
+/** Salary-based income breakdown panel showing projected income components and tax computation */
+function SalaryProjectionBreakdown({ projection }: Readonly<{ projection: ProjectedFYBreakdown }>) {
+  const monthlyTDS = projection.totalTax / 12
+  const annualTakeHome = projection.grossTaxable - projection.totalTax
+  const monthlyTakeHome = annualTakeHome / 12
+
+  return (
+    <div className="bg-app-card rounded-xl border border-border p-5">
+      <div className="flex items-center gap-3 mb-4">
+        <div className="p-2.5 bg-app-blue/20 rounded-xl">
+          <TrendingUp className="w-5 h-5 text-app-blue" />
+        </div>
+        <div>
+          <h3 className="text-lg font-semibold">
+            Salary-Based Projection — {projection.fy}
+            {projection.isProjected && <span className="text-xs text-muted-foreground ml-2">(projected)</span>}
+          </h3>
+          <p className="text-xs text-muted-foreground">Breakdown from salary structure and growth assumptions</p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {/* Left: Income Components */}
+        <div className="space-y-2">
+          <h4 className="text-sm font-semibold text-muted-foreground mb-3">Income Components</h4>
+          <ProjectionRow label="Base Salary" value={projection.baseSalary} className="text-income" />
+          {projection.hra > 0 && <ProjectionRow label="HRA" value={projection.hra} className="text-income" />}
+          {projection.bonus > 0 && <ProjectionRow label="Bonus" value={projection.bonus} className="text-income" />}
+          {projection.rsuIncome > 0 && <ProjectionRow label="RSU Vesting" value={projection.rsuIncome} className="text-income" />}
+          {projection.specialAllowance > 0 && <ProjectionRow label="Special Allowance" value={projection.specialAllowance} className="text-income" />}
+          {projection.otherTaxable > 0 && <ProjectionRow label="Other Taxable" value={projection.otherTaxable} className="text-income" />}
+          {projection.epf > 0 && <ProjectionRow label="EPF Deducted" value={-projection.epf} className="text-expense" />}
+          <div className="border-t border-border pt-2 mt-2">
+            <ProjectionRow label="Gross Taxable" value={projection.grossTaxable} className="text-foreground font-semibold" />
+          </div>
+          <ProjectionRow label="Standard Deduction" value={-projection.standardDeduction} className="text-muted-foreground" />
+          <ProjectionRow label="Net Taxable" value={projection.netTaxable} className="text-foreground font-semibold" />
+        </div>
+
+        {/* Right: Tax Computation */}
+        <div className="space-y-2">
+          <h4 className="text-sm font-semibold text-muted-foreground mb-3">Tax Computation</h4>
+          <ProjectionRow label="Total Tax" value={projection.totalTax} className="text-expense" />
+          <ProjectionRow label="Effective Tax Rate" value={null} displayValue={`${projection.effectiveTaxRate.toFixed(1)}%`} />
+          <ProjectionRow label="Monthly TDS (approx)" value={monthlyTDS} className="text-expense" />
+          <div className="border-t border-border pt-2 mt-2">
+            <ProjectionRow label="Annual Take-Home" value={annualTakeHome} className="text-income font-semibold" />
+            <ProjectionRow label="Monthly Take-Home" value={monthlyTakeHome} className="text-income" />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** Single row inside the salary projection breakdown */
+function ProjectionRow({ label, value, className = '', displayValue }: Readonly<{
+  label: string
+  value: number | null
+  className?: string
+  displayValue?: string
+}>) {
+  return (
+    <div className="flex items-center justify-between py-1">
+      <span className="text-sm text-muted-foreground">{label}</span>
+      <span className={`text-sm ${className}`}>
+        {displayValue ?? formatCurrency(value ?? 0)}
+      </span>
+    </div>
+  )
+}
+
+/** Multi-year salary projection comparison table */
+function MultiYearProjectionTable({ projections }: Readonly<{ projections: ProjectedFYBreakdown[] }>) {
+  const rows: Array<{ label: string; key: keyof ProjectedFYBreakdown; colorClass: string }> = [
+    { label: 'Base Salary', key: 'baseSalary', colorClass: 'text-income' },
+    { label: 'Bonus', key: 'bonus', colorClass: 'text-income' },
+    { label: 'RSU Vesting', key: 'rsuIncome', colorClass: 'text-income' },
+    { label: 'EPF', key: 'epf', colorClass: 'text-muted-foreground' },
+    { label: 'Other', key: 'otherTaxable', colorClass: 'text-muted-foreground' },
+    { label: 'Gross Taxable', key: 'grossTaxable', colorClass: 'text-foreground' },
+    { label: 'Total Tax', key: 'totalTax', colorClass: 'text-expense' },
+    { label: 'Take-Home', key: 'takeHome', colorClass: 'text-income' },
+  ]
+
+  return (
+    <div className="bg-app-card rounded-xl border border-border p-5">
+      <div className="flex items-center gap-3 mb-4">
+        <div className="p-2.5 bg-app-purple/20 rounded-xl">
+          <TrendingUp className="w-5 h-5 text-app-purple" />
+        </div>
+        <div>
+          <h3 className="text-lg font-semibold">Multi-Year Projection</h3>
+          <p className="text-xs text-muted-foreground">
+            {projections.length} year outlook based on salary structure and growth assumptions
+          </p>
+        </div>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-border">
+              <th className="text-left py-2 px-3 text-muted-foreground font-medium">Component</th>
+              {projections.map((p) => (
+                <th key={p.fy} className="text-right py-2 px-3 text-muted-foreground font-medium whitespace-nowrap">
+                  FY {p.fy}
+                  {p.isProjected && <span className="text-caption text-text-quaternary ml-1">*</span>}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => {
+              const hasAnyValue = projections.some((p) => (p[row.key] as number) > 0)
+              if (!hasAnyValue) return null
+              return (
+                <tr key={row.key} className="border-b border-border/50">
+                  <td className="py-2.5 px-3 font-medium text-foreground">{row.label}</td>
+                  {projections.map((p) => (
+                    <td key={p.fy} className={`py-2.5 px-3 text-right ${row.colorClass}`}>
+                      {formatCurrency(p[row.key] as number)}
+                    </td>
+                  ))}
+                </tr>
+              )
+            })}
+            {/* Effective Tax Rate row */}
+            <tr className="border-b border-border/50">
+              <td className="py-2.5 px-3 font-medium text-foreground">Effective Tax Rate</td>
+              {projections.map((p) => (
+                <td key={p.fy} className="py-2.5 px-3 text-right text-muted-foreground">
+                  {p.effectiveTaxRate.toFixed(1)}%
+                </td>
+              ))}
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <p className="text-xs text-text-tertiary mt-3">
+        * Projected values based on growth assumptions. Actual figures may vary.
+      </p>
     </div>
   )
 }

--- a/frontend/src/pages/TrendsForecastsPage.tsx
+++ b/frontend/src/pages/TrendsForecastsPage.tsx
@@ -7,7 +7,7 @@ import { Area, AreaChart, XAxis, YAxis, CartesianGrid, Tooltip, Line, ReferenceL
 import { getDateKey } from '@/lib/dateUtils'
 import { useState, useMemo } from 'react'
 import { formatCurrency, formatCurrencyShort, formatPercent, percentChange } from '@/lib/formatters'
-import { chartTooltipProps, PageHeader, ChartContainer, GRID_DEFAULTS, xAxisDefaults, yAxisDefaults, areaGradient, areaGradientUrl, shouldAnimate } from '@/components/ui'
+import { chartTooltipProps, PageHeader, ChartContainer, GRID_DEFAULTS, xAxisDefaults, yAxisDefaults, areaGradient, areaGradientUrl, shouldAnimate, ACTIVE_DOT } from '@/components/ui'
 import { CashFlowForecast } from '@/components/analytics'
 import EmptyState from '@/components/shared/EmptyState'
 import ChartEmptyState from '@/components/shared/ChartEmptyState'
@@ -587,8 +587,8 @@ export default function TrendsForecastsPage() {
                       />
                       <ReferenceLine y={peakIncome} stroke="rgba(255,255,255,0.2)" strokeDasharray="3 3" label={{ value: `Peak: ${formatCurrencyShort(peakIncome)}`, fill: '#71717a', fontSize: 10, position: 'insideTopRight' }} />
                       {activeLabel && <ReferenceLine x={activeLabel} stroke="rgba(255,255,255,0.3)" strokeDasharray="3 3" />}
-                      <Area type="monotone" dataKey="income" stroke={rawColors.app.green} fill={areaGradientUrl('trendIncome')} strokeWidth={2} dot={false} isAnimationActive={shouldAnimate(monthlyTrendWithAvg.length)} animationDuration={600} animationEasing="ease-out" />
-                      <Line type="monotone" dataKey="incomeAvg" stroke={rawColors.app.green} strokeWidth={2} strokeDasharray="6 3" dot={false} name="Income (3m avg)" isAnimationActive={shouldAnimate(monthlyTrendWithAvg.length)} animationDuration={600} animationEasing="ease-out" />
+                      <Area type="monotone" dataKey="income" stroke={rawColors.app.green} fill={areaGradientUrl('trendIncome')} strokeWidth={2} dot={false} activeDot={{ ...ACTIVE_DOT, fill: rawColors.app.green }} isAnimationActive={shouldAnimate(monthlyTrendWithAvg.length)} animationDuration={600} animationEasing="ease-out" />
+                      <Line type="monotone" dataKey="incomeAvg" stroke={rawColors.app.green} strokeWidth={2} strokeDasharray="6 3" dot={false} activeDot={{ ...ACTIVE_DOT, fill: rawColors.app.green }} name="Income (3m avg)" isAnimationActive={shouldAnimate(monthlyTrendWithAvg.length)} animationDuration={600} animationEasing="ease-out" />
                     </AreaChart>
                   </ChartContainer>
                 )}
@@ -624,8 +624,8 @@ export default function TrendsForecastsPage() {
                       />
                       <ReferenceLine y={peakExpenses} stroke="rgba(255,255,255,0.2)" strokeDasharray="3 3" label={{ value: `Peak: ${formatCurrencyShort(peakExpenses)}`, fill: '#71717a', fontSize: 10, position: 'insideTopRight' }} />
                       {activeLabel && <ReferenceLine x={activeLabel} stroke="rgba(255,255,255,0.3)" strokeDasharray="3 3" />}
-                      <Area type="monotone" dataKey="expenses" stroke={rawColors.app.red} fill={areaGradientUrl('trendExpense')} strokeWidth={2} dot={false} isAnimationActive={shouldAnimate(monthlyTrendWithAvg.length)} animationDuration={600} animationEasing="ease-out" />
-                      <Line type="monotone" dataKey="expensesAvg" stroke={rawColors.app.red} strokeWidth={2} strokeDasharray="6 3" dot={false} name="Spending (3m avg)" isAnimationActive={shouldAnimate(monthlyTrendWithAvg.length)} animationDuration={600} animationEasing="ease-out" />
+                      <Area type="monotone" dataKey="expenses" stroke={rawColors.app.red} fill={areaGradientUrl('trendExpense')} strokeWidth={2} dot={false} activeDot={{ ...ACTIVE_DOT, fill: rawColors.app.red }} isAnimationActive={shouldAnimate(monthlyTrendWithAvg.length)} animationDuration={600} animationEasing="ease-out" />
+                      <Line type="monotone" dataKey="expensesAvg" stroke={rawColors.app.red} strokeWidth={2} strokeDasharray="6 3" dot={false} activeDot={{ ...ACTIVE_DOT, fill: rawColors.app.red }} name="Spending (3m avg)" isAnimationActive={shouldAnimate(monthlyTrendWithAvg.length)} animationDuration={600} animationEasing="ease-out" />
                     </AreaChart>
                   </ChartContainer>
                 )}
@@ -661,8 +661,8 @@ export default function TrendsForecastsPage() {
                       />
                       <ReferenceLine y={peakSavings} stroke="rgba(255,255,255,0.2)" strokeDasharray="3 3" label={{ value: `Peak: ${formatCurrencyShort(peakSavings)}`, fill: '#71717a', fontSize: 10, position: 'insideTopRight' }} />
                       {activeLabel && <ReferenceLine x={activeLabel} stroke="rgba(255,255,255,0.3)" strokeDasharray="3 3" />}
-                      <Area type="monotone" dataKey="savings" stroke={rawColors.app.purple} fill={areaGradientUrl('trendSavings')} strokeWidth={2} dot={false} isAnimationActive={shouldAnimate(monthlyTrendWithAvg.length)} animationDuration={600} animationEasing="ease-out" />
-                      <Line type="monotone" dataKey="savingsAvg" stroke={rawColors.app.purple} strokeWidth={2} strokeDasharray="6 3" dot={false} name="Savings (3m avg)" isAnimationActive={shouldAnimate(monthlyTrendWithAvg.length)} animationDuration={600} animationEasing="ease-out" />
+                      <Area type="monotone" dataKey="savings" stroke={rawColors.app.purple} fill={areaGradientUrl('trendSavings')} strokeWidth={2} dot={false} activeDot={{ ...ACTIVE_DOT, fill: rawColors.app.purple }} isAnimationActive={shouldAnimate(monthlyTrendWithAvg.length)} animationDuration={600} animationEasing="ease-out" />
+                      <Line type="monotone" dataKey="savingsAvg" stroke={rawColors.app.purple} strokeWidth={2} strokeDasharray="6 3" dot={false} activeDot={{ ...ACTIVE_DOT, fill: rawColors.app.purple }} name="Savings (3m avg)" isAnimationActive={shouldAnimate(monthlyTrendWithAvg.length)} animationDuration={600} animationEasing="ease-out" />
                     </AreaChart>
                   </ChartContainer>
                 )}

--- a/frontend/src/pages/goals/GoalCard.tsx
+++ b/frontend/src/pages/goals/GoalCard.tsx
@@ -44,7 +44,7 @@ export default function GoalCard({
     <motion.div
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
-      className="glass rounded-2xl border border-border p-4 md:p-6 hover:scale-[1.01] transition-all duration-300"
+      className="glass rounded-2xl border border-border p-4 md:p-6 hover:scale-[1.01] transition-all duration-200"
     >
       {/* Header */}
       <div className="flex items-start justify-between">

--- a/frontend/src/pages/settings/SalaryStructureSection.tsx
+++ b/frontend/src/pages/settings/SalaryStructureSection.tsx
@@ -103,7 +103,7 @@ export default function SalaryStructureSection({
       const updated = { ...localSalaryStructure }
       updated[selectedFY] = {
         ...(updated[selectedFY] ?? { ...DEFAULT_SALARY_COMPONENTS }),
-        [field]: field === 'hra_monthly' || field === 'nps_monthly'
+        [field]: field === 'hra_annual' || field === 'nps_monthly'
           ? (raw === '' ? null : value)
           : value,
       }
@@ -140,8 +140,8 @@ export default function SalaryStructureSection({
   // -- Live summary --
   const annualCTC = useMemo(() => {
     const s = currentSalary
-    const base = (s.base_salary_monthly ?? 0) * 12
-    const hra = (s.hra_monthly ?? 0) * 12
+    const base = s.base_salary_annual ?? 0
+    const hra = s.hra_annual ?? 0
     const epf = (s.epf_monthly ?? 0) * 12
     const nps = (s.nps_monthly ?? 0) * 12
     return base + hra + (s.bonus_annual ?? 0) + epf + nps +
@@ -240,8 +240,8 @@ export default function SalaryStructureSection({
     hint: string
     nullable: boolean
   }> = [
-    { key: 'base_salary_monthly', label: 'Base Salary', hint: 'Monthly', nullable: false },
-    { key: 'hra_monthly', label: 'HRA', hint: 'Monthly, optional', nullable: true },
+    { key: 'base_salary_annual', label: 'Base Salary', hint: 'Annual', nullable: false },
+    { key: 'hra_annual', label: 'HRA', hint: 'Annual, optional', nullable: true },
     { key: 'bonus_annual', label: 'Bonus', hint: 'Annual', nullable: false },
     { key: 'epf_monthly', label: 'EPF', hint: 'Monthly', nullable: false },
     { key: 'nps_monthly', label: 'NPS', hint: 'Monthly, optional', nullable: true },

--- a/frontend/src/pages/settings/SalaryStructureSection.tsx
+++ b/frontend/src/pages/settings/SalaryStructureSection.tsx
@@ -101,11 +101,11 @@ export default function SalaryStructureSection({
       const value = raw === '' ? 0 : Number(raw)
       if (Number.isNaN(value)) return
       const updated = { ...localSalaryStructure }
+      const isNullableField = field === 'hra_annual' || field === 'nps_monthly'
+      const fieldValue = isNullableField && raw === '' ? null : value
       updated[selectedFY] = {
         ...(updated[selectedFY] ?? { ...DEFAULT_SALARY_COMPONENTS }),
-        [field]: field === 'hra_annual' || field === 'nps_monthly'
-          ? (raw === '' ? null : value)
-          : value,
+        [field]: fieldValue,
       }
       updateSalaryStructure(updated)
     },
@@ -226,8 +226,13 @@ export default function SalaryStructureSection({
   // -- Growth helpers --
   const updateGrowth = useCallback(
     (field: keyof GrowthAssumptions, raw: string | boolean) => {
-      const value = typeof raw === 'boolean' ? raw : (raw === '' ? 0 : Number(raw))
-      if (typeof value === 'number' && Number.isNaN(value)) return
+      let value: number | boolean
+      if (typeof raw === 'boolean') {
+        value = raw
+      } else {
+        value = raw === '' ? 0 : Number(raw)
+        if (Number.isNaN(value)) return
+      }
       updateGrowthAssumptions({ ...localGrowthAssumptions, [field]: value })
     },
     [localGrowthAssumptions, updateGrowthAssumptions],
@@ -434,7 +439,7 @@ export default function SalaryStructureSection({
                       const estValue = v.quantity * grant.stock_price
                       const fy = v.date ? dateToFY(v.date) : ''
                       return (
-                        <tr key={vi} className="border-b border-border/50">
+                        <tr key={`${grant.id}-${v.date}-${vi}`} className="border-b border-border/50">
                           <td className="py-2 pr-3">
                             <input
                               type="date"

--- a/frontend/src/pages/settings/SalaryStructureSection.tsx
+++ b/frontend/src/pages/settings/SalaryStructureSection.tsx
@@ -307,7 +307,7 @@ export default function SalaryStructureSection({
                     type="number"
                     min="0"
                     step="100"
-                    value={currentSalary[f.key] ?? ''}
+                    value={currentSalary[f.key] || ''}
                     onChange={(e) => updateField(f.key, e.target.value)}
                     placeholder={f.nullable ? 'Optional' : '0'}
                     className={inputClass}

--- a/frontend/src/pages/settings/SalaryStructureSection.tsx
+++ b/frontend/src/pages/settings/SalaryStructureSection.tsx
@@ -1,0 +1,19 @@
+import type { SalaryComponents, RsuGrant, GrowthAssumptions } from '@/types/salary'
+
+export interface SalaryStructureSectionProps {
+  index: number
+  localSalaryStructure: Record<string, SalaryComponents>
+  updateSalaryStructure: (structure: Record<string, SalaryComponents>) => void
+  localRsuGrants: RsuGrant[]
+  updateRsuGrants: (grants: RsuGrant[]) => void
+  localGrowthAssumptions: GrowthAssumptions
+  updateGrowthAssumptions: (assumptions: GrowthAssumptions) => void
+}
+
+/** Stub -- full UI will be implemented in Task 10. */
+export default function SalaryStructureSection(
+  props: SalaryStructureSectionProps,
+) {
+  void props
+  return null
+}

--- a/frontend/src/pages/settings/SalaryStructureSection.tsx
+++ b/frontend/src/pages/settings/SalaryStructureSection.tsx
@@ -140,12 +140,12 @@ export default function SalaryStructureSection({
   // -- Live summary --
   const annualCTC = useMemo(() => {
     const s = currentSalary
-    const base = s.base_salary_annual ?? 0
-    const hra = s.hra_annual ?? 0
-    const epf = (s.epf_monthly ?? 0) * 12
-    const nps = (s.nps_monthly ?? 0) * 12
-    return base + hra + (s.bonus_annual ?? 0) + epf + nps +
-      (s.special_allowance_annual ?? 0) + (s.other_taxable_annual ?? 0)
+    const base = Number(s.base_salary_annual) || 0
+    const hra = Number(s.hra_annual) || 0
+    const epf = (Number(s.epf_monthly) || 0) * 12
+    const nps = (Number(s.nps_monthly) || 0) * 12
+    return base + hra + (Number(s.bonus_annual) || 0) + epf + nps +
+      (Number(s.special_allowance_annual) || 0) + (Number(s.other_taxable_annual) || 0)
   }, [currentSalary])
 
   // -- RSU helpers --

--- a/frontend/src/pages/settings/SalaryStructureSection.tsx
+++ b/frontend/src/pages/settings/SalaryStructureSection.tsx
@@ -1,4 +1,23 @@
-import type { SalaryComponents, RsuGrant, GrowthAssumptions } from '@/types/salary'
+/**
+ * Salary Structure section - FY salary grid, RSU grants, and growth assumptions.
+ */
+
+import { useState, useMemo, useCallback } from 'react'
+import {
+  Banknote,
+  ChevronLeft,
+  ChevronRight,
+  Plus,
+  Trash2,
+  TrendingUp,
+  X,
+} from 'lucide-react'
+import { formatCurrency } from '@/lib/formatters'
+import { FY_START_MONTH } from '@/lib/taxCalculator'
+import type { SalaryComponents, RsuGrant, RsuVesting, GrowthAssumptions } from '@/types/salary'
+import { DEFAULT_SALARY_COMPONENTS } from '@/types/salary'
+import { Section, FieldLabel, Toggle } from './components'
+import { inputClass } from './styles'
 
 export interface SalaryStructureSectionProps {
   index: number
@@ -10,10 +29,575 @@ export interface SalaryStructureSectionProps {
   updateGrowthAssumptions: (assumptions: GrowthAssumptions) => void
 }
 
-/** Stub -- full UI will be implemented in Task 10. */
-export default function SalaryStructureSection(
-  props: SalaryStructureSectionProps,
-) {
-  void props
-  return null
+// ---------------------------------------------------------------------------
+// FY helpers (bare "2025-26" format, not "FY 2025-26")
+// ---------------------------------------------------------------------------
+
+/** Parse start year from bare FY label like "2025-26" */
+function parseBareStartYear(fy: string): number {
+  return Number.parseInt(fy.split('-')[0] || '0', 10)
+}
+
+function currentFYLabel(): string {
+  const now = new Date()
+  const month = now.getMonth() + 1
+  const year = now.getFullYear()
+  const startYear = month >= FY_START_MONTH ? year : year - 1
+  const endYear = (startYear + 1) % 100
+  return `${startYear}-${String(endYear).padStart(2, '0')}`
+}
+
+function nextFY(fy: string): string {
+  const start = parseBareStartYear(fy) + 1
+  const end = (start + 1) % 100
+  return `${start}-${String(end).padStart(2, '0')}`
+}
+
+/** Get FY string from a date string given fiscal year start month */
+function dateToFY(dateStr: string): string {
+  const d = new Date(dateStr)
+  if (Number.isNaN(d.getTime())) return ''
+  const month = d.getMonth() + 1
+  const year = d.getFullYear()
+  const fyStartYear = month >= FY_START_MONTH ? year : year - 1
+  const endYear = (fyStartYear + 1) % 100
+  return `${fyStartYear}-${String(endYear).padStart(2, '0')}`
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function SalaryStructureSection({
+  index,
+  localSalaryStructure,
+  updateSalaryStructure,
+  localRsuGrants,
+  updateRsuGrants,
+  localGrowthAssumptions,
+  updateGrowthAssumptions,
+}: Readonly<SalaryStructureSectionProps>) {
+  // -- FY selector state --
+  const fyKeys = useMemo(
+    () =>
+      Object.keys(localSalaryStructure).sort(
+        (a, b) => parseBareStartYear(a) - parseBareStartYear(b),
+      ),
+    [localSalaryStructure],
+  )
+  const [selectedFY, setSelectedFY] = useState(() => {
+    const cur = currentFYLabel()
+    return fyKeys.includes(cur) ? cur : fyKeys[0] ?? cur
+  })
+
+  const currentSalary = useMemo<SalaryComponents>(
+    () => localSalaryStructure[selectedFY] ?? { ...DEFAULT_SALARY_COMPONENTS },
+    [localSalaryStructure, selectedFY],
+  )
+
+  // -- Salary field updater --
+  const updateField = useCallback(
+    (field: keyof SalaryComponents, raw: string) => {
+      const value = raw === '' ? 0 : Number(raw)
+      if (Number.isNaN(value)) return
+      const updated = { ...localSalaryStructure }
+      updated[selectedFY] = {
+        ...(updated[selectedFY] ?? { ...DEFAULT_SALARY_COMPONENTS }),
+        [field]: field === 'hra_monthly' || field === 'nps_monthly'
+          ? (raw === '' ? null : value)
+          : value,
+      }
+      updateSalaryStructure(updated)
+    },
+    [localSalaryStructure, selectedFY, updateSalaryStructure],
+  )
+
+  // -- Add FY --
+  const addFY = useCallback(() => {
+    const next = fyKeys.length > 0 ? nextFY(fyKeys[fyKeys.length - 1]) : currentFYLabel()
+    if (localSalaryStructure[next]) return
+    const lastSalary = fyKeys.length > 0
+      ? localSalaryStructure[fyKeys[fyKeys.length - 1]]
+      : undefined
+    updateSalaryStructure({
+      ...localSalaryStructure,
+      [next]: lastSalary ? { ...lastSalary } : { ...DEFAULT_SALARY_COMPONENTS },
+    })
+    setSelectedFY(next)
+  }, [fyKeys, localSalaryStructure, updateSalaryStructure])
+
+  // -- Navigate FY --
+  const goNext = useCallback(() => {
+    const idx = fyKeys.indexOf(selectedFY)
+    if (idx < fyKeys.length - 1) setSelectedFY(fyKeys[idx + 1])
+  }, [fyKeys, selectedFY])
+
+  const goPrev = useCallback(() => {
+    const idx = fyKeys.indexOf(selectedFY)
+    if (idx > 0) setSelectedFY(fyKeys[idx - 1])
+  }, [fyKeys, selectedFY])
+
+  // -- Live summary --
+  const annualCTC = useMemo(() => {
+    const s = currentSalary
+    const base = (s.base_salary_monthly ?? 0) * 12
+    const hra = (s.hra_monthly ?? 0) * 12
+    const epf = (s.epf_monthly ?? 0) * 12
+    const nps = (s.nps_monthly ?? 0) * 12
+    return base + hra + (s.bonus_annual ?? 0) + epf + nps +
+      (s.special_allowance_annual ?? 0) + (s.other_taxable_annual ?? 0)
+  }, [currentSalary])
+
+  // -- RSU helpers --
+  const addGrant = useCallback(() => {
+    const grant: RsuGrant = {
+      id: crypto.randomUUID(),
+      stock_name: '',
+      stock_price: 0,
+      grant_date: null,
+      notes: null,
+      vestings: [],
+    }
+    updateRsuGrants([...localRsuGrants, grant])
+  }, [localRsuGrants, updateRsuGrants])
+
+  const removeGrant = useCallback(
+    (id: string) => updateRsuGrants(localRsuGrants.filter((g) => g.id !== id)),
+    [localRsuGrants, updateRsuGrants],
+  )
+
+  const updateGrant = useCallback(
+    (id: string, patch: Partial<RsuGrant>) => {
+      updateRsuGrants(
+        localRsuGrants.map((g) => (g.id === id ? { ...g, ...patch } : g)),
+      )
+    },
+    [localRsuGrants, updateRsuGrants],
+  )
+
+  const addVesting = useCallback(
+    (grantId: string) => {
+      updateGrant(grantId, {
+        vestings: [
+          ...(localRsuGrants.find((g) => g.id === grantId)?.vestings ?? []),
+          { date: '', quantity: 0 },
+        ],
+      })
+    },
+    [localRsuGrants, updateGrant],
+  )
+
+  const updateVesting = useCallback(
+    (grantId: string, vestIdx: number, patch: Partial<RsuVesting>) => {
+      const grant = localRsuGrants.find((g) => g.id === grantId)
+      if (!grant) return
+      const vestings = grant.vestings.map((v, i) =>
+        i === vestIdx ? { ...v, ...patch } : v,
+      )
+      updateGrant(grantId, { vestings })
+    },
+    [localRsuGrants, updateGrant],
+  )
+
+  const removeVesting = useCallback(
+    (grantId: string, vestIdx: number) => {
+      const grant = localRsuGrants.find((g) => g.id === grantId)
+      if (!grant) return
+      updateGrant(grantId, {
+        vestings: grant.vestings.filter((_, i) => i !== vestIdx),
+      })
+    },
+    [localRsuGrants, updateGrant],
+  )
+
+  // RSU totals
+  const rsuTotals = useMemo(() => {
+    let shares = 0
+    let value = 0
+    for (const g of localRsuGrants) {
+      for (const v of g.vestings) {
+        shares += v.quantity
+        value += v.quantity * g.stock_price
+      }
+    }
+    return { shares, value }
+  }, [localRsuGrants])
+
+  // -- Growth helpers --
+  const updateGrowth = useCallback(
+    (field: keyof GrowthAssumptions, raw: string | boolean) => {
+      const value = typeof raw === 'boolean' ? raw : (raw === '' ? 0 : Number(raw))
+      if (typeof value === 'number' && Number.isNaN(value)) return
+      updateGrowthAssumptions({ ...localGrowthAssumptions, [field]: value })
+    },
+    [localGrowthAssumptions, updateGrowthAssumptions],
+  )
+
+  // -- Salary field definitions --
+  const salaryFields: Array<{
+    key: keyof SalaryComponents
+    label: string
+    hint: string
+    nullable: boolean
+  }> = [
+    { key: 'base_salary_monthly', label: 'Base Salary', hint: 'Monthly', nullable: false },
+    { key: 'hra_monthly', label: 'HRA', hint: 'Monthly, optional', nullable: true },
+    { key: 'bonus_annual', label: 'Bonus', hint: 'Annual', nullable: false },
+    { key: 'epf_monthly', label: 'EPF', hint: 'Monthly', nullable: false },
+    { key: 'nps_monthly', label: 'NPS', hint: 'Monthly, optional', nullable: true },
+    { key: 'special_allowance_annual', label: 'Special Allowance', hint: 'Annual', nullable: false },
+    { key: 'other_taxable_annual', label: 'Other Taxable', hint: 'Annual', nullable: false },
+  ]
+
+  const fyIdx = fyKeys.indexOf(selectedFY)
+
+  return (
+    <Section
+      index={index}
+      icon={Banknote}
+      title="Income & Salary Structure"
+      description="Salary breakdown, RSU grants, and growth projections"
+    >
+      {/* ── A. Salary Structure (per FY) ── */}
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-white">Salary Structure</h3>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={goPrev}
+              disabled={fyIdx <= 0}
+              className="p-1.5 rounded-lg bg-white/5 hover:bg-white/10 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            >
+              <ChevronLeft className="w-4 h-4 text-white" />
+            </button>
+            <span className="text-sm font-medium text-white min-w-[80px] text-center">
+              {fyKeys.length > 0 ? `FY ${selectedFY}` : 'No FY'}
+            </span>
+            <button
+              type="button"
+              onClick={goNext}
+              disabled={fyIdx >= fyKeys.length - 1}
+              className="p-1.5 rounded-lg bg-white/5 hover:bg-white/10 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            >
+              <ChevronRight className="w-4 h-4 text-white" />
+            </button>
+            <button
+              type="button"
+              onClick={addFY}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg bg-primary/15 text-primary hover:bg-primary/25 transition-colors"
+            >
+              <Plus className="w-3.5 h-3.5" />
+              Add FY
+            </button>
+          </div>
+        </div>
+
+        {fyKeys.length > 0 && (
+          <>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {salaryFields.map((f) => (
+                <div key={f.key}>
+                  <FieldLabel htmlFor={`salary-${f.key}`}>
+                    {f.label}{' '}
+                    <span className="text-muted-foreground font-normal">({f.hint})</span>
+                  </FieldLabel>
+                  <input
+                    id={`salary-${f.key}`}
+                    type="number"
+                    min="0"
+                    step="100"
+                    value={currentSalary[f.key] ?? ''}
+                    onChange={(e) => updateField(f.key, e.target.value)}
+                    placeholder={f.nullable ? 'Optional' : '0'}
+                    className={inputClass}
+                  />
+                </div>
+              ))}
+            </div>
+
+            {/* Live summary card */}
+            <div className="rounded-xl bg-primary/5 border border-primary/20 p-4 flex items-center justify-between">
+              <div>
+                <p className="text-xs text-muted-foreground">Total Annual CTC (excl. RSUs)</p>
+                <p className="text-lg font-semibold text-white">{formatCurrency(annualCTC)}</p>
+              </div>
+              <div className="text-right">
+                <p className="text-xs text-muted-foreground">Monthly (pre-tax)</p>
+                <p className="text-lg font-semibold text-white">
+                  {formatCurrency(annualCTC / 12)}
+                </p>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* Divider */}
+      <div className="border-t border-border" />
+
+      {/* ── B. RSU Grants ── */}
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-white">RSU Grants</h3>
+          <button
+            type="button"
+            onClick={addGrant}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg bg-primary/15 text-primary hover:bg-primary/25 transition-colors"
+          >
+            <Plus className="w-3.5 h-3.5" />
+            Add Grant
+          </button>
+        </div>
+
+        {localRsuGrants.length === 0 && (
+          <p className="text-sm text-muted-foreground">
+            No RSU grants added yet. Click &quot;Add Grant&quot; to track stock-based compensation.
+          </p>
+        )}
+
+        {localRsuGrants.map((grant) => (
+          <div
+            key={grant.id}
+            className="rounded-xl bg-white/[0.03] border border-border p-4 space-y-3"
+          >
+            {/* Grant header */}
+            <div className="flex items-start gap-3">
+              <div className="flex-1 grid grid-cols-1 sm:grid-cols-3 gap-3">
+                <div>
+                  <FieldLabel htmlFor={`grant-stock-${grant.id}`}>Stock Name</FieldLabel>
+                  <input
+                    id={`grant-stock-${grant.id}`}
+                    type="text"
+                    value={grant.stock_name}
+                    onChange={(e) => updateGrant(grant.id, { stock_name: e.target.value })}
+                    placeholder="e.g. AAPL"
+                    className={inputClass}
+                  />
+                </div>
+                <div>
+                  <FieldLabel htmlFor={`grant-price-${grant.id}`}>Price / Share</FieldLabel>
+                  <input
+                    id={`grant-price-${grant.id}`}
+                    type="number"
+                    min="0"
+                    step="0.01"
+                    value={grant.stock_price || ''}
+                    onChange={(e) =>
+                      updateGrant(grant.id, {
+                        stock_price: e.target.value === '' ? 0 : Number(e.target.value),
+                      })
+                    }
+                    placeholder="0"
+                    className={inputClass}
+                  />
+                </div>
+                <div>
+                  <FieldLabel htmlFor={`grant-notes-${grant.id}`}>Notes</FieldLabel>
+                  <input
+                    id={`grant-notes-${grant.id}`}
+                    type="text"
+                    value={grant.notes ?? ''}
+                    onChange={(e) =>
+                      updateGrant(grant.id, { notes: e.target.value || null })
+                    }
+                    placeholder="Optional"
+                    className={inputClass}
+                  />
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => removeGrant(grant.id)}
+                className="p-2 rounded-lg text-red-400 hover:bg-red-500/10 transition-colors mt-6"
+                title="Delete grant"
+              >
+                <Trash2 className="w-4 h-4" />
+              </button>
+            </div>
+
+            {/* Vesting table */}
+            {grant.vestings.length > 0 && (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="text-xs text-muted-foreground border-b border-border">
+                      <th className="text-left py-2 pr-3 font-medium">Date</th>
+                      <th className="text-left py-2 pr-3 font-medium">Qty</th>
+                      <th className="text-left py-2 pr-3 font-medium">Est. Value</th>
+                      <th className="text-left py-2 pr-3 font-medium">FY</th>
+                      <th className="py-2 w-8" />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {grant.vestings.map((v, vi) => {
+                      const estValue = v.quantity * grant.stock_price
+                      const fy = v.date ? dateToFY(v.date) : ''
+                      return (
+                        <tr key={vi} className="border-b border-border/50">
+                          <td className="py-2 pr-3">
+                            <input
+                              type="date"
+                              value={v.date}
+                              onChange={(e) =>
+                                updateVesting(grant.id, vi, { date: e.target.value })
+                              }
+                              className={`${inputClass} max-w-[160px]`}
+                            />
+                          </td>
+                          <td className="py-2 pr-3">
+                            <input
+                              type="number"
+                              min="0"
+                              value={v.quantity || ''}
+                              onChange={(e) =>
+                                updateVesting(grant.id, vi, {
+                                  quantity: e.target.value === '' ? 0 : Number(e.target.value),
+                                })
+                              }
+                              placeholder="0"
+                              className={`${inputClass} max-w-[100px]`}
+                            />
+                          </td>
+                          <td className="py-2 pr-3 text-muted-foreground">
+                            {estValue > 0 ? formatCurrency(estValue) : '--'}
+                          </td>
+                          <td className="py-2 pr-3 text-muted-foreground">
+                            {fy ? `FY ${fy}` : '--'}
+                          </td>
+                          <td className="py-2">
+                            <button
+                              type="button"
+                              onClick={() => removeVesting(grant.id, vi)}
+                              className="p-1 rounded text-red-400 hover:bg-red-500/10 transition-colors"
+                              title="Remove vesting"
+                            >
+                              <X className="w-3.5 h-3.5" />
+                            </button>
+                          </td>
+                        </tr>
+                      )
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+
+            <button
+              type="button"
+              onClick={() => addVesting(grant.id)}
+              className="flex items-center gap-1.5 text-xs text-primary hover:text-primary/80 transition-colors"
+            >
+              <Plus className="w-3.5 h-3.5" />
+              Add Vesting Date
+            </button>
+          </div>
+        ))}
+
+        {/* RSU totals */}
+        {localRsuGrants.length > 0 && rsuTotals.shares > 0 && (
+          <div className="flex items-center gap-6 text-sm text-muted-foreground pt-1">
+            <span>
+              Total shares:{' '}
+              <span className="text-white font-medium">{rsuTotals.shares.toLocaleString()}</span>
+            </span>
+            <span>
+              Total value:{' '}
+              <span className="text-white font-medium">{formatCurrency(rsuTotals.value)}</span>
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Divider */}
+      <div className="border-t border-border" />
+
+      {/* ── C. Growth Assumptions ── */}
+      <div className="space-y-4">
+        <h3 className="text-sm font-semibold text-white flex items-center gap-2">
+          <TrendingUp className="w-4 h-4 text-primary" />
+          Growth Assumptions
+        </h3>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div>
+            <FieldLabel htmlFor="growth-base">Base Salary Growth (%/yr)</FieldLabel>
+            <input
+              id="growth-base"
+              type="number"
+              min="0"
+              max="100"
+              step="0.5"
+              value={localGrowthAssumptions.base_salary_growth_pct || ''}
+              onChange={(e) => updateGrowth('base_salary_growth_pct', e.target.value)}
+              placeholder="0"
+              className={inputClass}
+            />
+          </div>
+          <div>
+            <FieldLabel htmlFor="growth-stock">Stock Appreciation (%/yr)</FieldLabel>
+            <input
+              id="growth-stock"
+              type="number"
+              min="-50"
+              max="200"
+              step="0.5"
+              value={localGrowthAssumptions.stock_price_appreciation_pct || ''}
+              onChange={(e) => updateGrowth('stock_price_appreciation_pct', e.target.value)}
+              placeholder="0"
+              className={inputClass}
+            />
+          </div>
+          <div>
+            <FieldLabel htmlFor="growth-horizon">Projection Horizon (years)</FieldLabel>
+            <input
+              id="growth-horizon"
+              type="number"
+              min="1"
+              max="30"
+              step="1"
+              value={localGrowthAssumptions.projection_years || ''}
+              onChange={(e) => updateGrowth('projection_years', e.target.value)}
+              placeholder="3"
+              className={inputClass}
+            />
+          </div>
+          <div>
+            <FieldLabel htmlFor="growth-bonus">Bonus Growth (%/yr)</FieldLabel>
+            <input
+              id="growth-bonus"
+              type="number"
+              min="0"
+              max="100"
+              step="0.5"
+              value={localGrowthAssumptions.bonus_growth_pct || ''}
+              onChange={(e) => updateGrowth('bonus_growth_pct', e.target.value)}
+              placeholder="0"
+              className={inputClass}
+            />
+          </div>
+          <div>
+            <FieldLabel htmlFor="growth-nps">NPS Growth (%/yr)</FieldLabel>
+            <input
+              id="growth-nps"
+              type="number"
+              min="0"
+              max="100"
+              step="0.5"
+              value={localGrowthAssumptions.nps_growth_pct || ''}
+              onChange={(e) => updateGrowth('nps_growth_pct', e.target.value)}
+              placeholder="0"
+              className={inputClass}
+            />
+          </div>
+          <div className="flex items-center justify-between gap-3 self-end pb-0.5">
+            <FieldLabel>EPF Scales With Base</FieldLabel>
+            <Toggle
+              checked={localGrowthAssumptions.epf_scales_with_base}
+              onChange={(val) => updateGrowth('epf_scales_with_base', val)}
+            />
+          </div>
+        </div>
+      </div>
+    </Section>
+  )
 }

--- a/frontend/src/pages/settings/useSettingsState.ts
+++ b/frontend/src/pages/settings/useSettingsState.ts
@@ -5,9 +5,12 @@
 import { useState, useEffect, useMemo, useCallback } from 'react'
 import { useAccountBalances, useMasterCategories } from '@/hooks/useAnalytics'
 import { accountClassificationsService } from '@/services/api/accountClassifications'
+import { preferencesService } from '@/services/api/preferences'
 import { usePreferences, useUpdatePreferences, useResetPreferences } from '@/hooks/api/usePreferences'
 import { toast } from 'sonner'
 import { useDemoGuard } from '@/hooks/useDemoGuard'
+import type { SalaryComponents, RsuGrant, GrowthAssumptions } from '@/types/salary'
+import { DEFAULT_GROWTH_ASSUMPTIONS } from '@/types/salary'
 import type { LocalPrefs, LocalPrefKey } from './types'
 import { ACCOUNT_TYPES } from './types'
 import {
@@ -34,6 +37,9 @@ export function useSettingsState() {
   const [dragType, setDragType] = useState<'account' | null>(null)
   const [theme, setTheme] = useState<'dark' | 'system'>(getStoredTheme)
   const [visibleWidgets, setVisibleWidgets] = useState<string[]>(getStoredWidgets)
+  const [localSalaryStructure, setLocalSalaryStructure] = useState<Record<string, SalaryComponents>>({})
+  const [localRsuGrants, setLocalRsuGrants] = useState<RsuGrant[]>([])
+  const [localGrowthAssumptions, setLocalGrowthAssumptions] = useState<GrowthAssumptions>({ ...DEFAULT_GROWTH_ASSUMPTIONS })
 
   // Derived data
   const accounts = useMemo(() => {
@@ -122,6 +128,11 @@ export function useSettingsState() {
   useEffect(() => {
     if (!preferences || localPrefs) return
     setLocalPrefs(buildInitialLocalPrefs(preferences as unknown as Record<string, unknown>) as unknown as LocalPrefs)
+    if (preferences.salary_structure) setLocalSalaryStructure(preferences.salary_structure)
+    if (preferences.rsu_grants) setLocalRsuGrants(preferences.rsu_grants)
+    if (preferences.growth_assumptions) {
+      setLocalGrowthAssumptions({ ...DEFAULT_GROWTH_ASSUMPTIONS, ...preferences.growth_assumptions })
+    }
   }, [preferences, localPrefs])
 
   // Auto-classify unclassified income categories using keyword matching
@@ -191,6 +202,21 @@ export function useSettingsState() {
     [],
   )
 
+  const updateSalaryStructure = useCallback((structure: Record<string, SalaryComponents>) => {
+    setLocalSalaryStructure(structure)
+    setHasChanges(true)
+  }, [])
+
+  const updateRsuGrants = useCallback((grants: RsuGrant[]) => {
+    setLocalRsuGrants(grants)
+    setHasChanges(true)
+  }, [])
+
+  const updateGrowthAssumptions = useCallback((assumptions: GrowthAssumptions) => {
+    setLocalGrowthAssumptions(assumptions)
+    setHasChanges(true)
+  }, [])
+
   // Save / Reset
   const handleSave = useCallback(async () => {
     if (guardDemoAction('Saving settings')) return
@@ -204,6 +230,11 @@ export function useSettingsState() {
         changed.map(([name, type]) => accountClassificationsService.setClassification(name, type)),
       )
       if (localPrefs) await updatePreferences.mutateAsync(localPrefs)
+      await Promise.all([
+        preferencesService.updateSalaryStructure({ salary_structure: localSalaryStructure }),
+        preferencesService.updateRsuGrants({ rsu_grants: localRsuGrants }),
+        preferencesService.updateGrowthAssumptions({ growth_assumptions: localGrowthAssumptions }),
+      ])
       setHasChanges(false)
       toast.success('Settings saved successfully')
     } catch {
@@ -211,7 +242,7 @@ export function useSettingsState() {
     } finally {
       setIsSaving(false)
     }
-  }, [classifications, localPrefs, updatePreferences, guardDemoAction])
+  }, [classifications, localPrefs, updatePreferences, guardDemoAction, localSalaryStructure, localRsuGrants, localGrowthAssumptions])
 
   const handleReset = useCallback(async () => {
     if (guardDemoAction('Resetting settings')) return
@@ -238,5 +269,8 @@ export function useSettingsState() {
     unclassifiedAccounts, excludedAccounts, fixedCategories,
     unclassifiedIncomeItems, unmappedInvestmentAccounts,
     updateLocalPref, setLocalPrefs, handleSave, handleReset,
+    localSalaryStructure, updateSalaryStructure,
+    localRsuGrants, updateRsuGrants,
+    localGrowthAssumptions, updateGrowthAssumptions,
   }
 }

--- a/frontend/src/services/api/preferences.ts
+++ b/frontend/src/services/api/preferences.ts
@@ -13,6 +13,7 @@
  */
 
 import { apiClient } from './client'
+import type { SalaryComponents, RsuGrant, GrowthAssumptions } from '@/types/salary'
 
 // Types
 export interface UserPreferences {
@@ -88,6 +89,11 @@ export interface UserPreferences {
   notify_upcoming_bills: boolean
   notify_days_ahead: number
 
+  // Salary & Tax Projections
+  salary_structure: Record<string, SalaryComponents>
+  rsu_grants: RsuGrant[]
+  growth_assumptions: GrowthAssumptions
+
   // Metadata
   created_at: string | null
   updated_at: string | null
@@ -156,6 +162,18 @@ export interface EarningStartDateConfig {
   use_earning_start_date: boolean
 }
 
+export interface SalaryStructureConfig {
+  salary_structure: Record<string, SalaryComponents>
+}
+
+export interface RsuGrantsConfig {
+  rsu_grants: RsuGrant[]
+}
+
+export interface GrowthAssumptionsConfig {
+  growth_assumptions: GrowthAssumptions
+}
+
 // Helper to create section-specific updaters
 function createSectionUpdater<T>(endpoint: string) {
   return async (config: T): Promise<UserPreferences> => {
@@ -202,6 +220,9 @@ export const preferencesService = {
   updateSpendingRule: createSectionUpdater<SpendingRuleConfig>('spending-rule'),
   updateCreditCardLimits: createSectionUpdater<CreditCardLimitsConfig>('credit-card-limits'),
   updateEarningStartDate: createSectionUpdater<EarningStartDateConfig>('earning-start-date'),
+  updateSalaryStructure: createSectionUpdater<SalaryStructureConfig>('salary-structure'),
+  updateRsuGrants: createSectionUpdater<RsuGrantsConfig>('rsu-grants'),
+  updateGrowthAssumptions: createSectionUpdater<GrowthAssumptionsConfig>('growth-assumptions'),
 
   async getExchangeRates(base: string = 'INR'): Promise<{
     base: string

--- a/frontend/src/store/preferencesStore.ts
+++ b/frontend/src/store/preferencesStore.ts
@@ -11,6 +11,8 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { CURRENCIES, BASE_CURRENCY, getCurrencyMeta } from '@/constants/currencies'
+import type { SalaryComponents, RsuGrant, GrowthAssumptions } from '@/types/salary'
+import { DEFAULT_GROWTH_ASSUMPTIONS } from '@/types/salary'
 
 export interface DisplayPreferences {
   numberFormat: 'indian' | 'international'
@@ -60,7 +62,15 @@ export interface PreferencesState {
   earningStartDate: string | null
   useEarningStartDate: boolean
 
+  // Salary & Tax Projections
+  salaryStructure: Record<string, SalaryComponents>
+  rsuGrants: RsuGrant[]
+  growthAssumptions: GrowthAssumptions
+
   // Actions
+  setSalaryStructure: (structure: Record<string, SalaryComponents>) => void
+  setRsuGrants: (grants: RsuGrant[]) => void
+  setGrowthAssumptions: (assumptions: GrowthAssumptions) => void
   setDisplayPreferences: (prefs: Partial<DisplayPreferences>) => void
   setDisplayCurrency: (code: string) => void
   setExchangeRate: (rate: number, updatedAt: string) => void
@@ -87,6 +97,9 @@ export interface PreferencesState {
     credit_card_limits: Record<string, number>
     earning_start_date: string | null
     use_earning_start_date: boolean
+    salary_structure: Record<string, SalaryComponents>
+    rsu_grants: RsuGrant[]
+    growth_assumptions: GrowthAssumptions
   }) => void
 }
 
@@ -163,6 +176,11 @@ export const usePreferencesStore = create<PreferencesState>()(
       earningStartDate: null,
       useEarningStartDate: false,
 
+      // Default salary & tax projections
+      salaryStructure: {},
+      rsuGrants: [],
+      growthAssumptions: { ...DEFAULT_GROWTH_ASSUMPTIONS },
+
       // Actions
       setDisplayPreferences: (prefs) =>
         set((state) => ({
@@ -197,6 +215,10 @@ export const usePreferencesStore = create<PreferencesState>()(
 
       setInvestmentAccountMappings: (mappings) =>
         set({ investmentAccountMappings: mappings }),
+
+      setSalaryStructure: (structure) => set({ salaryStructure: structure }),
+      setRsuGrants: (grants) => set({ rsuGrants: grants }),
+      setGrowthAssumptions: (assumptions) => set({ growthAssumptions: assumptions }),
 
       // Hydrate from API response (with validation)
       hydrateFromApi: (apiPrefs) => {
@@ -235,6 +257,15 @@ export const usePreferencesStore = create<PreferencesState>()(
             ? apiPrefs.credit_card_limits : {},
           earningStartDate: typeof apiPrefs.earning_start_date === 'string' ? apiPrefs.earning_start_date : null,
           useEarningStartDate: apiPrefs.use_earning_start_date === true,
+          salaryStructure:
+            apiPrefs.salary_structure && typeof apiPrefs.salary_structure === 'object'
+              ? apiPrefs.salary_structure
+              : {},
+          rsuGrants: Array.isArray(apiPrefs.rsu_grants) ? apiPrefs.rsu_grants : [],
+          growthAssumptions:
+            apiPrefs.growth_assumptions && typeof apiPrefs.growth_assumptions === 'object'
+              ? { ...DEFAULT_GROWTH_ASSUMPTIONS, ...apiPrefs.growth_assumptions }
+              : { ...DEFAULT_GROWTH_ASSUMPTIONS },
         })
       },
     }),
@@ -253,6 +284,9 @@ export const usePreferencesStore = create<PreferencesState>()(
         creditCardLimits: state.creditCardLimits,
         earningStartDate: state.earningStartDate,
         useEarningStartDate: state.useEarningStartDate,
+        salaryStructure: state.salaryStructure,
+        rsuGrants: state.rsuGrants,
+        growthAssumptions: state.growthAssumptions,
       }),
     }
   )
@@ -303,3 +337,7 @@ export const selectDisplayCurrency = (state: PreferencesState) =>
 
 export const selectExchangeRate = (state: PreferencesState) =>
   state.exchangeRate
+
+export const selectSalaryStructure = (state: PreferencesState) => state.salaryStructure
+export const selectRsuGrants = (state: PreferencesState) => state.rsuGrants
+export const selectGrowthAssumptions = (state: PreferencesState) => state.growthAssumptions

--- a/frontend/src/store/preferencesStore.ts
+++ b/frontend/src/store/preferencesStore.ts
@@ -103,6 +103,61 @@ export interface PreferencesState {
   }) => void
 }
 
+// ─── Hydration helpers (extracted to reduce cognitive complexity) ─────────────
+
+function ensureArray(v: unknown): string[] {
+  return Array.isArray(v) ? v : []
+}
+
+function clampPercent(v: unknown, fallback: number): number {
+  const n = Number(v)
+  return Number.isFinite(n) && n >= 0 && n <= 100 ? n : fallback
+}
+
+function ensureObject<T>(v: unknown, fallback: T): T {
+  return v && typeof v === 'object' ? (v as T) : fallback
+}
+
+function ensureString(v: unknown, fallback: string): string {
+  return typeof v === 'string' ? v : fallback
+}
+
+/** Parse and validate API preferences into store-ready state. */
+function parseApiPreferences(apiPrefs: Record<string, unknown>): Partial<PreferencesState> {
+  const fySm = Number(apiPrefs.fiscal_year_start_month)
+
+  return {
+    displayPreferences: {
+      numberFormat: apiPrefs.number_format === 'international' ? 'international' : 'indian',
+      currencySymbol: ensureString(apiPrefs.currency_symbol, '₹'),
+      currencySymbolPosition: apiPrefs.currency_symbol_position === 'after' ? 'after' : 'before',
+      defaultTimeRange: ensureString(apiPrefs.default_time_range, 'all_time'),
+    },
+    displayCurrency: typeof apiPrefs.display_currency === 'string' && apiPrefs.display_currency in CURRENCIES
+      ? apiPrefs.display_currency : BASE_CURRENCY,
+    fiscalYearStartMonth: fySm >= 1 && fySm <= 12 ? fySm : 4,
+    essentialCategories: ensureArray(apiPrefs.essential_categories),
+    incomeClassification: {
+      taxable: ensureArray(apiPrefs.taxable_income_categories),
+      investmentReturns: ensureArray(apiPrefs.investment_returns_categories),
+      nonTaxable: ensureArray(apiPrefs.non_taxable_income_categories),
+      other: ensureArray(apiPrefs.other_income_categories),
+    },
+    investmentAccountMappings: ensureObject(apiPrefs.investment_account_mappings, {}),
+    needsTargetPercent: clampPercent(apiPrefs.needs_target_percent, 50),
+    wantsTargetPercent: clampPercent(apiPrefs.wants_target_percent, 30),
+    savingsTargetPercent: clampPercent(apiPrefs.savings_target_percent, 20),
+    creditCardLimits: ensureObject(apiPrefs.credit_card_limits, {}),
+    earningStartDate: ensureString(apiPrefs.earning_start_date, '') || null,
+    useEarningStartDate: apiPrefs.use_earning_start_date === true,
+    salaryStructure: ensureObject(apiPrefs.salary_structure, {}),
+    rsuGrants: Array.isArray(apiPrefs.rsu_grants) ? apiPrefs.rsu_grants : [],
+    growthAssumptions: apiPrefs.growth_assumptions && typeof apiPrefs.growth_assumptions === 'object'
+      ? { ...DEFAULT_GROWTH_ASSUMPTIONS, ...(apiPrefs.growth_assumptions as Record<string, unknown>) }
+      : { ...DEFAULT_GROWTH_ASSUMPTIONS },
+  }
+}
+
 export const usePreferencesStore = create<PreferencesState>()(
   persist(
     (set) => ({
@@ -223,50 +278,7 @@ export const usePreferencesStore = create<PreferencesState>()(
       // Hydrate from API response (with validation)
       hydrateFromApi: (apiPrefs) => {
         if (!apiPrefs || typeof apiPrefs !== 'object') return
-
-        const ensureArray = (v: unknown): string[] => Array.isArray(v) ? v : []
-        const fySm = Number(apiPrefs.fiscal_year_start_month)
-        const clampPercent = (v: unknown, fallback: number) => {
-          const n = Number(v)
-          return Number.isFinite(n) && n >= 0 && n <= 100 ? n : fallback
-        }
-
-        set({
-          displayPreferences: {
-            numberFormat: apiPrefs.number_format === 'international' ? 'international' : 'indian',
-            currencySymbol: typeof apiPrefs.currency_symbol === 'string' ? apiPrefs.currency_symbol : '₹',
-            currencySymbolPosition: apiPrefs.currency_symbol_position === 'after' ? 'after' : 'before',
-            defaultTimeRange: typeof apiPrefs.default_time_range === 'string' ? apiPrefs.default_time_range : 'all_time',
-          },
-          displayCurrency: typeof apiPrefs.display_currency === 'string' && apiPrefs.display_currency in CURRENCIES
-            ? apiPrefs.display_currency : BASE_CURRENCY,
-          fiscalYearStartMonth: fySm >= 1 && fySm <= 12 ? fySm : 4,
-          essentialCategories: ensureArray(apiPrefs.essential_categories),
-          incomeClassification: {
-            taxable: ensureArray(apiPrefs.taxable_income_categories),
-            investmentReturns: ensureArray(apiPrefs.investment_returns_categories),
-            nonTaxable: ensureArray(apiPrefs.non_taxable_income_categories),
-            other: ensureArray(apiPrefs.other_income_categories),
-          },
-          investmentAccountMappings: apiPrefs.investment_account_mappings && typeof apiPrefs.investment_account_mappings === 'object'
-            ? apiPrefs.investment_account_mappings : {},
-          needsTargetPercent: clampPercent(apiPrefs.needs_target_percent, 50),
-          wantsTargetPercent: clampPercent(apiPrefs.wants_target_percent, 30),
-          savingsTargetPercent: clampPercent(apiPrefs.savings_target_percent, 20),
-          creditCardLimits: apiPrefs.credit_card_limits && typeof apiPrefs.credit_card_limits === 'object'
-            ? apiPrefs.credit_card_limits : {},
-          earningStartDate: typeof apiPrefs.earning_start_date === 'string' ? apiPrefs.earning_start_date : null,
-          useEarningStartDate: apiPrefs.use_earning_start_date === true,
-          salaryStructure:
-            apiPrefs.salary_structure && typeof apiPrefs.salary_structure === 'object'
-              ? apiPrefs.salary_structure
-              : {},
-          rsuGrants: Array.isArray(apiPrefs.rsu_grants) ? apiPrefs.rsu_grants : [],
-          growthAssumptions:
-            apiPrefs.growth_assumptions && typeof apiPrefs.growth_assumptions === 'object'
-              ? { ...DEFAULT_GROWTH_ASSUMPTIONS, ...apiPrefs.growth_assumptions }
-              : { ...DEFAULT_GROWTH_ASSUMPTIONS },
-        })
+        set(parseApiPreferences(apiPrefs))
       },
     }),
     {

--- a/frontend/src/types/salary.ts
+++ b/frontend/src/types/salary.ts
@@ -1,0 +1,78 @@
+/** Compensation breakdown for a single fiscal year. */
+export interface SalaryComponents {
+  base_salary_monthly: number
+  hra_monthly: number | null
+  bonus_annual: number
+  epf_monthly: number
+  nps_monthly: number
+  special_allowance_annual: number
+  other_taxable_annual: number
+}
+
+/** A single vesting event within an RSU grant. */
+export interface RsuVesting {
+  date: string // YYYY-MM-DD
+  quantity: number
+}
+
+/** An RSU grant with its vesting schedule. */
+export interface RsuGrant {
+  id: string
+  stock_name: string
+  stock_price: number
+  grant_date: string | null
+  notes: string | null
+  vestings: RsuVesting[]
+}
+
+/** Growth parameters for multi-year projections. */
+export interface GrowthAssumptions {
+  base_salary_growth_pct: number
+  bonus_growth_pct: number
+  epf_scales_with_base: boolean
+  nps_growth_pct: number
+  stock_price_appreciation_pct: number
+  projection_years: number
+}
+
+/** Default salary components for a new FY entry. */
+export const DEFAULT_SALARY_COMPONENTS: SalaryComponents = {
+  base_salary_monthly: 0,
+  hra_monthly: null,
+  bonus_annual: 0,
+  epf_monthly: 3600,
+  nps_monthly: 0,
+  special_allowance_annual: 0,
+  other_taxable_annual: 0,
+}
+
+/** Default growth assumptions. */
+export const DEFAULT_GROWTH_ASSUMPTIONS: GrowthAssumptions = {
+  base_salary_growth_pct: 0,
+  bonus_growth_pct: 0,
+  epf_scales_with_base: true,
+  nps_growth_pct: 0,
+  stock_price_appreciation_pct: 0,
+  projection_years: 3,
+}
+
+/** Projected breakdown for a single fiscal year. */
+export interface ProjectedFYBreakdown {
+  fy: string
+  baseSalary: number
+  hra: number
+  bonus: number
+  epf: number
+  nps: number
+  specialAllowance: number
+  otherTaxable: number
+  rsuIncome: number
+  rsuDetails: Array<{ stock_name: string; shares: number; value: number }>
+  grossTaxable: number
+  standardDeduction: number
+  netTaxable: number
+  totalTax: number
+  takeHome: number
+  effectiveTaxRate: number
+  isProjected: boolean
+}

--- a/frontend/src/types/salary.ts
+++ b/frontend/src/types/salary.ts
@@ -1,7 +1,7 @@
 /** Compensation breakdown for a single fiscal year. */
 export interface SalaryComponents {
-  base_salary_monthly: number
-  hra_monthly: number | null
+  base_salary_annual: number
+  hra_annual: number | null
   bonus_annual: number
   epf_monthly: number
   nps_monthly: number
@@ -37,8 +37,8 @@ export interface GrowthAssumptions {
 
 /** Default salary components for a new FY entry. */
 export const DEFAULT_SALARY_COMPONENTS: SalaryComponents = {
-  base_salary_monthly: 0,
-  hra_monthly: null,
+  base_salary_annual: 0,
+  hra_annual: null,
   bonus_annual: 0,
   epf_monthly: 3600,
   nps_monthly: 0,

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -3,7 +3,7 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "types": ["vite/client"],
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

- Add salary structure input per fiscal year (base, HRA, bonus, EPF, NPS, etc.) to Settings page
- Track RSU grants with stock name, price per share, and full vesting schedules (multiple dates/quantities per grant)
- Define growth assumptions (base raise %, stock appreciation, bonus behavior, projection horizon) for multi-year forecasting
- Extend Tax Planning page to navigate into future FYs with projection mode and a "From Transactions" / "From Salary Structure" toggle
- Show salary-based income breakdown (left panel: income components, right panel: tax computation with effective rate, monthly TDS, take-home)
- Multi-year projection comparison table spanning up to 5 future fiscal years

## Architecture

- **Backend**: 3 new JSON columns in `user_preferences` (salary_structure, rsu_grants, growth_assumptions), 3 new PUT endpoints following existing `_update_section()` pattern, Pydantic validation schemas
- **Frontend**: New TypeScript types, Zustand store extensions, TanStack Query mutation hooks, pure projection calculator module (`projectionCalculator.ts`) that calls existing `calculateTax()`, new `SalaryStructureSection` settings component, Tax Planning page enhancements
- All projection logic is client-side (pure functions in projectionCalculator.ts)
- 13 new schema validation tests (backend) + 11 projection calculator tests (frontend)

## Test plan

- [x] Backend: 51/51 tests pass (13 new salary schema tests + 38 existing)
- [x] Frontend: 20/20 tests pass (11 new projection calculator tests + 9 existing)
- [x] Type-check: clean (tsc -b --noEmit)
- [x] Lint: clean (ruff + eslint)
- [ ] Manual: Settings page -- add salary structure for FY, add RSU grants with vestings, set growth assumptions, save
- [ ] Manual: Tax Planning page -- navigate to future FY, verify projection toggle, check income breakdown, verify multi-year table
- [ ] Manual: Verify existing transaction-based tax view is unchanged