### PR TITLE
fix(calc): correct FIRE year computation + robust recurring day-of-month

### DIFF
--- a/backend/src/ledger_sync/core/_analytics_helpers.py
+++ b/backend/src/ledger_sync/core/_analytics_helpers.py
@@ -86,6 +86,30 @@ def resolve_pattern_display(
     }
 
 
+def infer_expected_day_of_month(days: list[int]) -> int | None:
+    """Infer the intended billing day from observed day-of-month values.
+
+    For a subscription set to the 31st, short months clamp it to 28/30, producing
+    values like [31, 28, 31, 30, 31]. A plain mode can pick the wrong "canonical"
+    day. Heuristic:
+
+    - If any observation is >= 25, assume a late-month bill and return the max
+      (the "intended" day before short-month clamping).
+    - Otherwise return the median (robust to occasional 1-day drifts like
+      weekend settlement lag).
+    """
+    if not days:
+        return None
+    if max(days) >= 25:
+        return max(days)
+    sorted_days = sorted(days)
+    mid = len(sorted_days) // 2
+    if len(sorted_days) % 2 == 1:
+        return sorted_days[mid]
+    # For even count, pick the lower median (integers, no averaging)
+    return sorted_days[mid - 1]
+
+
 def aggregate_holdings_data(
     transactions: list[Transaction],
     is_investment_account: Callable[[str | None], bool],

--- a/backend/src/ledger_sync/core/analytics_engine.py
+++ b/backend/src/ledger_sync/core/analytics_engine.py
@@ -36,6 +36,9 @@ from ledger_sync.core._analytics_helpers import (
     group_txns_by_pattern as _group_txns_by_pattern,
 )
 from ledger_sync.core._analytics_helpers import (
+    infer_expected_day_of_month as _infer_expected_day_of_month,
+)
+from ledger_sync.core._analytics_helpers import (
     resolve_pattern_display as _resolve_pattern_display,
 )
 from ledger_sync.core.query_helpers import fmt_year_month
@@ -1218,8 +1221,7 @@ class AnalyticsEngine:
             RecurrenceFrequency.SEMIANNUAL,
             RecurrenceFrequency.YEARLY,
         ):
-            days_of_month = [d.day for d in sorted_dates]
-            expected_day = max(set(days_of_month), key=days_of_month.count)
+            expected_day = _infer_expected_day_of_month([d.day for d in sorted_dates])
 
         return frequency, confidence, expected_day
 

--- a/backend/tests/unit/test_analytics_helpers.py
+++ b/backend/tests/unit/test_analytics_helpers.py
@@ -1,0 +1,39 @@
+from ledger_sync.core._analytics_helpers import infer_expected_day_of_month
+
+
+def test_infer_returns_none_for_empty():
+    assert infer_expected_day_of_month([]) is None
+
+
+def test_single_day():
+    assert infer_expected_day_of_month([15]) == 15
+
+
+def test_consistent_mid_month_uses_median():
+    # Bills on the 15th, always clean
+    assert infer_expected_day_of_month([15, 15, 15, 15]) == 15
+
+
+def test_late_month_clamping_returns_max():
+    # 31st bill clamped to 28/30 in shorter months -- max recovers true intent
+    assert infer_expected_day_of_month([31, 28, 31, 30, 31]) == 31
+
+
+def test_28th_bill_feb_clamp():
+    # 28th bill, Feb leap/non-leap edge cases
+    assert infer_expected_day_of_month([28, 28, 28, 28]) == 28
+
+
+def test_occasional_drift_mid_month_robust():
+    # 5th bill, one-day weekend drift on 4th or 6th -- median is robust
+    assert infer_expected_day_of_month([5, 5, 4, 5, 6, 5]) == 5
+
+
+def test_first_of_month_outlier_from_end_of_month():
+    # 28th bill that occasionally posts on 1st of next month: max still returns 28
+    assert infer_expected_day_of_month([28, 1, 28, 28, 1]) == 28
+
+
+def test_mid_month_even_count_uses_lower_median():
+    # Mix of 10 and 12 with no clear mode
+    assert infer_expected_day_of_month([10, 12]) == 10

--- a/frontend/src/lib/__tests__/fireCalculator.test.ts
+++ b/frontend/src/lib/__tests__/fireCalculator.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest'
+import {
+  computeFIRENumber,
+  computeCoastFIRE,
+  computeLeanFIRE,
+  computeFatFIRE,
+  computeYearsToFIRE,
+  computeFIRE,
+  computeRetirementCorpus,
+} from '../fireCalculator'
+
+describe('computeFIRENumber', () => {
+  it('divides annual expenses by SWR', () => {
+    expect(computeFIRENumber(600000, 0.03)).toBe(20_000_000)
+    expect(computeFIRENumber(1200000, 0.04)).toBe(30_000_000)
+  })
+
+  it('returns 0 for zero or negative SWR', () => {
+    expect(computeFIRENumber(600000, 0)).toBe(0)
+    expect(computeFIRENumber(600000, -0.01)).toBe(0)
+  })
+})
+
+describe('computeCoastFIRE', () => {
+  it('discounts FIRE number back to today via compound growth', () => {
+    // 1 Cr needed in 20 years at 7% real return => ~25.84 L today
+    expect(computeCoastFIRE(10_000_000, 0.07, 20)).toBe(2_584_190)
+  })
+
+  it('returns FIRE number itself when retiring today', () => {
+    expect(computeCoastFIRE(10_000_000, 0.07, 0)).toBe(10_000_000)
+  })
+})
+
+describe('computeLeanFIRE / computeFatFIRE', () => {
+  it('lean uses essential expenses only', () => {
+    expect(computeLeanFIRE(360000, 0.03)).toBe(12_000_000)
+  })
+
+  it('fat is 2x FIRE number', () => {
+    expect(computeFatFIRE(20_000_000)).toBe(40_000_000)
+  })
+})
+
+describe('computeYearsToFIRE', () => {
+  it('returns 0 when already at FIRE', () => {
+    expect(computeYearsToFIRE(10_000_000, 500000, 0.07, 10_000_000)).toBe(0)
+    expect(computeYearsToFIRE(10_000_000, 500000, 0.07, 15_000_000)).toBe(0)
+  })
+
+  it('computes years from zero portfolio via savings alone', () => {
+    // Save 10L/year at 7% real return, target 1Cr
+    //   solve: 10L * [((1.07)^n - 1) / 0.07] = 1Cr
+    //   (1.07)^n - 1 = 0.7   =>  n = log(1.7)/log(1.07) ≈ 7.84
+    const years = computeYearsToFIRE(10_000_000, 1_000_000, 0.07, 0)
+    expect(years).toBeCloseTo(7.84, 1)
+  })
+
+  it('compounds existing portfolio for ALL years, not just 1 (regression test)', () => {
+    // 50L today, 10L/year savings at 7% real, target 1Cr
+    //   savings perpetuity = 10L/0.07 = 142.86L
+    //   ratio = (100L + 142.86L) / (50L + 142.86L) = 242.86/192.86 ≈ 1.2593
+    //   n = log(1.2593)/log(1.07) ≈ 3.41
+    const years = computeYearsToFIRE(10_000_000, 1_000_000, 0.07, 5_000_000)
+    expect(years).toBeCloseTo(3.41, 1)
+
+    // Previously (buggy) code gave target = 100L - 50L * 1.07 = 46.5L
+    // then fvFactor = (46.5L * 0.07 / 10L) + 1 = 1.3255
+    // n = log(1.3255)/log(1.07) ≈ 4.17
+    // So the new (correct) answer must be noticeably lower than 4.17
+    expect(years).toBeLessThan(4.0)
+  })
+
+  it('handles zero return: linear savings', () => {
+    // Target 1Cr, 10L savings, 0% return, 20L existing => 80L gap / 10L = 8 years
+    expect(computeYearsToFIRE(10_000_000, 1_000_000, 0, 2_000_000)).toBe(8)
+  })
+
+  it('handles zero savings: pure compounding', () => {
+    // Target 1Cr, 50L existing, 7% real return
+    //   (1.07)^n = 2  =>  n = log(2)/log(1.07) ≈ 10.24
+    expect(computeYearsToFIRE(10_000_000, 0, 0.07, 5_000_000)).toBeCloseTo(10.24, 1)
+  })
+
+  it('returns Infinity when savings and return are both zero/negative', () => {
+    expect(computeYearsToFIRE(10_000_000, 0, 0, 0)).toBe(Infinity)
+    expect(computeYearsToFIRE(10_000_000, 0, -0.01, 0)).toBe(Infinity)
+  })
+})
+
+describe('computeFIRE orchestrator', () => {
+  it('returns all variants', () => {
+    const result = computeFIRE({
+      annualExpenses: 600000,
+      essentialAnnualExpenses: 360000,
+      annualSavings: 500000,
+      annualIncome: 1500000,
+      currentPortfolio: 0,
+      swr: 0.03,
+      realReturn: 0.07,
+      yearsToRetire: 25,
+    })
+    expect(result.fireNumber).toBe(20_000_000)
+    expect(result.leanFIRE).toBe(12_000_000)
+    expect(result.fatFIRE).toBe(40_000_000)
+    expect(result.currentSavingsRate).toBeCloseTo(33.33, 1)
+    expect(result.yearsToFIRE).toBeGreaterThan(0)
+    expect(result.yearsToFIRE).toBeLessThan(Infinity)
+  })
+})
+
+describe('computeRetirementCorpus', () => {
+  it('inflates expenses to retirement year', () => {
+    const result = computeRetirementCorpus({
+      monthlyExpenses: 50000,
+      inflationRate: 0.065,
+      expectedReturn: 0.12,
+      yearsToRetirement: 30,
+      swr: 0.03,
+    })
+    // 50K * (1.065)^30 ≈ 330K/month
+    expect(result.monthlyExpenseAtRetirement).toBeGreaterThan(300_000)
+    expect(result.monthlyExpenseAtRetirement).toBeLessThan(350_000)
+    expect(result.requiredCorpus).toBeGreaterThan(0)
+    expect(result.monthlySIP).toBeGreaterThan(0)
+    expect(result.projectionData).toHaveLength(30)
+  })
+
+  it('returns zeros for non-positive years', () => {
+    const result = computeRetirementCorpus({
+      monthlyExpenses: 50000,
+      yearsToRetirement: 0,
+    })
+    expect(result.requiredCorpus).toBe(0)
+    expect(result.monthlySIP).toBe(0)
+    expect(result.projectionData).toEqual([])
+  })
+})

--- a/frontend/src/lib/fireCalculator.ts
+++ b/frontend/src/lib/fireCalculator.ts
@@ -61,9 +61,15 @@ export function computeFatFIRE(fireNumber: number): number {
 }
 
 /**
- * Years to FIRE using compound growth formula
- * Formula: ln(FIRE * SWR / annualSavings + 1) / ln(1 + realReturn)
- * Accounts for existing portfolio value
+ * Years to FIRE, solving for n in the future-value equation:
+ *   P(1+r)^n + S * [((1+r)^n - 1) / r] = F
+ * where P = current portfolio, S = annual savings, r = real return, F = FIRE number.
+ *
+ * Rearranged:
+ *   (1+r)^n = (F + S/r) / (P + S/r)
+ *   n = ln((F + S/r) / (P + S/r)) / ln(1 + r)
+ *
+ * Handles edge cases: already at FIRE, zero savings, zero return, zero portfolio.
  */
 export function computeYearsToFIRE(
   fireNumber: number,
@@ -71,13 +77,26 @@ export function computeYearsToFIRE(
   realReturn: number,
   currentPortfolio = 0,
 ): number {
-  if (annualSavings <= 0 || realReturn <= 0) return Infinity
-  const target = fireNumber - currentPortfolio * Math.pow(1 + realReturn, 1)
-  if (target <= 0) return 0
-  // Future value of annuity formula solved for n
-  const fvFactor = (target * realReturn) / annualSavings + 1
-  if (fvFactor <= 0) return Infinity
-  return Math.max(0, Math.log(fvFactor) / Math.log(1 + realReturn))
+  // Already there
+  if (currentPortfolio >= fireNumber) return 0
+
+  // Zero-growth case: portfolio never grows, must reach via savings alone
+  if (realReturn <= 0) {
+    if (annualSavings <= 0) return Infinity
+    return Math.max(0, (fireNumber - currentPortfolio) / annualSavings)
+  }
+
+  // Zero-savings case: pure compounding of existing portfolio
+  if (annualSavings <= 0) {
+    if (currentPortfolio <= 0) return Infinity
+    return Math.max(0, Math.log(fireNumber / currentPortfolio) / Math.log(1 + realReturn))
+  }
+
+  // General case: both portfolio growth and ongoing savings
+  const savingsPerpetuity = annualSavings / realReturn
+  const ratio = (fireNumber + savingsPerpetuity) / (currentPortfolio + savingsPerpetuity)
+  if (ratio <= 0) return Infinity
+  return Math.max(0, Math.log(ratio) / Math.log(1 + realReturn))
 }
 
 /**


### PR DESCRIPTION
Fixes two verified calculation bugs surfaced during the calculations audit.

## 1. \`computeYearsToFIRE\` -- portfolio compounding bug

**File:** \`frontend/src/lib/fireCalculator.ts\`

The old formula treated the current portfolio as growing for exactly **1 year**, regardless of \`yearsToRetire\`:

\`\`\`typescript
const target = fireNumber - currentPortfolio * Math.pow(1 + realReturn, 1)
\`\`\`

This doesn't satisfy the underlying future-value equation. For a user with a meaningful existing portfolio (e.g., 50L today, 10L/year savings, 7% real return, 1Cr target), the bug output ~4.17 years; the correct answer is ~3.41 years. Users consistently see their "years to FIRE" **overstated**.

### Correct derivation

Solve \`P(1+r)^n + S*[((1+r)^n - 1) / r] = F\` for \`n\`:

\`\`\`
(1+r)^n = (F + S/r) / (P + S/r)
n = ln((F + S/r) / (P + S/r)) / ln(1 + r)
\`\`\`

### Tests

15 new tests in \`frontend/src/lib/__tests__/fireCalculator.test.ts\` covering:

- Already at FIRE (portfolio >= target)
- Zero savings (pure compounding)
- Zero return (linear savings)
- Zero portfolio (savings-only case)
- General case with both portfolio and savings
- **Regression test** that locks in the fix vs. old buggy output

## 2. Recurring \`expected_day\` -- robust to short-month clamping

**Files:** \`backend/src/ledger_sync/core/analytics_engine.py\`, \`backend/src/ledger_sync/core/_analytics_helpers.py\`

Mode-based day inference breaks for end-of-month subscriptions. A \"31st\" bill clamped to 28/30 in short months produces \`[31, 28, 31, 30, 31]\`, where \`mode()\` can pick the wrong canonical day. Occasional 1-day bank-settlement drift also pollutes the mode for mid-month bills.

### New heuristic

\`_analytics_helpers.infer_expected_day_of_month\`:

- If any observed day is >= 25: return **max** (the intended day before short-month clamping)
- Otherwise: return **median** (robust to occasional drift)

### Tests

8 new tests in \`backend/tests/unit/test_analytics_helpers.py\`:

- Late-month 31st bill with clamping
- 28th bill with Feb edge cases
- 28th bill that occasionally posts on the 1st (outlier rejection)
- Mid-month bill with weekend drift
- Single day, empty list, even-count median

## Checks

- [x] Backend: 62 tests pass (up from 54), ruff clean, mypy clean
- [x] Frontend: 49 tests pass (up from 34), tsc clean, eslint clean