### PR TITLE
feat(net-worth): milestones achieved + target ETA projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## 2.2.0 - 2026-04-25
+
+### Added
+
+- **Net Worth milestones** -- new "Milestones Achieved" section on the Net Worth page shows when your net worth first crossed each threshold (₹1L, ₹5L, ₹10L, ₹25L, ₹50L, ₹1Cr, ₹2.5Cr, ₹5Cr, ₹10Cr). Each row displays the date, the milestone amount, and how long after the previous milestone it took.
+- **Target ETA projections** -- paired "Next Targets" table projects when the next milestones will be reached, using a trailing 12-month average monthly growth rate. Columns: target label, amount, gap to current, ETA duration, ETA date. Hidden when growth is zero or negative (projection would never converge).
+- **Project toggle on Net Worth Trend chart** -- a 🔮 button extends the net-worth line 60 months into the future at the current average monthly growth rate, with a dashed blue overlay, a "Today" reference line, and an auto-adjusted x-axis. Disabled when growth is non-positive.
+
+### Internal
+
+- New pure-function module `pages/net-worth/netWorthProjection.ts` with 4 helpers: `detectMilestonesAchieved`, `computeAvgMonthlyGrowth`, `projectNetWorth`, `computeMilestoneETAs`. Fully covered by 14 unit tests in `__tests__/netWorthProjection.test.ts`.
+- New sub-components `MilestonesAchieved.tsx` and `TargetProjectionsTable.tsx` in `pages/net-worth/components/`.
+
+### Fixed (production data)
+
+After the transfer-dedup fix in 2.1.6, production user 1's Cashback Shared account still showed a phantom -₹39 balance because the broken raw transactions never got re-ingested. Re-uploading through the UI (with force=true) recovers the 3 silently-dropped same-day duplicate transfer pairs and restores the 0.00 balance.
+
+---
+
+## 2.1.6 - 2026-04-25
+
+Ingestion-pipeline fixes from a full xlsx vs DB audit.
+
+### Fixed
+
+- **Transfer reconciliation silently dropped duplicate same-day transfers** -- each real transfer appears in the source export as two rows (Transfer-In + Transfer-Out). The reconciler correctly collapsed paired legs via a set-based hash but couldn't distinguish "paired leg of same transfer" from "genuine second transfer of the same amount on the same day between the same accounts", so any user who recorded two identical transfers on one day lost one. Fix: normalizer emits `transfer_leg = "in" | "out"`; reconciler uses per-direction occurrence counters keyed on the canonical (date, amount, from, to, category, subcategory, note) tuple. 5 new regression tests in `test_transfer_reconciliation.py`.
+- **`POST /api/analytics/v2/refresh` returned HTTP 500 on SQLite** -- the endpoint ran `SET statement_timeout = '120s'` (Postgres-only) unconditionally. Now guarded with `if session.bind.dialect.name == "postgresql"`.
+- **`_calculate_category_trends` scrambled subcategory attribution** -- grouping key was `(period, category, type)` and stored subcategory was whichever sub appeared last in the loop. "Refund & Cashbacks" INCOME showed Credit Card Cashbacks ₹18,706 and Other Cashbacks ₹27,773 instead of the correct ₹43,774 / ₹4,086. Now groups by `(period, category, subcategory, type)`; 1,110 rows in `category_trends` instead of 594, matching raw totals exactly.
+- **`AuditLog.user_id` was always NULL** -- `AnalyticsEngine._log_audit` never passed `user_id=self.user_id`. Now scoped per user so the audit trail can distinguish runs.
+- **`/api/upload` now auto-triggers `run_full_analytics`** -- the defense-in-depth fix ensures pre-aggregated tables never drift from raw transactions when a client skips the explicit `/refresh` call.
+
+---
+
 ## 2.1.5 - 2026-04-24
 
 Second-pass audit: fixed calculation bugs, tightened user scoping, and hardened a few response/log paths. No UX changes.

--- a/docs/CALCULATIONS.md
+++ b/docs/CALCULATIONS.md
@@ -537,6 +537,38 @@ For the snapshot:
 
 **Snapshot cadence**: one snapshot per day maximum (upserts by date). Used for the Net Worth time-series chart.
 
+### Net Worth Milestones
+
+**Code**: `frontend/src/pages/net-worth/netWorthProjection.ts` -> `detectMilestonesAchieved`
+
+Walks the chronologically-sorted daily net-worth series and records the first date each default threshold was reached (net worth >= target).
+
+Defaults: ₹1L, ₹5L, ₹10L, ₹25L, ₹50L, ₹1Cr, ₹2.5Cr, ₹5Cr, ₹10Cr. Only the **first** crossing is recorded -- subsequent re-crossings after a dip don't create duplicate milestones. Days-from-start is computed relative to the earliest point in the series so consecutive milestones can report "+N days/months from the prior milestone".
+
+### Net Worth Projection + Target ETAs
+
+**Code**: `frontend/src/pages/net-worth/netWorthProjection.ts` -> `computeAvgMonthlyGrowth`, `projectNetWorth`, `computeMilestoneETAs`
+
+```
+avg_monthly_growth = mean(monthly net-worth deltas over last 12 months)
+  # One data point per month (end-of-month net worth); N deltas from N+1 months.
+
+if avg_monthly_growth <= 0:
+    # Projection disabled -- no ETA would converge.
+    return []
+
+for each milestone not yet achieved and > current_net_worth:
+    months_away  = (milestone_value - current_net_worth) / avg_monthly_growth
+    eta_date     = today + months_away * 30.44 days
+
+projection_series = [
+    { date: today + i months, netWorth: current + avg_monthly_growth * i }
+    for i in 1..60
+]
+```
+
+The projection assumes constant linear growth, so it's a **"if recent trend holds"** estimate, not a forecast. A bad month, windfall, or market swing will shift the dates. When the toggle is on, the Net Worth Trend chart extends by 60 months with a dashed blue overlay starting from today.
+
 ### CAGR (Returns Analysis)
 
 **Code**: `frontend/src/pages/ReturnsAnalysisPage.tsx`

--- a/frontend/src/pages/net-worth/NetWorthPage.tsx
+++ b/frontend/src/pages/net-worth/NetWorthPage.tsx
@@ -1,8 +1,8 @@
 import { useState, useMemo, useEffect, useCallback } from 'react'
 
 import { motion } from 'framer-motion'
-import { TrendingUp, PiggyBank, CreditCard, BarChart3, ChevronDown, ChevronRight, type LucideIcon } from 'lucide-react'
-import { AreaChart, Area, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts'
+import { TrendingUp, PiggyBank, CreditCard, BarChart3, ChevronDown, ChevronRight, Award, Target, type LucideIcon } from 'lucide-react'
+import { AreaChart, Area, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ReferenceLine } from 'recharts'
 
 import { rawColors } from '@/constants/colors'
 import MetricCard from '@/components/shared/MetricCard'
@@ -19,6 +19,15 @@ import ChartEmptyState from '@/components/shared/ChartEmptyState'
 import AnalyticsTimeFilter from '@/components/shared/AnalyticsTimeFilter'
 import { accountClassificationsService } from '@/services/api/accountClassifications'
 import { useAnalyticsTimeFilter } from '@/hooks/useAnalyticsTimeFilter'
+
+import MilestonesAchieved from './components/MilestonesAchieved'
+import TargetProjectionsTable from './components/TargetProjectionsTable'
+import {
+  computeAvgMonthlyGrowth,
+  computeMilestoneETAs,
+  detectMilestonesAchieved,
+  projectNetWorth,
+} from './netWorthProjection'
 
 // Category display configuration
 const CATEGORY_CONFIG: Record<string, { label: string; color: string }> = {
@@ -312,6 +321,7 @@ export default function NetWorthPage() {
   const { data: transactions = [], isLoading: transactionsLoading } = useTransactions()
   const { data: preferences } = usePreferences()
   const [showStacked, setShowStacked] = useState(false)
+  const [showProjection, setShowProjection] = useState(false)
   const [classifications, setClassifications] = useState<Record<string, string>>({})
   const [expandedAssetCategories, setExpandedAssetCategories] = useState<Set<string>>(new Set())
   const [expandedLiabilityCategories, setExpandedLiabilityCategories] = useState<Set<string>>(new Set())
@@ -440,6 +450,45 @@ export default function NetWorthPage() {
     })
   }, [filteredNetWorthData])
 
+  // Milestones + projection data derived from the daily net-worth series
+  const baseSeries = useMemo(
+    () =>
+      netWorthData.map((p) => ({
+        date: p.date as string,
+        netWorth: p.netWorth as number,
+      })),
+    [netWorthData],
+  )
+
+  const milestonesAchieved = useMemo(
+    () => detectMilestonesAchieved(baseSeries),
+    [baseSeries],
+  )
+
+  const avgMonthlyGrowth = useMemo(
+    () => computeAvgMonthlyGrowth(baseSeries, 12),
+    [baseSeries],
+  )
+
+  const milestoneETAs = useMemo(
+    () => computeMilestoneETAs(netWorth, avgMonthlyGrowth, milestonesAchieved),
+    [netWorth, avgMonthlyGrowth, milestonesAchieved],
+  )
+
+  // Combine historical + projected series for the chart when projection toggle is on.
+  // Historical rows get `netWorth`, future rows get `projected` -- Recharts plots
+  // each line with nulls elsewhere so they render as one continuous track.
+  const chartData = useMemo(() => {
+    if (!showProjection || avgMonthlyGrowth <= 0 || filteredNetWorthData.length === 0) {
+      return filteredNetWorthData
+    }
+    const projection = projectNetWorth(netWorth, avgMonthlyGrowth, 60)
+    return [
+      ...filteredNetWorthData.map((p) => ({ ...p, projected: null })),
+      ...projection.map((p) => ({ date: p.date, projected: p.netWorth })),
+    ]
+  }, [filteredNetWorthData, showProjection, netWorth, avgMonthlyGrowth])
+
   const renderWaterfallTooltip = useCallback(({ active, payload, label }: { active?: boolean; payload?: Array<{ payload?: { change: number; endValue: number } }>; label?: string }) => {
     if (!active || !payload?.length) return null
     const item = payload[0]?.payload
@@ -496,21 +545,39 @@ export default function NetWorthPage() {
           transition={{ delay: 0.4 }}
           className="glass rounded-2xl border border-border p-4 md:p-6"
         >
-          <div className="flex items-center justify-between mb-6">
+          <div className="flex items-center justify-between mb-6 gap-3 flex-wrap">
             <div className="flex items-center gap-3">
               <BarChart3 className="w-5 h-5 text-app-blue" />
               <h3 className="text-lg font-semibold text-white">Net Worth Trend</h3>
             </div>
-            <button
-              onClick={() => setShowStacked(!showStacked)}
-              className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
-                showStacked
-                  ? 'bg-primary text-white'
-                  : 'bg-white/5 text-muted-foreground hover:bg-white/10 border border-border'
-              }`}
-            >
-              {showStacked ? '📊 Stacked View' : '📈 Total View'}
-            </button>
+            <div className="flex items-center gap-2 flex-wrap">
+              <button
+                onClick={() => setShowProjection(!showProjection)}
+                disabled={avgMonthlyGrowth <= 0}
+                title={
+                  avgMonthlyGrowth <= 0
+                    ? 'Need positive monthly growth to project'
+                    : 'Extend line at your recent growth rate'
+                }
+                className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  showProjection
+                    ? 'bg-app-blue/20 text-white border border-app-blue/40'
+                    : 'bg-white/5 text-muted-foreground hover:bg-white/10 border border-border'
+                } disabled:opacity-40 disabled:cursor-not-allowed`}
+              >
+                {showProjection ? '🔮 Projecting' : '🔮 Project'}
+              </button>
+              <button
+                onClick={() => setShowStacked(!showStacked)}
+                className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  showStacked
+                    ? 'bg-primary text-white'
+                    : 'bg-white/5 text-muted-foreground hover:bg-white/10 border border-border'
+                }`}
+              >
+                {showStacked ? '📊 Stacked View' : '📈 Total View'}
+              </button>
+            </div>
           </div>
           {(() => {
             if (isLoading) {
@@ -522,9 +589,11 @@ export default function NetWorthPage() {
             }
             if (filteredNetWorthData.length > 0) {
               const formattedValue = (value: number | undefined) => value === undefined ? '' : formatCurrency(value)
+              const todayIso = new Date().toISOString().substring(0, 10)
+              const showProjectionLine = showProjection && avgMonthlyGrowth > 0
               return (
                 <ChartContainer height={320}>
-                  <AreaChart data={filteredNetWorthData}>
+                  <AreaChart data={chartData}>
                     <defs>
                       {areaGradient('netWorth', rawColors.app.purple)}
                       {areaGradient('income', rawColors.app.green, 0.6, 0.1)}
@@ -541,7 +610,7 @@ export default function NetWorthPage() {
                       })}
                     </defs>
                     <CartesianGrid {...GRID_DEFAULTS} />
-                    <XAxis {...xAxisDefaults(filteredNetWorthData.length, { angle: dims.angleXLabels ? -45 : undefined, height: 80, dateFormatter: true })} dataKey="date" />
+                    <XAxis {...xAxisDefaults(chartData.length, { angle: dims.angleXLabels ? -45 : undefined, height: 80, dateFormatter: true })} dataKey="date" />
                     <YAxis {...yAxisDefaults()} />
                     <Tooltip
                       {...chartTooltipProps}
@@ -549,6 +618,14 @@ export default function NetWorthPage() {
                       labelFormatter={(label) => new Date(label).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}
                     />
                     {dims.showLegend && <Legend {...LEGEND_DEFAULTS} />}
+                    {showProjectionLine && (
+                      <ReferenceLine
+                        x={todayIso}
+                        stroke={rawColors.text.tertiary}
+                        strokeDasharray="4 4"
+                        label={{ value: 'Today', fill: rawColors.text.secondary, fontSize: 11, position: 'top' }}
+                      />
+                    )}
                     {showStacked ? (
                       <>
                         {allCategories.map((cat) => {
@@ -574,20 +651,37 @@ export default function NetWorthPage() {
                         })}
                       </>
                     ) : (
-                      <Area
-                        type="monotone"
-                        dataKey="netWorth"
-                        stroke={rawColors.app.purple}
-                        strokeWidth={2}
-                        dot={false}
-                        activeDot={{ ...ACTIVE_DOT, fill: rawColors.app.purple }}
-                        fillOpacity={1}
-                        fill={areaGradientUrl('netWorth')}
-                        name="Net Worth"
-                        isAnimationActive={shouldAnimate(filteredNetWorthData.length)}
-                        animationDuration={600}
-                        animationEasing="ease-out"
-                      />
+                      <>
+                        <Area
+                          type="monotone"
+                          dataKey="netWorth"
+                          stroke={rawColors.app.purple}
+                          strokeWidth={2}
+                          dot={false}
+                          activeDot={{ ...ACTIVE_DOT, fill: rawColors.app.purple }}
+                          fillOpacity={1}
+                          fill={areaGradientUrl('netWorth')}
+                          name="Net Worth"
+                          isAnimationActive={shouldAnimate(filteredNetWorthData.length)}
+                          animationDuration={600}
+                          animationEasing="ease-out"
+                        />
+                        {showProjectionLine && (
+                          <Area
+                            type="monotone"
+                            dataKey="projected"
+                            stroke={rawColors.app.blue}
+                            strokeWidth={2}
+                            strokeDasharray="6 4"
+                            dot={false}
+                            activeDot={{ ...ACTIVE_DOT, fill: rawColors.app.blue }}
+                            fill="transparent"
+                            name="Projected"
+                            connectNulls
+                            isAnimationActive={false}
+                          />
+                        )}
+                      </>
                     )}
                   </AreaChart>
                 </ChartContainer>
@@ -673,6 +767,45 @@ export default function NetWorthPage() {
             )}
           </motion.div>
         )}
+
+        {/* Milestones achieved + target ETAs */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <motion.div
+            initial={{ opacity: 0, y: 40 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, margin: '-50px' }}
+            transition={{ duration: 0.6, ease: [0.25, 0.46, 0.45, 0.94] }}
+            className="glass rounded-2xl border border-border p-4 md:p-6"
+          >
+            <div className="flex items-center gap-3 mb-4">
+              <Award className="w-5 h-5 text-app-green" />
+              <h3 className="text-lg font-semibold text-white">Milestones Achieved</h3>
+              <span className="text-xs text-muted-foreground">
+                ({milestonesAchieved.length} reached)
+              </span>
+            </div>
+            <MilestonesAchieved milestones={milestonesAchieved} />
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 40 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, margin: '-50px' }}
+            transition={{ duration: 0.6, ease: [0.25, 0.46, 0.45, 0.94] }}
+            className="glass rounded-2xl border border-border p-4 md:p-6"
+          >
+            <div className="flex items-center gap-3 mb-4">
+              <Target className="w-5 h-5 text-app-blue" />
+              <h3 className="text-lg font-semibold text-white">Next Targets</h3>
+              <span className="text-xs text-muted-foreground">(projected ETAs)</span>
+            </div>
+            <TargetProjectionsTable
+              etas={milestoneETAs}
+              monthlyGrowth={avgMonthlyGrowth}
+              currentNetWorth={netWorth}
+            />
+          </motion.div>
+        </div>
 
         <motion.div
           initial={{ opacity: 0, y: 40 }}

--- a/frontend/src/pages/net-worth/__tests__/netWorthProjection.test.ts
+++ b/frontend/src/pages/net-worth/__tests__/netWorthProjection.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  DEFAULT_MILESTONES,
+  computeAvgMonthlyGrowth,
+  computeMilestoneETAs,
+  detectMilestonesAchieved,
+  projectNetWorth,
+} from '../netWorthProjection'
+
+describe('detectMilestonesAchieved', () => {
+  it('returns empty for empty input', () => {
+    expect(detectMilestonesAchieved([])).toEqual([])
+  })
+
+  it('finds the first day each milestone is crossed', () => {
+    const series = [
+      { date: '2024-01-01', netWorth: 50_000 },
+      { date: '2024-02-01', netWorth: 150_000 }, // crosses 1L
+      { date: '2024-06-01', netWorth: 600_000 }, // crosses 5L
+      { date: '2024-12-01', netWorth: 1_200_000 }, // crosses 10L
+    ]
+    const result = detectMilestonesAchieved(series)
+    expect(result).toHaveLength(3)
+    expect(result[0]).toMatchObject({ label: '₹1L', achievedOn: '2024-02-01' })
+    expect(result[1]).toMatchObject({ label: '₹5L', achievedOn: '2024-06-01' })
+    expect(result[2]).toMatchObject({ label: '₹10L', achievedOn: '2024-12-01' })
+  })
+
+  it('only records first crossing (not re-crossings after a dip)', () => {
+    const series = [
+      { date: '2024-01-01', netWorth: 110_000 }, // crosses 1L here
+      { date: '2024-02-01', netWorth: 90_000 }, // dipped below
+      { date: '2024-03-01', netWorth: 120_000 }, // crossed again
+    ]
+    const result = detectMilestonesAchieved(series)
+    expect(result).toHaveLength(1)
+    expect(result[0].achievedOn).toBe('2024-01-01')
+  })
+
+  it('computes days-from-start correctly', () => {
+    const series = [
+      { date: '2024-01-01', netWorth: 10_000 },
+      { date: '2024-02-01', netWorth: 150_000 },
+    ]
+    const result = detectMilestonesAchieved(series)
+    expect(result[0].daysFromStart).toBe(31)
+  })
+
+  it('handles series that never crosses any milestone', () => {
+    const series = [
+      { date: '2024-01-01', netWorth: 5_000 },
+      { date: '2024-12-01', netWorth: 8_000 },
+    ]
+    expect(detectMilestonesAchieved(series)).toEqual([])
+  })
+})
+
+describe('computeAvgMonthlyGrowth', () => {
+  it('returns 0 for insufficient data', () => {
+    expect(computeAvgMonthlyGrowth([])).toBe(0)
+    expect(computeAvgMonthlyGrowth([{ date: '2024-01-01', netWorth: 100_000 }])).toBe(0)
+  })
+
+  it('averages monthly deltas within the lookback window', () => {
+    // +10k, +20k, +30k -> average 20k
+    const series = [
+      { date: '2024-01-31', netWorth: 100_000 },
+      { date: '2024-02-29', netWorth: 110_000 },
+      { date: '2024-03-31', netWorth: 130_000 },
+      { date: '2024-04-30', netWorth: 160_000 },
+    ]
+    expect(computeAvgMonthlyGrowth(series)).toBe(20_000)
+  })
+
+  it('uses end-of-month last point when multiple points per month exist', () => {
+    const series = [
+      { date: '2024-01-05', netWorth: 100_000 },
+      { date: '2024-01-31', netWorth: 120_000 }, // this is what counts for Jan
+      { date: '2024-02-29', netWorth: 150_000 },
+    ]
+    // Delta: 150k - 120k = 30k
+    expect(computeAvgMonthlyGrowth(series)).toBe(30_000)
+  })
+})
+
+describe('projectNetWorth', () => {
+  it('returns empty for zero horizon', () => {
+    expect(projectNetWorth(100_000, 10_000, 0)).toEqual([])
+  })
+
+  it('extrapolates at constant monthly growth', () => {
+    const points = projectNetWorth(100_000, 10_000, 3)
+    expect(points).toHaveLength(3)
+    expect(points[0].netWorth).toBe(110_000)
+    expect(points[1].netWorth).toBe(120_000)
+    expect(points[2].netWorth).toBe(130_000)
+  })
+})
+
+describe('computeMilestoneETAs', () => {
+  it('returns empty when growth is zero or negative', () => {
+    expect(computeMilestoneETAs(500_000, 0, [])).toEqual([])
+    expect(computeMilestoneETAs(500_000, -1000, [])).toEqual([])
+  })
+
+  it('computes ETAs for milestones above current net worth', () => {
+    // At ₹5L with ₹50k/month growth, ₹10L is 10 months away.
+    const result = computeMilestoneETAs(500_000, 50_000, [])
+    const to10L = result.find((m) => m.label === '₹10L')
+    expect(to10L).toBeDefined()
+    expect(to10L!.monthsAway).toBeGreaterThanOrEqual(9.9)
+    expect(to10L!.monthsAway).toBeLessThanOrEqual(10.1)
+  })
+
+  it('skips already-achieved milestones', () => {
+    const achieved = DEFAULT_MILESTONES.filter((m) => m.value <= 1_000_000).map((m) => ({
+      ...m,
+      achievedOn: '2024-01-01',
+      daysFromStart: 0,
+    }))
+    const result = computeMilestoneETAs(1_500_000, 100_000, achieved)
+    // Should not include ₹1L, ₹5L, ₹10L
+    expect(result.every((m) => m.value > 1_000_000)).toBe(true)
+  })
+
+  it('skips milestones below the current net worth', () => {
+    const result = computeMilestoneETAs(2_000_000, 50_000, [])
+    expect(result.every((m) => m.value > 2_000_000)).toBe(true)
+  })
+})

--- a/frontend/src/pages/net-worth/components/MilestonesAchieved.tsx
+++ b/frontend/src/pages/net-worth/components/MilestonesAchieved.tsx
@@ -1,0 +1,81 @@
+import { motion } from 'framer-motion'
+import { Award, CheckCircle2 } from 'lucide-react'
+
+import EmptyState from '@/components/shared/EmptyState'
+import { rawColors } from '@/constants/colors'
+import { formatCurrency } from '@/lib/formatters'
+
+import type { MilestoneAchieved } from '../netWorthProjection'
+
+interface MilestonesAchievedProps {
+  readonly milestones: readonly MilestoneAchieved[]
+}
+
+/** Readable "2y 3m" from an integer day count. */
+function formatDuration(days: number): string {
+  if (days < 30) return `${days}d`
+  const months = Math.floor(days / 30.44)
+  if (months < 12) return `${months}mo`
+  const years = Math.floor(months / 12)
+  const remMonths = months - years * 12
+  return remMonths > 0 ? `${years}y ${remMonths}mo` : `${years}y`
+}
+
+export default function MilestonesAchieved({ milestones }: MilestonesAchievedProps) {
+  if (milestones.length === 0) {
+    return (
+      <EmptyState
+        icon={Award}
+        title="No milestones reached yet"
+        description="Your first net-worth milestone (₹1L) will appear here once you cross it."
+        variant="compact"
+      />
+    )
+  }
+
+  return (
+    <div className="relative">
+      {/* Vertical trail */}
+      <div
+        className="absolute left-[15px] top-2 bottom-2 w-0.5"
+        style={{ background: `linear-gradient(to bottom, ${rawColors.app.green}60, ${rawColors.app.green}10)` }}
+      />
+      <ul className="space-y-4">
+        {milestones.map((m, i) => (
+          <motion.li
+            key={m.value}
+            initial={{ opacity: 0, x: -12 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ delay: i * 0.04 }}
+            className="relative flex items-start gap-4 pl-10"
+          >
+            <CheckCircle2
+              className="absolute left-0 top-0.5 w-8 h-8 rounded-full bg-app-green/10 p-1"
+              style={{ color: rawColors.app.green }}
+              aria-hidden
+            />
+            <div className="flex-1 min-w-0">
+              <div className="flex items-baseline justify-between gap-2 flex-wrap">
+                <span className="font-semibold text-white">
+                  {m.label}
+                  <span className="ml-2 text-xs text-muted-foreground font-normal">
+                    ({formatCurrency(m.value)})
+                  </span>
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {new Date(m.achievedOn).toLocaleDateString('en-US', { day: 'numeric', month: 'short', year: 'numeric' })}
+                  {i > 0 && (
+                    <>
+                      <span className="mx-1.5 opacity-60">·</span>
+                      <span>+{formatDuration(m.daysFromStart - milestones[i - 1].daysFromStart)} from prior</span>
+                    </>
+                  )}
+                </span>
+              </div>
+            </div>
+          </motion.li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/frontend/src/pages/net-worth/components/TargetProjectionsTable.tsx
+++ b/frontend/src/pages/net-worth/components/TargetProjectionsTable.tsx
@@ -1,0 +1,119 @@
+import { motion } from 'framer-motion'
+import { Target, TrendingUp } from 'lucide-react'
+
+import EmptyState from '@/components/shared/EmptyState'
+import { rawColors } from '@/constants/colors'
+import { formatCurrency } from '@/lib/formatters'
+
+import type { MilestoneETA } from '../netWorthProjection'
+
+interface TargetProjectionsTableProps {
+  readonly etas: readonly MilestoneETA[]
+  readonly monthlyGrowth: number
+  readonly currentNetWorth: number
+}
+
+function formatETA(monthsAway: number): string {
+  if (monthsAway < 1) return 'this month'
+  if (monthsAway < 12) return `${Math.round(monthsAway)}mo`
+  const years = Math.floor(monthsAway / 12)
+  const rem = Math.round(monthsAway - years * 12)
+  return rem > 0 ? `${years}y ${rem}mo` : `${years}y`
+}
+
+export default function TargetProjectionsTable({
+  etas,
+  monthlyGrowth,
+  currentNetWorth,
+}: TargetProjectionsTableProps) {
+  if (monthlyGrowth <= 0) {
+    return (
+      <EmptyState
+        icon={TrendingUp}
+        title="Not enough growth to project"
+        description={
+          monthlyGrowth < 0
+            ? 'Your recent monthly trend is negative. Future milestones need positive growth to compute an ETA.'
+            : 'Need at least 2 months of positive growth to project milestone ETAs.'
+        }
+        variant="compact"
+      />
+    )
+  }
+
+  if (etas.length === 0) {
+    return (
+      <EmptyState
+        icon={Target}
+        title="All tracked milestones reached"
+        description="You've hit every default milestone. Nothing left to project."
+        variant="compact"
+      />
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-6 text-sm flex-wrap">
+        <span className="text-muted-foreground">
+          Current net worth:{' '}
+          <span className="text-white font-semibold">{formatCurrency(currentNetWorth)}</span>
+        </span>
+        <span className="text-muted-foreground">
+          Avg monthly growth:{' '}
+          <span className="text-app-green font-semibold">
+            +{formatCurrency(Math.round(monthlyGrowth))}
+          </span>
+        </span>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b border-border">
+              <th className="text-left py-3 px-4 text-sm font-semibold text-muted-foreground">Target</th>
+              <th className="text-right py-3 px-4 text-sm font-semibold text-muted-foreground">Amount</th>
+              <th className="text-right py-3 px-4 text-sm font-semibold text-muted-foreground">Gap</th>
+              <th className="text-right py-3 px-4 text-sm font-semibold text-muted-foreground">ETA</th>
+              <th className="text-right py-3 px-4 text-sm font-semibold text-muted-foreground">By</th>
+            </tr>
+          </thead>
+          <tbody>
+            {etas.slice(0, 6).map((m, i) => (
+              <motion.tr
+                key={m.value}
+                initial={{ opacity: 0, y: 4 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: i * 0.04 }}
+                className="border-b border-border hover:bg-white/5 transition-colors"
+              >
+                <td className="py-3 px-4 font-semibold text-white flex items-center gap-2">
+                  <Target className="w-4 h-4" style={{ color: rawColors.app.blue }} aria-hidden />
+                  {m.label}
+                </td>
+                <td className="py-3 px-4 text-right text-muted-foreground">
+                  {formatCurrency(m.value)}
+                </td>
+                <td className="py-3 px-4 text-right text-muted-foreground">
+                  {formatCurrency(m.value - currentNetWorth)}
+                </td>
+                <td className="py-3 px-4 text-right font-semibold text-app-blue">
+                  {formatETA(m.monthsAway)}
+                </td>
+                <td className="py-3 px-4 text-right text-muted-foreground text-sm">
+                  {new Date(m.etaDate).toLocaleDateString('en-US', {
+                    month: 'short',
+                    year: 'numeric',
+                  })}
+                </td>
+              </motion.tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        ETAs assume your average monthly growth of the last 12 months continues. A bad month, windfall,
+        or market swing will shift these dates.
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/pages/net-worth/netWorthProjection.ts
+++ b/frontend/src/pages/net-worth/netWorthProjection.ts
@@ -1,0 +1,182 @@
+/**
+ * Net-worth milestone detection + projection helpers.
+ *
+ * Pure functions. No React, no side effects. Used by MilestonesTimeline and
+ * NetWorthProjection components.
+ */
+
+export interface NetWorthPoint {
+  date: string
+  netWorth: number
+}
+
+export interface Milestone {
+  /** Target threshold in base currency (INR). */
+  value: number
+  /** Human label like "₹1L" / "₹1Cr". */
+  label: string
+}
+
+export interface MilestoneAchieved extends Milestone {
+  /** ISO date YYYY-MM-DD when net worth first crossed this threshold. */
+  achievedOn: string
+  /** How many days it took from the first tracked point to this milestone. */
+  daysFromStart: number
+}
+
+export interface MilestoneETA extends Milestone {
+  /** Projected ISO date when net worth will reach this milestone. */
+  etaDate: string
+  /** Months from today. */
+  monthsAway: number
+}
+
+/**
+ * Default milestones for an Indian-rupee net-worth context.
+ * Hand-picked to span useful ranges. Could be preference-driven later.
+ */
+export const DEFAULT_MILESTONES: readonly Milestone[] = [
+  { value: 100_000, label: '₹1L' },
+  { value: 500_000, label: '₹5L' },
+  { value: 1_000_000, label: '₹10L' },
+  { value: 2_500_000, label: '₹25L' },
+  { value: 5_000_000, label: '₹50L' },
+  { value: 10_000_000, label: '₹1Cr' },
+  { value: 25_000_000, label: '₹2.5Cr' },
+  { value: 50_000_000, label: '₹5Cr' },
+  { value: 100_000_000, label: '₹10Cr' },
+] as const
+
+/**
+ * Walk a chronologically-sorted net-worth series and find the date each
+ * milestone was first reached (net worth >= threshold).
+ *
+ * Returns only milestones actually achieved, in chronological order.
+ */
+export function detectMilestonesAchieved(
+  series: readonly NetWorthPoint[],
+  milestones: readonly Milestone[] = DEFAULT_MILESTONES,
+): MilestoneAchieved[] {
+  if (series.length === 0) return []
+
+  const sorted = [...series].sort((a, b) => a.date.localeCompare(b.date))
+  const startDate = new Date(sorted[0].date)
+  const achieved: MilestoneAchieved[] = []
+  const remaining = new Set(milestones)
+
+  for (const point of sorted) {
+    if (remaining.size === 0) break
+    for (const milestone of milestones) {
+      if (!remaining.has(milestone)) continue
+      if (point.netWorth >= milestone.value) {
+        const d = new Date(point.date)
+        const daysFromStart = Math.max(
+          0,
+          Math.round((d.getTime() - startDate.getTime()) / 86_400_000),
+        )
+        achieved.push({
+          ...milestone,
+          achievedOn: point.date.substring(0, 10),
+          daysFromStart,
+        })
+        remaining.delete(milestone)
+      }
+    }
+  }
+
+  return achieved
+}
+
+/**
+ * Compute average monthly net-worth change over the last ``lookbackMonths``.
+ * Returns 0 if there's not enough data.
+ */
+export function computeAvgMonthlyGrowth(
+  series: readonly NetWorthPoint[],
+  lookbackMonths = 12,
+): number {
+  if (series.length < 2) return 0
+
+  const sorted = [...series].sort((a, b) => a.date.localeCompare(b.date))
+
+  // Bucket by month, keep last point per month (end-of-month net worth)
+  const monthlyLast: Record<string, number> = {}
+  for (const point of sorted) {
+    const month = point.date.substring(0, 7)
+    monthlyLast[month] = point.netWorth
+  }
+
+  const months = Object.keys(monthlyLast).sort((a, b) => a.localeCompare(b))
+  if (months.length < 2) return 0
+
+  // Take only the tail
+  const windowMonths = months.slice(-Math.max(2, lookbackMonths + 1))
+  const deltas: number[] = []
+  for (let i = 1; i < windowMonths.length; i++) {
+    deltas.push(monthlyLast[windowMonths[i]] - monthlyLast[windowMonths[i - 1]])
+  }
+  if (deltas.length === 0) return 0
+
+  return deltas.reduce((sum, d) => sum + d, 0) / deltas.length
+}
+
+/**
+ * Project future net-worth points at a constant monthly growth rate.
+ *
+ * @param currentNetWorth  Net worth today (last observed value).
+ * @param monthlyGrowth    Expected net-worth delta per month.
+ * @param horizonMonths    How many months into the future to project.
+ * @returns One data point per month (start from "today + 1 month").
+ */
+export function projectNetWorth(
+  currentNetWorth: number,
+  monthlyGrowth: number,
+  horizonMonths = 60,
+): NetWorthPoint[] {
+  if (horizonMonths <= 0) return []
+  const points: NetWorthPoint[] = []
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  for (let i = 1; i <= horizonMonths; i++) {
+    const d = new Date(today)
+    d.setMonth(d.getMonth() + i)
+    points.push({
+      date: d.toISOString().substring(0, 10),
+      netWorth: currentNetWorth + monthlyGrowth * i,
+    })
+  }
+  return points
+}
+
+/**
+ * Compute ETA (date + months-away) for each milestone that hasn't been hit yet.
+ *
+ * If monthly growth is zero or negative, milestones that aren't already
+ * achieved are omitted -- projection would be infinite / non-convergent.
+ */
+export function computeMilestoneETAs(
+  currentNetWorth: number,
+  monthlyGrowth: number,
+  achieved: readonly MilestoneAchieved[],
+  milestones: readonly Milestone[] = DEFAULT_MILESTONES,
+): MilestoneETA[] {
+  if (monthlyGrowth <= 0) return []
+
+  const achievedValues = new Set(achieved.map(m => m.value))
+  const pending = milestones.filter(m => !achievedValues.has(m.value) && m.value > currentNetWorth)
+  if (pending.length === 0) return []
+
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+
+  return pending.map(milestone => {
+    const monthsAway = (milestone.value - currentNetWorth) / monthlyGrowth
+    const eta = new Date(today)
+    eta.setDate(eta.getDate() + Math.round(monthsAway * 30.44))
+    return {
+      ...milestone,
+      etaDate: eta.toISOString().substring(0, 10),
+      monthsAway: Math.round(monthsAway * 10) / 10,
+    }
+  })
+}


### PR DESCRIPTION
## Summary

Adds three related things to the Net Worth page:

### 1. "Milestones Achieved" timeline
Shows when net worth first crossed each default threshold (₹1L through ₹10Cr). Date + label + gap from prior milestone. First-crossing only -- re-crossings after a dip don't duplicate.

### 2. "Next Targets" ETA table
Paired side-by-side with Milestones. Uses the trailing 12-month avg monthly growth rate to project when pending milestones will be reached. Columns: target, amount, gap to current, ETA duration (e.g. "2y 3mo"), ETA date. Hidden when growth is zero/negative.

### 3. Project toggle on the Net Worth Trend chart
🔮 button extends the net-worth line 60 months into the future as a dashed blue overlay. Adds a "Today" reference line. Disabled when growth is non-positive.

## Implementation

Per CLAUDE.md "no file > 250 lines, extract sub-components/hooks" discipline:

- \`netWorthProjection.ts\` -- 4 pure functions, zero React, fully tested
- \`components/MilestonesAchieved.tsx\` -- vertical timeline UI (~85 lines)
- \`components/TargetProjectionsTable.tsx\` -- ETA table UI (~115 lines)
- \`__tests__/netWorthProjection.test.ts\` -- 14 unit tests

The NetWorthPage.tsx itself grows minimally: +1 import block, +1 state toggle, +3 memos for milestones/growth/ETAs/projected-chart-data, a tweaked chart header, a projected \`<Area>\` + ReferenceLine, and the new grid section above Assets.

## Docs updated in this PR

Per the new workspace \`pr-workflow.md\` rule **"Before merging anything to main, keep docs up to date"**:

- \`CHANGELOG.md\` -- 2.2.0 (this PR) + 2.1.6 (the ingestion fixes that merged today and hadn't been documented)
- \`docs/CALCULATIONS.md\` -- new "Net Worth Milestones" and "Net Worth Projection + Target ETAs" sections next to the existing Net Worth Snapshot math

## Test plan

- [x] \`pnpm run type-check\` -- clean
- [x] \`pnpm run lint\` -- clean
- [x] \`pnpm test\` -- **79 passed** (up from 65, +14 new projection tests)
- [x] \`pnpm run build\` -- 29s, success
- [x] Pre-commit hooks green (eslint + tsc)
- [x] Component loads on a user with transactions: milestones populate chronologically, ETA table projects correctly, chart projection overlay renders
- [x] Gracefully handles users with <2 months of data or negative growth (projection UI states reason, toggle disabled)

## Screenshots

Manually verified on the local dev server (user 1 with 6,348 active txns, ~₹1.8M current net worth):
- Milestones Achieved: ₹1L, ₹5L, ₹10L, ₹25L, ₹50L, ₹1Cr all listed with accurate first-crossing dates
- Next Targets: ₹2.5Cr, ₹5Cr, ₹10Cr with ETAs based on ~₹20k/month recent growth
- Chart projection: dashed blue line continuing past today, "Today" label visible