### PR TITLE
feat(net-worth): milestones table - Target | Status | First Reached | Stable Since | Expected to Reach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## 2.3.1 - 2026-04-25
+
+Milestones table redesigned around the question users actually ask: "have I *held* this threshold, or just touched it once?"
+
+### Changed
+
+- **[Milestones table](frontend/src/pages/net-worth/components/MilestonesTable.tsx) columns simplified to 5:** Target | Status | First Reached | Stable Since | Expected to Reach. Dropped the separate Amount column (now shown as a subline under the Target label) and the Notes column (replaced by structured date columns).
+- **Status now has 3 states** instead of 2:
+  - **Stable** (green ✓) -- crossed the threshold and never dipped below since.
+  - **Reached** (yellow ○) -- crossed once but later dipped below; still achieved, not stable.
+  - **Upcoming** (muted ⊙) -- not yet crossed.
+- **Header stats** now show Current net worth, Avg monthly growth, Stable X/N, and Reached X/N (was: Achieved X/N only).
+
+### Added
+
+- **`stableSince` field** on [`MilestoneRow`](frontend/src/pages/net-worth/netWorthProjection.ts). Computed by scanning backward for the last dip below target; returns the crossing date that stuck. `null` when the milestone is upcoming or when net worth is currently below threshold after a prior crossing. 5 new unit tests covering never-dipped, dipped-then-recovered, dipped-still-below, upcoming, and multiple-dips scenarios.
+
+---
+
 ## 2.3.0 - 2026-04-25
 
 Codebase-wide consolidation of hand-rolled UI primitives. A component-reuse audit found 35+ files re-implementing identical `<table>` + `<thead>` + `<tbody>` boilerplate and ~30 files repeating recharts config. This release ships a shared table primitive, a new radar chart wrapper, and migrates every file where the chart shape cleanly fits the existing wrappers.

--- a/docs/CALCULATIONS.md
+++ b/docs/CALCULATIONS.md
@@ -555,14 +555,32 @@ buildMilestoneRows(series, anchor, growth):
     # Defaults: ₹1L, ₹5L, ₹10L, ₹25L, ₹50L, ₹1Cr, ₹2.5Cr, ₹5Cr, ₹10Cr.
     for each default milestone:
         if ever crossed in series:
-            status = "achieved", date = crossing_date
+            status = "achieved"
+            date = first_crossing_date
+            stableSince = findStableSince(series, value, first_crossing_date)
         elif growth > 0 and value > anchor.netWorth:
             months_away = (value - anchor.netWorth) / growth
-            status = "upcoming", date = anchor.date + months_away * 30.44 days
+            status = "upcoming"
+            date = anchor.date + months_away * 30.44 days
+            stableSince = null
         else:
-            status = "upcoming", date = null  # unprojectable
+            status = "upcoming", date = null, stableSince = null
     sort rows by value ascending
+
+findStableSince(series, target, firstCrossing):
+    # Scan backward for the last index where value < target.
+    # Never dipped below -> stable since firstCrossing.
+    # Last index is the final point -> not stable (null).
+    # Otherwise -> stable since the first point after that dip that is >= target.
 ```
+
+**Three status tiers** (displayed in the Milestones table):
+
+- **Stable** -- `stableSince !== null`: crossed and never dipped back below. Green.
+- **Reached** -- `status === 'achieved' && stableSince === null`: crossed at least once but net worth is currently (or was recently) below the threshold. Yellow.
+- **Upcoming** -- `status === 'upcoming'`: not yet crossed. Muted.
+
+The "Reached but not Stable" tier exists because touching a milestone once is weaker evidence than holding it -- a user who crossed ₹10L on a bonus day and then dipped back should not be told "₹10L achieved" the same way as a user who crossed it on salary growth and held.
 
 **Chart projection overlay** (toggle-gated):
 

--- a/frontend/src/pages/net-worth/__tests__/netWorthProjection.test.ts
+++ b/frontend/src/pages/net-worth/__tests__/netWorthProjection.test.ts
@@ -83,6 +83,73 @@ describe('buildMilestoneRows', () => {
     const oneL = requireRow(rows, '₹1L')
     expect(oneL.date).toBe('2024-01-01')
   })
+
+  describe('stableSince', () => {
+    it('equals first crossing when value never dips below', () => {
+      const series = [
+        { date: '2024-01-01', netWorth: 80_000 },
+        { date: '2024-02-01', netWorth: 120_000 }, // crosses 1L
+        { date: '2024-03-01', netWorth: 150_000 }, // still above
+        { date: '2024-04-01', netWorth: 200_000 }, // still above
+      ]
+      const rows = buildMilestoneRows(series, series[3], 0)
+      const oneL = requireRow(rows, '₹1L')
+      expect(oneL.stableSince).toBe('2024-02-01')
+      expect(oneL.stableSince).toBe(oneL.date)
+    })
+
+    it('is the recovery date when value dips then recovers', () => {
+      const series = [
+        { date: '2024-01-01', netWorth: 110_000 }, // 1L crossed
+        { date: '2024-02-01', netWorth: 90_000 }, // dipped below
+        { date: '2024-03-01', netWorth: 95_000 }, // still below
+        { date: '2024-04-01', netWorth: 130_000 }, // recovered
+        { date: '2024-05-01', netWorth: 140_000 }, // stays above
+      ]
+      const rows = buildMilestoneRows(series, series[4], 0)
+      const oneL = requireRow(rows, '₹1L')
+      expect(oneL.date).toBe('2024-01-01')
+      expect(oneL.stableSince).toBe('2024-04-01')
+    })
+
+    it('is null when the milestone was crossed but anchor is currently below', () => {
+      const series = [
+        { date: '2024-01-01', netWorth: 110_000 }, // crossed
+        { date: '2024-02-01', netWorth: 90_000 }, // fell back below
+      ]
+      const rows = buildMilestoneRows(series, series[1], 0)
+      const oneL = requireRow(rows, '₹1L')
+      expect(oneL.status).toBe('achieved') // was reached once
+      expect(oneL.date).toBe('2024-01-01')
+      expect(oneL.stableSince).toBeNull()
+    })
+
+    it('is null for upcoming (not-yet-achieved) rows', () => {
+      const series = [
+        { date: '2024-01-01', netWorth: 50_000 },
+        { date: '2024-12-01', netWorth: 500_000 },
+      ]
+      const anchor = { date: '2024-12-01', netWorth: 500_000 }
+      const rows = buildMilestoneRows(series, anchor, 50_000)
+      const tenL = requireRow(rows, '₹10L')
+      expect(tenL.status).toBe('upcoming')
+      expect(tenL.stableSince).toBeNull()
+    })
+
+    it('picks the latest recovery when there are multiple dips', () => {
+      const series = [
+        { date: '2024-01-01', netWorth: 110_000 }, // crossed
+        { date: '2024-02-01', netWorth: 90_000 }, // dip 1
+        { date: '2024-03-01', netWorth: 130_000 }, // recovered
+        { date: '2024-04-01', netWorth: 85_000 }, // dip 2
+        { date: '2024-05-01', netWorth: 120_000 }, // recovered again
+        { date: '2024-06-01', netWorth: 140_000 }, // holds
+      ]
+      const rows = buildMilestoneRows(series, series[5], 0)
+      const oneL = requireRow(rows, '₹1L')
+      expect(oneL.stableSince).toBe('2024-05-01')
+    })
+  })
 })
 
 describe('computeAvgMonthlyGrowth', () => {

--- a/frontend/src/pages/net-worth/components/MilestonesTable.tsx
+++ b/frontend/src/pages/net-worth/components/MilestonesTable.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle2, Target, TrendingUp } from 'lucide-react'
+import { CheckCircle2, Circle, Target, TrendingUp } from 'lucide-react'
 
 import EmptyState from '@/components/shared/EmptyState'
 import { DataTable, type DataTableColumn } from '@/components/ui'
@@ -22,82 +22,111 @@ function formatMonthsAway(monthsAway: number): string {
   return rem > 0 ? `${years}y ${rem}mo` : `${years}y`
 }
 
-/** "Mar 2024" style */
+/** "Mar 2024" */
 function formatMonthYear(iso: string): string {
   return new Date(iso).toLocaleDateString('en-US', { month: 'short', year: 'numeric' })
 }
 
-function buildColumns(currentNetWorth: number): DataTableColumn<MilestoneRow>[] {
+function StatusCell({ row }: Readonly<{ row: MilestoneRow }>) {
+  if (row.status === 'achieved' && row.stableSince !== null) {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-app-green text-sm">
+        <CheckCircle2 className="w-4 h-4" aria-hidden />
+        Stable
+      </span>
+    )
+  }
+  if (row.status === 'achieved') {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-app-yellow text-sm">
+        <Circle className="w-4 h-4" aria-hidden />
+        Reached
+      </span>
+    )
+  }
+  return (
+    <span className="inline-flex items-center gap-1.5 text-muted-foreground text-sm">
+      <Target className="w-4 h-4" aria-hidden />
+      Upcoming
+    </span>
+  )
+}
+
+function buildColumns(): DataTableColumn<MilestoneRow>[] {
   return [
     {
       key: 'label',
       header: 'Target',
-      widthClass: 'w-24',
-      cell: (row) => <span className="font-semibold text-white">{row.label}</span>,
-    },
-    {
-      key: 'value',
-      header: 'Amount',
-      align: 'right',
-      cell: (row) => <span className="text-muted-foreground">{formatCurrency(row.value)}</span>,
+      widthClass: 'w-28',
+      cell: (row) => (
+        <div>
+          <div className="font-semibold text-white">{row.label}</div>
+          <div className="text-xs text-muted-foreground">{formatCurrency(row.value)}</div>
+        </div>
+      ),
     },
     {
       key: 'status',
       header: 'Status',
-      cell: (row) => {
-        if (row.status === 'achieved' && row.date !== null) {
-          return (
-            <span className="inline-flex items-center gap-1.5 text-app-green text-sm">
-              <CheckCircle2 className="w-4 h-4" aria-hidden />
-              Achieved
-            </span>
-          )
-        }
-        if (row.date !== null && row.distance !== null) {
-          return (
-            <span className="inline-flex items-center gap-1.5 text-app-blue text-sm">
-              <Target className="w-4 h-4" aria-hidden />
-              Upcoming
-            </span>
-          )
-        }
-        return (
-          <span className="inline-flex items-center gap-1.5 text-muted-foreground text-sm">
-            <Target className="w-4 h-4" aria-hidden />
-            Upcoming
-          </span>
-        )
-      },
+      widthClass: 'w-32',
+      cell: (row) => <StatusCell row={row} />,
     },
     {
-      key: 'when',
-      header: 'When',
+      key: 'firstReached',
+      header: 'First Reached',
       align: 'right',
+      widthClass: 'w-36',
       cell: (row) => {
-        const isAchieved = row.status === 'achieved'
-        const color = isAchieved ? rawColors.app.green : rawColors.app.blue
-        if (row.date === null) return <span className="text-muted-foreground text-sm">—</span>
+        if (row.date === null || row.status !== 'achieved') {
+          return <span className="text-muted-foreground">—</span>
+        }
         return (
-          <span className="text-sm font-semibold" style={{ color }}>
+          <span className="text-sm font-medium" style={{ color: rawColors.app.green }}>
             {formatMonthYear(row.date)}
           </span>
         )
       },
     },
     {
-      key: 'notes',
-      header: 'Notes',
+      key: 'stableSince',
+      header: 'Stable Since',
+      align: 'right',
+      widthClass: 'w-36',
+      cell: (row) => {
+        if (row.stableSince === null) {
+          if (row.status === 'achieved') {
+            return <span className="text-app-yellow text-xs">dipped below</span>
+          }
+          return <span className="text-muted-foreground">—</span>
+        }
+        return (
+          <span className="text-sm font-medium" style={{ color: rawColors.app.green }}>
+            {formatMonthYear(row.stableSince)}
+          </span>
+        )
+      },
+    },
+    {
+      key: 'expectedToReach',
+      header: 'Expected to Reach',
       align: 'right',
       cell: (row) => {
-        let notes: string
-        if (row.status === 'achieved' && row.date !== null) {
-          notes = 'Crossed'
-        } else if (row.date !== null && row.distance !== null) {
-          notes = `in ${formatMonthsAway(row.distance)} · gap ${formatCurrency(row.value - currentNetWorth)}`
-        } else {
-          notes = 'Need positive growth to project'
+        if (row.status === 'achieved') {
+          return <span className="text-muted-foreground">—</span>
         }
-        return <span className="text-muted-foreground text-xs">{notes}</span>
+        if (row.date === null || row.distance === null) {
+          return <span className="text-muted-foreground text-xs">need positive growth</span>
+        }
+        return (
+          <div className="text-right">
+            <div className="text-sm font-semibold" style={{ color: rawColors.app.blue }}>
+              {formatMonthYear(row.date)}
+            </div>
+            <div className="text-xs text-muted-foreground">
+              in {formatMonthsAway(row.distance)}
+            </div>
+          </div>
+        )
       },
     },
   ]
@@ -108,9 +137,10 @@ export default function MilestonesTable({
   currentNetWorth,
   monthlyGrowth,
 }: MilestonesTableProps) {
-  const achievedCount = rows.filter((r) => r.status === 'achieved').length
+  const stableCount = rows.filter((r) => r.stableSince !== null).length
+  const reachedCount = rows.filter((r) => r.status === 'achieved').length
   const hasGrowth = monthlyGrowth > 0
-  const columns = buildColumns(currentNetWorth)
+  const columns = buildColumns()
 
   if (rows.length === 0) {
     return (
@@ -127,7 +157,7 @@ export default function MilestonesTable({
     <div className="space-y-4">
       <div className="flex items-center gap-6 text-sm flex-wrap">
         <span className="text-muted-foreground">
-          Current net worth:{' '}
+          Current:{' '}
           <span className="text-white font-semibold">{formatCurrency(currentNetWorth)}</span>
         </span>
         <span className="text-muted-foreground">
@@ -140,9 +170,15 @@ export default function MilestonesTable({
           </span>
         </span>
         <span className="text-muted-foreground">
-          Achieved:{' '}
+          Stable:{' '}
+          <span className="text-app-green font-semibold">
+            {stableCount} / {rows.length}
+          </span>
+        </span>
+        <span className="text-muted-foreground">
+          Reached:{' '}
           <span className="text-white font-semibold">
-            {achievedCount} / {rows.length}
+            {reachedCount} / {rows.length}
           </span>
         </span>
       </div>
@@ -151,13 +187,19 @@ export default function MilestonesTable({
         columns={columns}
         rows={rows}
         rowKey={(row) => String(row.value)}
-        rowClassName={(row) => (row.status === 'achieved' ? 'opacity-95' : 'opacity-80')}
+        rowClassName={(row) => {
+          if (row.stableSince !== null) return 'opacity-100'
+          if (row.status === 'achieved') return 'opacity-85'
+          return 'opacity-75'
+        }}
         ariaLabel="Net worth milestones"
       />
 
       <p className="text-xs text-muted-foreground">
-        ETAs assume your average monthly growth over the last 12 months continues. A bad month,
-        windfall, or market swing will shift these dates.
+        <span className="text-app-green">Stable</span> means your net worth never dropped below
+        that threshold after the crossing.{' '}
+        <span className="text-app-yellow">Reached</span> means you crossed it but later dipped
+        below. ETAs assume your last 12 months of growth continues.
       </p>
     </div>
   )

--- a/frontend/src/pages/net-worth/netWorthProjection.ts
+++ b/frontend/src/pages/net-worth/netWorthProjection.ts
@@ -30,6 +30,14 @@ export interface MilestoneRow extends Milestone {
    * For 'upcoming': months away from the anchor date (can be fractional).
    */
   distance: number | null
+  /**
+   * ISO date YYYY-MM-DD from which net worth never dropped back below this
+   * milestone value. `null` when the row is upcoming, or when net worth has
+   * dipped below the threshold after the most recent crossing and is still
+   * below at the anchor. When the milestone was crossed once and never dipped,
+   * equals the `date` field.
+   */
+  stableSince: string | null
 }
 
 /**
@@ -143,13 +151,52 @@ function scanAchievements(
   return achieved
 }
 
+/**
+ * Find the date from which net worth never dropped below `target`.
+ *
+ * Scans from the end backward: finds the last index where value < target.
+ * - If no such index exists: stable since the first crossing.
+ * - If that index is the final point: not stable (still below).
+ * - Otherwise: stable since the crossing that immediately follows that dip.
+ */
+function findStableSince(
+  sortedSeries: readonly NetWorthPoint[],
+  target: number,
+  firstCrossing: string,
+): string | null {
+  if (sortedSeries.length === 0) return null
+
+  // Find last index where value is below target
+  let lastBelowIndex = -1
+  for (let i = sortedSeries.length - 1; i >= 0; i--) {
+    if (sortedSeries[i].netWorth < target) {
+      lastBelowIndex = i
+      break
+    }
+  }
+
+  // Never dipped below target -> stable from first crossing
+  if (lastBelowIndex === -1) return firstCrossing
+
+  // Currently below target -> not stable
+  if (lastBelowIndex === sortedSeries.length - 1) return null
+
+  // Stable from the first point after the last dip that's >= target
+  for (let i = lastBelowIndex + 1; i < sortedSeries.length; i++) {
+    if (sortedSeries[i].netWorth >= target) {
+      return sortedSeries[i].date.substring(0, 10)
+    }
+  }
+  return null
+}
+
 function buildUpcomingRow(
   m: Milestone,
   anchor: NetWorthPoint,
   monthlyGrowth: number,
 ): MilestoneRow {
   if (monthlyGrowth <= 0 || m.value <= anchor.netWorth) {
-    return { ...m, status: 'upcoming', date: null, distance: null }
+    return { ...m, status: 'upcoming', date: null, distance: null, stableSince: null }
   }
   const monthsAway = (m.value - anchor.netWorth) / monthlyGrowth
   const eta = new Date(anchor.date)
@@ -159,6 +206,7 @@ function buildUpcomingRow(
     status: 'upcoming',
     date: eta.toISOString().substring(0, 10),
     distance: Math.round(monthsAway * 10) / 10,
+    stableSince: null,
   }
 }
 
@@ -183,6 +231,7 @@ export function buildMilestoneRows(
       status: 'upcoming',
       date: null,
       distance: null,
+      stableSince: null,
     }))
   }
 
@@ -197,7 +246,13 @@ export function buildMilestoneRows(
         0,
         Math.round((new Date(dateStr).getTime() - startDate.getTime()) / 86_400_000),
       )
-      return { ...m, status: 'achieved', date: dateStr, distance: daysFromStart }
+      return {
+        ...m,
+        status: 'achieved',
+        date: dateStr,
+        distance: daysFromStart,
+        stableSince: findStableSince(sorted, m.value, dateStr),
+      }
     }
     return buildUpcomingRow(m, anchor, monthlyGrowth)
   })


### PR DESCRIPTION
## Summary

Redesigns the Net Worth milestones table around the question users actually ask: **"have I held this threshold, or just touched it once?"**

### New columns

| Target | Status | First Reached | Stable Since | Expected to Reach |
|---|---|---|---|---|
| ₹1L (₹100,000) | Stable | Feb 2024 | Feb 2024 | — |
| ₹10L (₹1,000,000) | Reached | Mar 2024 | dipped below | — |
| ₹25L (₹2,500,000) | Upcoming | — | — | Aug 2026 (in 1y 4mo) |

### Three status tiers

- **Stable** (green ✓) -- crossed the threshold and never dipped back below.
- **Reached** (yellow ○) -- crossed once but later dipped; still achieved, not stable.
- **Upcoming** (muted ⊙) -- not yet crossed.

### Why "Reached but not Stable" matters

Touching ₹10L on a bonus day and then dipping back is weaker evidence than crossing it on organic growth and holding. Old table said "Achieved" for both — same green checkmark, same visual weight. New table distinguishes them.

## The `stableSince` algorithm

Scans backward from the end of the series for the last point where value < target.

- **No dip found** → stable since first crossing.
- **Last dip is the final point** → not stable (currently below). `stableSince = null`, status = Reached.
- **Otherwise** → stable since the first post-dip point that recovered to ≥ threshold.

See [netWorthProjection.ts](frontend/src/pages/net-worth/netWorthProjection.ts) `findStableSince`. Covered by 5 new unit tests.

## Changed

- [`netWorthProjection.ts`](frontend/src/pages/net-worth/netWorthProjection.ts) -- added `stableSince: string | null` to `MilestoneRow`, new `findStableSince` helper, `buildMilestoneRows` wires it in.
- [`MilestonesTable.tsx`](frontend/src/pages/net-worth/components/MilestonesTable.tsx) -- rebuilt with 5 new columns. Drops Amount (now a subline under Target label) and Notes columns (replaced by structured date columns).
- [`netWorthProjection.test.ts`](frontend/src/pages/net-worth/__tests__/netWorthProjection.test.ts) -- +5 tests covering never-dipped, dipped-then-recovered, dipped-still-below, upcoming, multiple dips.
- [`CHANGELOG.md`](CHANGELOG.md) -- 2.3.1 entry.
- [`docs/CALCULATIONS.md`](docs/CALCULATIONS.md) -- updated pseudocode + 3-tier status documentation.

## Test plan

- [x] `pnpm run type-check` clean
- [x] `pnpm run lint` clean
- [x] `pnpm test` -- **93/93 pass** (88 before + 5 new stableSince tests)
- [x] `pnpm run build` clean
- [ ] Visual QA on Net Worth page: verify all 3 status tiers render correctly with real data

## Do not merge

Per the user's request -- waiting on their review before merging.