### PR TITLE
fix(ingest): preserve transfer leg; fix refresh 500 on SQLite

### DIFF
--- a/backend/src/ledger_sync/api/analytics_v2.py
+++ b/backend/src/ledger_sync/api/analytics_v2.py
@@ -93,11 +93,13 @@ def refresh_analytics(
     """
     session = SessionLocal()
     try:
-        # Relax timeouts for the heavy analytics workload.
-        # Default connection listener sets 30 s statement / 60 s idle-in-txn,
-        # which is too tight for a full analytics recompute.
-        session.execute(text("SET statement_timeout = '120s'"))
-        session.execute(text("SET idle_in_transaction_session_timeout = '300s'"))
+        # Relax timeouts for the heavy analytics workload. The per-connection
+        # listener in db/session.py sets 30 s / 60 s by default on Postgres,
+        # which is too tight for a full recompute. These SETs are Postgres-only
+        # syntax -- SQLite has no equivalent, so we skip them for local dev.
+        if session.bind is not None and session.bind.dialect.name == "postgresql":
+            session.execute(text("SET statement_timeout = '120s'"))
+            session.execute(text("SET idle_in_transaction_session_timeout = '300s'"))
 
         engine = AnalyticsEngine(session, user_id=current_user.id)
         results = engine.run_full_analytics(source_file="manual-refresh")

--- a/backend/src/ledger_sync/core/reconciler.py
+++ b/backend/src/ledger_sync/core/reconciler.py
@@ -1,5 +1,6 @@
 """Transaction reconciliation logic."""
 
+from collections import defaultdict
 from datetime import datetime
 from typing import Any
 
@@ -594,6 +595,8 @@ class Reconciler:
         normalized_row: dict[str, Any],
         source_file: str,
         import_time: datetime,
+        *,
+        occurrence: int = 0,
     ) -> tuple[Transaction, str]:
         """Reconcile a single transfer (now stored as Transaction with type='Transfer').
 
@@ -601,6 +604,8 @@ class Reconciler:
             normalized_row: Normalized transfer data
             source_file: Source file name
             import_time: Import timestamp
+            occurrence: Zero-based index for hash disambiguation when multiple
+                genuine transfers share the same (date, amount, from, to).
 
         Returns:
             Tuple of (Transaction, action) where action is "inserted", "updated", or "skipped"
@@ -621,6 +626,7 @@ class Reconciler:
             subcategory=normalized_row["subcategory"],
             tx_type=normalized_row["type"],
             user_id=user_id,
+            occurrence=occurrence,
         )
 
         existing = self._find_existing_record(transfer_id, user_id)
@@ -705,6 +711,13 @@ class Reconciler:
         Uses batch-fetch to pre-load all existing records in one query,
         avoiding N+1 SELECT overhead on high-latency connections.
 
+        Each real transfer appears TWICE in the source export (once as
+        Transfer-In, once as Transfer-Out). Legs are counted per-direction
+        so two genuinely-identical transfers on the same day (same amount
+        between the same accounts) are NOT collapsed into one by dedup -
+        the first In + first Out pair up (occurrence 0), the second In +
+        second Out pair up (occurrence 1), and so on.
+
         Args:
             normalized_rows: List of normalized transfer data
             source_file: Source file name
@@ -721,12 +734,34 @@ class Reconciler:
 
         stats = ReconciliationStats()
 
-        # Phase 1: Pre-compute all transfer IDs and deduplicate pairs
+        # Phase 1: Pre-compute transfer IDs.
+        # Per-leg-direction occurrence counters: first leg in each direction
+        # for a given (canonical key) pairs with the first leg in the other
+        # direction to form one transfer (occurrence 0). The second in each
+        # direction form the second transfer (occurrence 1). And so on.
+        legs_seen: dict[tuple[Any, ...], dict[str, int]] = defaultdict(
+            lambda: {"in": 0, "out": 0},
+        )
         seen_in_batch: set[str] = set()
         row_ids: list[str] = []
         skip_flags: list[bool] = []
         for row in normalized_rows:
             try:
+                # Canonical key ignores leg direction: both In and Out rows
+                # for the same real transfer produce the same key.
+                canonical_key = (
+                    row["date"],
+                    row["amount"],
+                    row["from_account"],
+                    row["to_account"],
+                    row.get("category"),
+                    row.get("subcategory"),
+                    row.get("note"),
+                )
+                leg = row.get("transfer_leg", "out")
+                occurrence = legs_seen[canonical_key][leg]
+                legs_seen[canonical_key][leg] += 1
+
                 record_id = self.hasher.generate_transaction_id(
                     date=row["date"],
                     amount=row["amount"],
@@ -736,8 +771,11 @@ class Reconciler:
                     subcategory=row["subcategory"],
                     tx_type=row["type"],
                     user_id=user_id,
+                    occurrence=occurrence,
                 )
                 if record_id in seen_in_batch:
+                    # This row is the paired leg (same occurrence) of an
+                    # earlier row we already kept. Safe to skip.
                     self._log_batch_duplicate(row, record_id, is_transfer=True)
                     row_ids.append(record_id)
                     skip_flags.append(True)

--- a/backend/src/ledger_sync/ingest/normalizer.py
+++ b/backend/src/ledger_sync/ingest/normalizer.py
@@ -379,10 +379,12 @@ class DataNormalizer:
             # Money coming IN: category is source (from), account is destination (to)
             from_account = self._standardize_account(category)
             to_account = self._standardize_account(account)
+            leg = "in"
         else:
             # Money going OUT (default): account is source (from), category is destination (to)
             from_account = self._standardize_account(account)
             to_account = self._standardize_account(category)
+            leg = "out"
 
         return {
             "date": self.normalize_date(row[column_mapping["date"]]),
@@ -396,6 +398,11 @@ class DataNormalizer:
             "subcategory": subcategory,
             "note": note,
             "is_transfer": True,
+            # Preserve which LEG of the transfer pair this row represents
+            # (Transfer-In vs Transfer-Out in the source) so the reconciler
+            # can distinguish "paired leg of same transfer" from "genuine
+            # second transfer of the same amount on the same day".
+            "transfer_leg": leg,
         }
 
     def normalize_row(self, row: pd.Series, column_mapping: dict[str, str]) -> dict[str, Any]:
@@ -509,9 +516,11 @@ class DataNormalizer:
                 if TRANSFER_IN_HYPHEN in raw_type or TRANSFER_IN in raw_type:
                     from_account = self._standardize_account(category)
                     to_account = self._standardize_account(account)
+                    leg = "in"
                 else:
                     from_account = self._standardize_account(account)
                     to_account = self._standardize_account(category)
+                    leg = "out"
 
                 return {
                     "date": date,
@@ -525,6 +534,7 @@ class DataNormalizer:
                     "subcategory": subcategory,
                     "note": note,
                     "is_transfer": True,
+                    "transfer_leg": leg,
                 }
 
             return {

--- a/backend/tests/integration/test_transfer_reconciliation.py
+++ b/backend/tests/integration/test_transfer_reconciliation.py
@@ -1,0 +1,172 @@
+"""Integration tests for transfer reconciliation with pair-based dedup.
+
+Each real transfer in the source export appears twice - once as Transfer-In
+and once as Transfer-Out. The reconciler must treat those two legs as one
+transfer (dedup collapses them), but must NOT collapse two genuinely
+distinct transfers of the same amount between the same accounts on the same
+date into one record.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from ledger_sync.core.reconciler import Reconciler
+from ledger_sync.db.models import Transaction, TransactionType
+
+
+def _transfer_row(
+    *,
+    leg: str,
+    from_acct: str,
+    to_acct: str,
+    amount: Decimal,
+    date: datetime,
+) -> dict:
+    """Build a normalized transfer-row dict matching the normalizer's output shape."""
+    return {
+        "date": date,
+        "amount": amount,
+        "currency": "INR",
+        "type": TransactionType.TRANSFER,
+        "account": from_acct,
+        "from_account": from_acct,
+        "to_account": to_acct,
+        "category": f"Transfer: {from_acct} -> {to_acct}",
+        "subcategory": None,
+        "note": None,
+        "is_transfer": True,
+        "transfer_leg": leg,
+    }
+
+
+class TestTransferReconciliation:
+    """Transfer dedup semantics."""
+
+    def test_paired_legs_collapse_to_single_transfer(self, test_db_session, test_user):
+        """The In and Out rows of a single real transfer must dedupe to 1 row."""
+        reconciler = Reconciler(test_db_session, user_id=test_user.id)
+        d = datetime(2024, 11, 23, tzinfo=UTC)
+        rows = [
+            _transfer_row(
+                leg="in", from_acct="Friends", to_acct="Cashback", amount=Decimal("39.00"), date=d
+            ),
+            _transfer_row(
+                leg="out", from_acct="Friends", to_acct="Cashback", amount=Decimal("39.00"), date=d
+            ),
+        ]
+
+        stats = reconciler.reconcile_transfers_batch(rows, "test.xlsx", datetime.now(UTC))
+
+        assert stats.processed == 2
+        assert stats.inserted == 1
+        assert stats.skipped == 1
+
+        db_rows = (
+            test_db_session.query(Transaction)
+            .filter(
+                Transaction.user_id == test_user.id,
+                Transaction.type == TransactionType.TRANSFER,
+            )
+            .all()
+        )
+        assert len(db_rows) == 1
+        assert db_rows[0].from_account == "Friends"
+        assert db_rows[0].to_account == "Cashback"
+        assert db_rows[0].amount == Decimal("39.00")
+
+    def test_two_identical_transfers_same_day_both_kept(self, test_db_session, test_user):
+        """Two genuine same-day, same-amount, same-account transfers must both persist.
+
+        Regression: previously the reconciler dedupe'd by leg-less hash, so a
+        user who recorded two separate 39-rupee cashback forwards from
+        'Friends' to 'Cashback Shared' on 2024-11-23 lost one of them.
+        """
+        reconciler = Reconciler(test_db_session, user_id=test_user.id)
+        d = datetime(2024, 11, 23, tzinfo=UTC)
+        # Transfer #1 (both legs)
+        # Transfer #2 (both legs) -- identical to #1 except it's a DIFFERENT real movement
+        rows = [
+            _transfer_row(
+                leg="in", from_acct="Friends", to_acct="Cashback", amount=Decimal("39.00"), date=d
+            ),
+            _transfer_row(
+                leg="out", from_acct="Friends", to_acct="Cashback", amount=Decimal("39.00"), date=d
+            ),
+            _transfer_row(
+                leg="in", from_acct="Friends", to_acct="Cashback", amount=Decimal("39.00"), date=d
+            ),
+            _transfer_row(
+                leg="out", from_acct="Friends", to_acct="Cashback", amount=Decimal("39.00"), date=d
+            ),
+        ]
+
+        stats = reconciler.reconcile_transfers_batch(rows, "test.xlsx", datetime.now(UTC))
+
+        assert stats.processed == 4
+        assert stats.inserted == 2  # two real transfers
+        assert stats.skipped == 2  # two paired-leg duplicates
+
+        db_rows = (
+            test_db_session.query(Transaction)
+            .filter(
+                Transaction.user_id == test_user.id,
+                Transaction.type == TransactionType.TRANSFER,
+            )
+            .all()
+        )
+        assert len(db_rows) == 2
+        # Both should have the same logical shape, but different transaction_ids
+        assert db_rows[0].transaction_id != db_rows[1].transaction_id
+        for r in db_rows:
+            assert r.amount == Decimal("39.00")
+            assert r.from_account == "Friends"
+            assert r.to_account == "Cashback"
+
+    def test_interleaved_pair_legs_still_dedupe_correctly(self, test_db_session, test_user):
+        """Out-then-In leg order is valid (Money Manager can emit either order first)."""
+        reconciler = Reconciler(test_db_session, user_id=test_user.id)
+        d = datetime(2024, 11, 23, tzinfo=UTC)
+        rows = [
+            _transfer_row(
+                leg="out", from_acct="Friends", to_acct="Cashback", amount=Decimal("50.00"), date=d
+            ),
+            _transfer_row(
+                leg="in", from_acct="Friends", to_acct="Cashback", amount=Decimal("50.00"), date=d
+            ),
+        ]
+
+        stats = reconciler.reconcile_transfers_batch(rows, "test.xlsx", datetime.now(UTC))
+
+        assert stats.inserted == 1
+        assert stats.skipped == 1
+
+    def test_three_distinct_same_day_same_amount_transfers(self, test_db_session, test_user):
+        """Three genuine transfers of the same amount on the same day all persist."""
+        reconciler = Reconciler(test_db_session, user_id=test_user.id)
+        d = datetime(2025, 1, 1, tzinfo=UTC)
+        rows = [
+            _transfer_row(leg="in", from_acct="A", to_acct="B", amount=Decimal("100.00"), date=d),
+            _transfer_row(leg="out", from_acct="A", to_acct="B", amount=Decimal("100.00"), date=d),
+            _transfer_row(leg="in", from_acct="A", to_acct="B", amount=Decimal("100.00"), date=d),
+            _transfer_row(leg="out", from_acct="A", to_acct="B", amount=Decimal("100.00"), date=d),
+            _transfer_row(leg="in", from_acct="A", to_acct="B", amount=Decimal("100.00"), date=d),
+            _transfer_row(leg="out", from_acct="A", to_acct="B", amount=Decimal("100.00"), date=d),
+        ]
+
+        stats = reconciler.reconcile_transfers_batch(rows, "test.xlsx", datetime.now(UTC))
+
+        assert stats.inserted == 3
+        assert stats.skipped == 3
+
+    def test_single_unpaired_transfer_still_inserts(self, test_db_session, test_user):
+        """A transfer missing its sibling leg (data-quality edge case) still gets persisted."""
+        reconciler = Reconciler(test_db_session, user_id=test_user.id)
+        d = datetime(2025, 1, 1, tzinfo=UTC)
+        rows = [
+            _transfer_row(leg="in", from_acct="A", to_acct="B", amount=Decimal("77.00"), date=d),
+        ]
+        stats = reconciler.reconcile_transfers_batch(rows, "test.xlsx", datetime.now(UTC))
+        assert stats.inserted == 1
+        assert stats.skipped == 0


### PR DESCRIPTION
## Root-cause from a live xlsx vs DB audit

Daisy pointed out their "Cashback Shared" virtual account was showing -Rs. 39 when it should be 0. I loaded the source \`CASHBOOK_2011-08-01~2026-04-30.xlsx\` (7,459 rows) alongside the DB and traced every row, every transfer, every balance — surfaced two real bugs.

## Bug 1: transfer reconciliation silently dropped genuine duplicates

Each real transfer appears in the Money Manager export **twice** — once as \`Transfer-In\` and once as \`Transfer-Out\`. The reconciler correctly dedup'd paired legs via a set-based hash, but **couldn't distinguish "paired leg of same transfer" from "genuine second transfer of the same amount on the same day between the same accounts"**. Any user who recorded two identical transfers on one day lost one.

### Concrete evidence from the xlsx

2024-11-23 has **TWO real** Rs. 39 Friends -> Cashback Shared transfers (4 rows total in xlsx: 2 In + 2 Out). Old code stored only **1 real transfer**, leaving Cashback Shared with a Rs. 39 phantom deficit.

Full xlsx-vs-DB reconciliation:
- xlsx total transfer volume: **Rs. 13,806,658.25**
- DB before fix: **Rs. 13,804,840.25** (missing Rs. 1,818 across multiple same-day-duplicate transfers)
- DB after fix: **Rs. 13,806,658.25** (perfect match)

Cashback Shared specifically:
- xlsx balance: **0.00** (6,594.49 in - 8.81 out - 6,585.68 expenses)
- DB before fix: **-39.00** (missing one Rs. 39 inflow)
- DB after fix: **0.00** ✓

### Fix

Normalizer now emits \`transfer_leg = "in" | "out"\` on each transfer row. \`reconcile_transfers_batch\` uses per-direction occurrence counters keyed on the canonical \`(date, amount, from, to, category, subcategory, note)\` tuple — the Nth In leg pairs with the Nth Out leg for the same key, both receiving \`occurrence=N-1\`.

\`hash_id.py\` already had occurrence support built in with backward-compat guard (\`if occurrence > 0: hash_input += f"|{occurrence}"\`), so:
- First transfer of a key: \`occurrence=0\` -> old hash format -> matches existing row
- Second transfer: \`occurrence=1\` -> new hash -> fresh insert
- No migration needed; existing rows keep their IDs.

\`reconcile_transfer\` (single-row path) gains the same \`occurrence\` kwarg for API consistency.

## Bug 2: \`POST /api/analytics/v2/refresh\` returned HTTP 500 on SQLite

The endpoint unconditionally ran \`SET statement_timeout = '120s'\` — Postgres-only syntax. SQLite threw \`OperationalError: near "SET": syntax error\`, bubbled up as a 500. Daisy hit this in the browser console while testing.

The per-connection listener in \`db/session.py\` already guards with \`if is_sqlite else\`; the refresh endpoint was missing the same guard. Fixed with \`if session.bind.dialect.name == "postgresql"\`.

## Test plan

- [x] \`uv run pytest\` — **75 passed** (up from 70 with 5 new regression tests covering: paired-leg collapse, two identical same-day transfers, interleaved In/Out order, three same-day duplicates, single unpaired leg)
- [x] \`uv run ruff check .\` — clean
- [x] \`uv run mypy src/\` — clean (101 files)
- [x] \`pnpm run lint\` + \`type-check\` + \`test\` — clean (65 tests)
- [x] Live verification: imported Cashbook xlsx into local DB with fix → Cashback Shared balance = +0.00, transfer total matches xlsx exactly
- [x] Live verification: \`POST /api/analytics/v2/refresh\` with valid JWT returns HTTP 200 with success body on SQLite

## New files
- \`backend/tests/integration/test_transfer_reconciliation.py\` — 5 regression tests for transfer dedup semantics