### PR TITLE
fix: preferences API prefix and stale-token eager fetching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,7 @@ Runs on push/PR to main. Python 3.12, Node 22, pnpm 10, uv (latest).
 - **Colors**: Use CSS custom properties from `index.css` (`var(--color-income)`, `var(--color-expense)`, etc.). Never raw hex/rgb.
 - **Charts**: Wrap in `ChartContainer`. Use Recharts. Use colors from `constants/`.
 - **Layout**: Use `PageHeader` for page titles, `MetricCard` for KPIs, `EmptyState` for no-data states.
-- **Dark-only**: No light theme. Don't add `dark:` prefixes or theme toggles.
+- **Dark-only (for now)**: Light theme planned (#79). Until then, don't add `dark:` prefixes or theme toggles.
 - **No inline styles** for layout -- use Tailwind classes.
 
 ## Import Conventions

--- a/backend/src/ledger_sync/api/analytics_v2.py
+++ b/backend/src/ledger_sync/api/analytics_v2.py
@@ -34,6 +34,7 @@ from ledger_sync.db.models import (
     TransferFlow,
     User,
 )
+from ledger_sync.db.session import SessionLocal
 
 _FREQUENCY_DAYS = {
     "daily": 1,
@@ -80,20 +81,23 @@ router = APIRouter(prefix="/api/analytics/v2", tags=["analytics-v2"])
 @router.post("/refresh")
 async def refresh_analytics(
     current_user: CurrentUser,
-    db: DatabaseSession,
 ) -> dict[str, Any]:
     """Recompute all pre-aggregated analytics tables.
 
     Called by the frontend after a successful upload to ensure analytics
-    are fresh. Runs synchronously so the response is only sent after
-    all tables are updated (avoids the stale-data problem with
-    BackgroundTasks on serverless platforms like Vercel).
+    are fresh. Uses its own DB session (not the request-scoped DI session)
+    because analytics runs in a worker thread and SQLAlchemy sessions
+    are not thread-safe.
     """
     user_id = current_user.id
 
     def _run() -> dict[str, Any]:
-        engine = AnalyticsEngine(db, user_id=user_id)
-        return engine.run_full_analytics(source_file="manual-refresh")
+        session = SessionLocal()
+        try:
+            engine = AnalyticsEngine(session, user_id=user_id)
+            return engine.run_full_analytics(source_file="manual-refresh")
+        finally:
+            session.close()
 
     results = await anyio.to_thread.run_sync(_run)
     return {"success": True, "analytics": {k: v for k, v in results.items() if isinstance(v, int)}}

--- a/backend/src/ledger_sync/api/preferences.py
+++ b/backend/src/ledger_sync/api/preferences.py
@@ -28,7 +28,7 @@ from ledger_sync.schemas.salary import (
     SalaryStructureConfig,
 )
 
-router = APIRouter(prefix="/preferences", tags=["preferences"])
+router = APIRouter(prefix="/api/preferences", tags=["preferences"])
 
 
 # ----- Pydantic Models -----

--- a/frontend/src/hooks/api/usePreferences.ts
+++ b/frontend/src/hooks/api/usePreferences.ts
@@ -41,12 +41,14 @@ function invalidatePreferenceDependents(queryClient: ReturnType<typeof useQueryC
 export function usePreferences() {
   const hydrateFromApi = usePreferencesStore((state) => state.hydrateFromApi)
   const accessToken = useAuthStore((state) => state.accessToken)
+  const isLoading = useAuthStore((state) => state.isLoading)
 
   const query = useQuery<UserPreferences>({
     queryKey: PREFERENCES_KEY,
     queryFn: () => preferencesService.getPreferences(),
-    // Only fetch when the user is authenticated (prevents 401 before login)
-    enabled: !!accessToken,
+    // Wait for useAuthInit to finish verifying the token before fetching.
+    // Without `!isLoading`, a stale token from localStorage triggers a 401.
+    enabled: !!accessToken && !isLoading,
     // Preferences only change on explicit save (mutations invalidate this key).
     staleTime: Infinity,
   })

--- a/frontend/src/services/api/preferences.ts
+++ b/frontend/src/services/api/preferences.ts
@@ -177,7 +177,7 @@ export interface GrowthAssumptionsConfig {
 // Helper to create section-specific updaters
 function createSectionUpdater<T>(endpoint: string) {
   return async (config: T): Promise<UserPreferences> => {
-    const response = await apiClient.put<UserPreferences>(`/preferences/${endpoint}`, config)
+    const response = await apiClient.put<UserPreferences>(`/api/preferences/${endpoint}`, config)
     return response.data
   }
 }
@@ -188,7 +188,7 @@ export const preferencesService = {
    * Get current user preferences
    */
   async getPreferences(): Promise<UserPreferences> {
-    const response = await apiClient.get<UserPreferences>('/preferences')
+    const response = await apiClient.get<UserPreferences>('/api/preferences')
     return response.data
   },
 
@@ -196,7 +196,7 @@ export const preferencesService = {
    * Update user preferences (partial update supported)
    */
   async updatePreferences(updates: UserPreferencesUpdate): Promise<UserPreferences> {
-    const response = await apiClient.put<UserPreferences>('/preferences', updates)
+    const response = await apiClient.put<UserPreferences>('/api/preferences', updates)
     return response.data
   },
 
@@ -204,7 +204,7 @@ export const preferencesService = {
    * Reset all preferences to defaults
    */
   async resetPreferences(): Promise<UserPreferences> {
-    const response = await apiClient.post<UserPreferences>('/preferences/reset')
+    const response = await apiClient.post<UserPreferences>('/api/preferences/reset')
     return response.data
   },
 


### PR DESCRIPTION
## Summary

- **Preferences router prefix**: changed `/preferences` to `/api/preferences` for consistency with all other data routers (`/api/analytics`, `/api/auth`, `/api/calculations`, etc.)
- **Frontend service URLs**: updated all preferences service calls to use `/api/preferences` (get, update, reset, and all 14 section-specific endpoints via `createSectionUpdater`)
- **Stale-token guard**: added `!isLoading` to `usePreferences` `enabled` flag so it waits for `useAuthInit` to verify the token before fetching -- prevents 401 from expired persisted tokens in localStorage
- **Analytics refresh thread-safety**: `POST /api/analytics/v2/refresh` now creates its own `SessionLocal()` session instead of using the DI request-scoped session (SQLAlchemy sessions aren't thread-safe across `anyio.to_thread`)
- **CLAUDE.md**: updated dark-only note to reference #79

## Test plan

- [x] `pnpm run check` passes (lint + types + 82 tests)
- [ ] Login flow: verify no `/preferences` 401 appears in server logs before auth completes
- [ ] Upload flow: verify analytics refresh completes without 500
- [ ] Settings page: verify all preference sections save correctly via `/api/preferences/*`
- [ ] Fresh browser (no localStorage): verify no stale-token requests fire