### PR TITLE
fix(analytics): include subcategory in category-trends aggregation key

### DIFF
--- a/backend/src/ledger_sync/core/analytics/trends.py
+++ b/backend/src/ledger_sync/core/analytics/trends.py
@@ -21,6 +21,56 @@ from ledger_sync.db.models import (
 )
 
 
+def _cat_trend_sort_key(
+    item: tuple[tuple[str, str, str | None, str], list[float]],
+) -> tuple[str, str, str, str]:
+    """Sort key for category-trend iteration.
+
+    Tolerates ``subcategory=None`` by substituting an empty string so the
+    natural tuple ordering stays total-ordered.
+    """
+    period, cat, sub, tp = item[0]
+    return (period, cat, sub or "", tp)
+
+
+def _build_category_trend(
+    *,
+    user_id: int | None,
+    period_key: str,
+    category: str,
+    subcategory: str | None,
+    txn_type: str,
+    amounts: list[float],
+    total: float,
+    monthly_type_total: float,
+    prev_total: float | None,
+) -> CategoryTrend:
+    """Build a single CategoryTrend row from aggregated per-month data."""
+    pct = (total / monthly_type_total * 100) if monthly_type_total > 0 else 0
+    mom_change = 0.0
+    mom_change_pct = 0.0
+    if prev_total is not None and prev_total > 0:
+        mom_change = total - prev_total
+        mom_change_pct = (mom_change / prev_total) * 100
+
+    return CategoryTrend(
+        user_id=user_id,
+        period_key=period_key,
+        category=category,
+        subcategory=subcategory,
+        transaction_type=TransactionType(txn_type),
+        total_amount=Decimal(str(total)),
+        transaction_count=len(amounts),
+        avg_transaction=Decimal(str(mean(amounts))) if amounts else Decimal(0),
+        max_transaction=Decimal(str(max(amounts))) if amounts else Decimal(0),
+        min_transaction=Decimal(str(min(amounts))) if amounts else Decimal(0),
+        pct_of_monthly_total=pct,
+        mom_change=Decimal(str(mom_change)),
+        mom_change_pct=mom_change_pct,
+        last_calculated=datetime.now(UTC),
+    )
+
+
 class TrendsMixin(AnalyticsEngineBase):
     """Mixin: category trends and transfer flows persistence."""
 
@@ -28,26 +78,26 @@ class TrendsMixin(AnalyticsEngineBase):
         self,
         all_transactions: list[Transaction] | None = None,
     ) -> int:
-        """Calculate category-level trends over time."""
+        """Calculate category + subcategory trends over time.
+
+        Grouping key is ``(period, category, subcategory, type)``: previously
+        we grouped by ``(period, category, type)`` and overwrote ``subcategory``
+        with the last-seen value, which scrambled subcategory totals across
+        months (e.g. Cashbacks under the wrong subcategory heading).
+        """
         transactions = [
             t
             for t in (all_transactions or self._user_transaction_query().all())
             if t.type != TransactionType.TRANSFER
         ]
 
-        # Group by period + category + type
-        category_data: dict[tuple[str, str, str], dict[str, Any]] = defaultdict(
-            lambda: {
-                "amounts": [],
-                "subcategory": None,
-            },
+        category_data: dict[tuple[str, str, str | None, str], list[float]] = defaultdict(
+            list,
         )
-
         for txn in transactions:
             period_key = txn.date.strftime("%Y-%m")
-            key = (period_key, txn.category, txn.type.value)
-            category_data[key]["amounts"].append(float(txn.amount))
-            category_data[key]["subcategory"] = txn.subcategory
+            key = (period_key, txn.category, txn.subcategory, txn.type.value)
+            category_data[key].append(float(txn.amount))
 
         monthly_totals = _monthly_type_totals(transactions)
 
@@ -58,37 +108,26 @@ class TrendsMixin(AnalyticsEngineBase):
         self.db.execute(del_stmt)
 
         count = 0
-        prev_amounts: dict[tuple[str, str], float] = {}
+        # MoM change is computed at the (category, subcategory, type) granularity
+        # so a "Food & Dining / Groceries" row compares to the prior month's
+        # "Food & Dining / Groceries" row, not "Food & Dining / Restaurants".
+        prev_amounts: dict[tuple[str, str | None, str], float] = {}
 
-        for (period_key, category, txn_type), data in sorted(category_data.items()):
-            amounts = data["amounts"]
+        for key, amounts in sorted(category_data.items(), key=_cat_trend_sort_key):
+            period_key, category, subcategory, txn_type = key
             total = sum(amounts)
             monthly_type_total = float(monthly_totals[period_key].get(txn_type, Decimal(0)))
-            pct = (total / monthly_type_total * 100) if monthly_type_total > 0 else 0
-
-            # MoM change
-            prev_key = (category, txn_type)
-            mom_change = 0.0
-            mom_change_pct = 0.0
-            if prev_key in prev_amounts and prev_amounts[prev_key] > 0:
-                mom_change = total - prev_amounts[prev_key]
-                mom_change_pct = (mom_change / prev_amounts[prev_key]) * 100
-
-            trend = CategoryTrend(
+            prev_key = (category, subcategory, txn_type)
+            trend = _build_category_trend(
                 user_id=self.user_id,
                 period_key=period_key,
                 category=category,
-                subcategory=data["subcategory"],
-                transaction_type=TransactionType(txn_type),
-                total_amount=Decimal(str(total)),
-                transaction_count=len(amounts),
-                avg_transaction=Decimal(str(mean(amounts))) if amounts else Decimal(0),
-                max_transaction=Decimal(str(max(amounts))) if amounts else Decimal(0),
-                min_transaction=Decimal(str(min(amounts))) if amounts else Decimal(0),
-                pct_of_monthly_total=pct,
-                mom_change=Decimal(str(mom_change)),
-                mom_change_pct=mom_change_pct,
-                last_calculated=datetime.now(UTC),
+                subcategory=subcategory,
+                txn_type=txn_type,
+                amounts=amounts,
+                total=total,
+                monthly_type_total=monthly_type_total,
+                prev_total=prev_amounts.get(prev_key),
             )
             self.db.add(trend)
             count += 1


### PR DESCRIPTION
## What was broken

The \`_calculate_category_trends\` method in the analytics engine grouped transactions by \`(period, category, type)\` and overwrote the stored \`subcategory\` with whichever subcategory was seen last during the loop. So subcategory totals in the persisted \`category_trends\` table were scrambled -- a given (category, subcategory) pair's monthly sum got attributed to a different sibling subcategory of the same parent.

Discovered while end-to-end auditing the local DB against API responses. The user reported "Cashback Shared -39 instead of 0" which led me to inspect everything cashback-related.

### Concrete example: "Refund & Cashbacks" income subcategories

| Subcategory | Before fix (API) | After fix (API) | Raw DB truth |
|---|---:|---:|---:|
| Other Cashbacks | 27,773.46 | 4,086.01 | 4,086.01 |
| Credit Card Cashbacks | 18,706.72 | 43,774.29 | 43,774.29 |
| Product/Service Refunds | 6,055.92 | 4,475.80 | 4,475.80 |
| Deposit Return | (missing) | 200.00 | 200.00 |
| **TOTAL** | 52,536.10 | 52,536.10 | 52,536.10 |

The category-level total (52,536.10) was always correct, so page headline numbers weren't affected. But any drill-down chart showing **"Other Cashbacks"** vs **"Credit Card Cashbacks"** was silently displaying swapped values.

## Cause

[trends.py:47-50](backend/src/ledger_sync/core/analytics/trends.py#L47-L50) (before fix):

\`\`\`python
key = (period_key, txn.category, txn.type.value)  # no subcategory in the key
category_data[key]["amounts"].append(float(txn.amount))
category_data[key]["subcategory"] = txn.subcategory  # overwritten each iteration
\`\`\`

For a given category in a given month, the "amounts" list ended up as the full sum (correct), but the persisted row's \`subcategory\` was just whichever sub appeared last in the iteration -- that month's total got stamped with a wrong label.

## Fix

Group by \`(period, category, subcategory, type)\` so each distinct subcategory gets its own row. Extracted per-row build into \`_build_category_trend\` + \`_cat_trend_sort_key\` module-level helpers to keep the main function's cognitive complexity at 15 (the project threshold).

Row count in \`category_trends\` went from 594 → 1110 for my local DB, reflecting the split.

## Verification

Ran \`run_full_analytics\` post-fix against my local DB, then diffed every \`(category, subcategory, type)\` tuple in \`category_trends\` against the raw transactions sum:

\`\`\`
Raw tuples:    73
Trend tuples:  73
Mismatches:    0
PERFECT: every (category, subcategory, type) total matches raw.
\`\`\`

Also hit \`/api/calculations/category-breakdown?transaction_type=income\` and verified all 4 "Refund & Cashbacks" subcategories now match raw.

## Test plan

- [x] \`uv run ruff check .\` -- all checks passed
- [x] \`uv run mypy src/\` -- no issues in 101 source files
- [x] \`uv run pytest\` -- **70 passed** (unchanged)
- [x] \`pnpm run lint\` -- clean
- [x] \`pnpm run type-check\` -- clean
- [x] \`pnpm test\` -- **65 passed**
- [x] Live API: \`/api/calculations/category-breakdown\` returns corrected subcategory splits
- [x] Pre-commit hooks green

## Local DB heal needed for existing users

Users on existing deployments will need one \`POST /api/analytics/v2/refresh\` to rebuild their scrambled \`category_trends\` table from raw transactions. New uploads already auto-trigger this (PR #113).