### PR TITLE
fix: add missing recurrencefrequency enum values to PostgreSQL

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'backend/alembic/**'
+      - 'backend/src/ledger_sync/db/migrations/**'
       - 'backend/src/ledger_sync/db/models.py'
 
   workflow_dispatch: # Allow manual trigger

--- a/backend/src/ledger_sync/db/migrations/versions/20260412_1200_add_missing_recurrence_enum_values.py
+++ b/backend/src/ledger_sync/db/migrations/versions/20260412_1200_add_missing_recurrence_enum_values.py
@@ -1,0 +1,42 @@
+"""add missing recurrencefrequency enum values
+
+The original migration created the PostgreSQL enum with only
+DAILY, WEEKLY, BIWEEKLY, MONTHLY, QUARTERLY, YEARLY.
+The Python enum (and analytics engine) also uses BIMONTHLY and
+SEMIANNUAL, which causes INSERT failures on PostgreSQL.
+
+PostgreSQL 12+ allows ALTER TYPE ... ADD VALUE IF NOT EXISTS
+inside a transaction, so this is safe on Neon (PostgreSQL 17).
+
+Revision ID: f1a2b3c4d5e6
+Revises: e844a13cc445
+Create Date: 2026-04-12 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision: str = "f1a2b3c4d5e6"
+down_revision: str | None = "e844a13cc445"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # Skip on SQLite (no enum types)
+    if conn.dialect.name == "sqlite":
+        return
+
+    # Add missing values — IF NOT EXISTS prevents errors if already present
+    conn.execute(text("ALTER TYPE recurrencefrequency ADD VALUE IF NOT EXISTS 'BIMONTHLY'"))
+    conn.execute(text("ALTER TYPE recurrencefrequency ADD VALUE IF NOT EXISTS 'SEMIANNUAL'"))
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary

- Adds Alembic migration to add `BIMONTHLY` and `SEMIANNUAL` values to the `recurrencefrequency` PostgreSQL enum type in production
- Fixes the `migrate.yml` workflow path to also watch `backend/src/ledger_sync/db/migrations/**` (where migrations actually live)

## Root Cause

The original migration (Feb 2026) created the PostgreSQL enum with 6 values: `DAILY, WEEKLY, BIWEEKLY, MONTHLY, QUARTERLY, YEARLY`. The Python `RecurrenceFrequency` enum was later extended with `BIMONTHLY` and `SEMIANNUAL`, but no migration was created. The analytics engine's `_detect_recurring_transactions()` generates these frequency values, and INSERTs into `recurring_transactions` fail with `invalid input value for enum recurrencefrequency: "SEMIANNUAL"` -- causing the 500 error on `POST /api/analytics/v2/refresh` after upload.

## Migration Details

Uses `ALTER TYPE recurrencefrequency ADD VALUE IF NOT EXISTS` (safe on PostgreSQL 12+, Neon runs PG 17). Skips on SQLite (dev). Idempotent.

## Test plan

- [ ] CI passes (lint, type-check, tests)
- [ ] After merge, verify GitHub Actions `migrate.yml` triggers and runs `alembic upgrade head`
- [ ] Test upload flow in production -- analytics refresh should succeed