### PR TITLE
fix: relax DB timeouts for analytics refresh

### DIFF
--- a/backend/src/ledger_sync/api/analytics_v2.py
+++ b/backend/src/ledger_sync/api/analytics_v2.py
@@ -11,7 +11,7 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
-from sqlalchemy import desc
+from sqlalchemy import desc, text
 
 from ledger_sync.api.deps import CurrentUser, DatabaseSession
 from ledger_sync.core.analytics_engine import AnalyticsEngine
@@ -84,18 +84,28 @@ def refresh_analytics(
     """Recompute all pre-aggregated analytics tables.
 
     Called by the frontend after a successful upload to ensure analytics
-    are fresh. Uses its own DB session (not the request-scoped DI session)
-    so it is independent of the request lifecycle.
+    are fresh. Uses its own DB session with a relaxed statement timeout
+    (analytics runs many heavy computations that can exceed the default
+    30 s limit).
 
     Defined as a sync ``def`` so FastAPI runs it in an external threadpool
-    automatically -- this avoids ``anyio.to_thread`` issues under Mangum
-    on Vercel serverless where the one-shot event loop can't reliably
-    spawn worker threads.
+    automatically -- avoids event-loop issues under Mangum on Vercel.
     """
     session = SessionLocal()
     try:
+        # Relax timeouts for the heavy analytics workload.
+        # Default connection listener sets 30 s statement / 60 s idle-in-txn,
+        # which is too tight for a full analytics recompute.
+        session.execute(text("SET statement_timeout = '120s'"))
+        session.execute(text("SET idle_in_transaction_session_timeout = '300s'"))
+
         engine = AnalyticsEngine(session, user_id=current_user.id)
         results = engine.run_full_analytics(source_file="manual-refresh")
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Analytics refresh failed: {exc}",
+        ) from exc
     finally:
         session.close()
     return {"success": True, "analytics": {k: v for k, v in results.items() if isinstance(v, int)}}


### PR DESCRIPTION
## Summary

- **Relax DB timeouts** for the analytics refresh session: `statement_timeout` 30s -> 120s, `idle_in_transaction_session_timeout` 60s -> 300s. The default connection-level timeouts (set in `session.py`) are too tight for a full analytics recompute on Neon.
- **Add try/except** with `HTTPException` so errors return a proper JSON response WITH CORS headers instead of a bare 500 that browsers misreport as a CORS error.

## Root cause

`session.py` line 57 sets `statement_timeout = '30s'` on every DB connection. The analytics engine runs multiple heavy queries (load all transactions, delete+reinsert aggregation tables, detect recurring patterns, etc.) -- any single statement exceeding 30s causes Neon to kill the query, which crashes the function before FastAPI's CORS middleware can add response headers.

## Test plan

- [x] `pnpm run check` passes (lint + types + 82 tests)
- [ ] Upload file in production -- verify analytics refresh succeeds
- [ ] If it still fails, the error message will now be visible in the browser console (JSON response with CORS headers instead of bare 500)