### PR TITLE
fix: earning-start-date is a view filter, not a data filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## 2.3.1 - 2026-04-26
+
+### Fixed
+
+- **Earning-start-date is now a view filter, not a data filter.** Previously, toggling "Use as analytics start" silently dropped pre-earning-start transactions from every backend query, which corrupted factual totals: Net Worth dropped (because pre-earning balance-affecting transactions vanished), account balances shrank, and historical milestone crossings disappeared. Earning-start is now applied only at the chart x-axis layer via `useAnalyticsTimeFilter`; all underlying data (account balances, totals, milestone history) is always computed from the user's full transaction history.
+  - Backend: `build_transaction_query(apply_earning_start=True)` default flipped to `False`. `_apply_date_range` in `transactions.py` no longer accepts a `user` parameter. Three analytics_v2 endpoints (`/monthly-summaries`, `/daily-summaries`, `/category-trends`) no longer clamp their period by earning-start. The `_get_earning_start_period` helper is removed (dead code).
+  - Frontend: `useTransactions` hook no longer filters by earning-start-date. `useAnalyticsTimeFilter` now applies earning-start to `dateRange.start_date` (the chart-window lower bound) via a new `clampStartToEarningStart` helper with unit tests. Net Worth milestones scan the full unfiltered history, so "First Reached" dates from before earning-start remain visible.
+  - 8 new unit tests (7 for `clampStartToEarningStart`, 1 regression for milestone preservation).
+
+---
+
 ## 2.3.0 - 2026-04-25
 
 Codebase-wide consolidation of hand-rolled UI primitives. A component-reuse audit found 35+ files re-implementing identical `<table>` + `<thead>` + `<tbody>` boilerplate and ~30 files repeating recharts config. This release ships a shared table primitive, a new radar chart wrapper, and migrates every file where the chart shape cleanly fits the existing wrappers.

--- a/backend/src/ledger_sync/api/analytics_v2.py
+++ b/backend/src/ledger_sync/api/analytics_v2.py
@@ -31,7 +31,6 @@ from ledger_sync.db.models import (
     RecurringTransaction,
     TransactionType,
     TransferFlow,
-    User,
 )
 from ledger_sync.db.session import SessionLocal
 
@@ -133,17 +132,6 @@ class ReviewAnomalyRequest(BaseModel):
     notes: str | None = None
 
 
-def _get_earning_start_period(user: User) -> str | None:
-    """Return the earning start date as a YYYY-MM period key, or None."""
-    prefs = user.preferences
-    if prefs is None:
-        return None
-    if not prefs.use_earning_start_date or not prefs.earning_start_date:
-        return None
-    # earning_start_date is YYYY-MM-DD; take first 7 chars for YYYY-MM
-    return prefs.earning_start_date[:7]
-
-
 @router.get("/monthly-summaries")
 def get_monthly_summaries(
     current_user: CurrentUser,
@@ -159,12 +147,11 @@ def get_monthly_summaries(
     - Expense breakdown (essential vs discretionary)
     - Savings metrics
     - Month-over-month changes
-    """
-    # Clamp start_period to earning start date if enabled
-    earning_period = _get_earning_start_period(current_user)
-    if earning_period:
-        start_period = max(start_period, earning_period) if start_period else earning_period
 
+    Earning-start-date is deliberately NOT applied here. This endpoint
+    returns factual monthly aggregates; view-window cropping belongs on
+    the frontend chart layer, not in the data source.
+    """
     query = (
         db.query(MonthlySummary)
         .filter(MonthlySummary.user_id == current_user.id)
@@ -231,17 +218,14 @@ def get_daily_summaries(
 
     Used by YearInReview heatmap and daily trend charts.
     Returns daily income/expense/net totals with transaction counts.
-    """
-    earning_period = _get_earning_start_period(current_user)
-    earning_date = f"{earning_period}-01" if earning_period else None
 
+    Earning-start-date is deliberately NOT applied here. View-window
+    cropping belongs on the frontend chart layer.
+    """
     query = db.query(DailySummary).filter(DailySummary.user_id == current_user.id)
 
-    effective_start = start_date
-    if earning_date:
-        effective_start = max(effective_start, earning_date) if effective_start else earning_date
-    if effective_start:
-        query = query.filter(DailySummary.date >= effective_start)
+    if start_date:
+        query = query.filter(DailySummary.date >= start_date)
     if end_date:
         query = query.filter(DailySummary.date <= end_date)
 
@@ -336,12 +320,10 @@ def get_category_trends(
     - Time series charts per category
     - Category growth/decline analysis
     - Spending pattern identification
-    """
-    # Clamp start_period to earning start date if enabled
-    earning_period = _get_earning_start_period(current_user)
-    if earning_period:
-        start_period = max(start_period, earning_period) if start_period else earning_period
 
+    Earning-start-date is deliberately NOT applied here. View-window
+    cropping belongs on the frontend chart layer.
+    """
     query = (
         db.query(CategoryTrend)
         .filter(CategoryTrend.user_id == current_user.id)

--- a/backend/src/ledger_sync/api/transactions.py
+++ b/backend/src/ledger_sync/api/transactions.py
@@ -13,8 +13,7 @@ from sqlalchemy.orm import Query as SAQuery
 from sqlalchemy.orm import Session
 
 from ledger_sync.api.deps import CurrentUser, DatabaseSession
-from ledger_sync.core.query_helpers import apply_earning_start_date as _apply_earning_start_date
-from ledger_sync.db.models import Transaction, TransactionType, User
+from ledger_sync.db.models import Transaction, TransactionType
 from ledger_sync.ingest.hash_id import TransactionHasher
 from ledger_sync.schemas.transactions import (
     TransactionCreateRequest,
@@ -186,14 +185,13 @@ def _apply_date_range(
     query: SAQuery[Transaction],
     start_date: datetime | None,
     end_date: datetime | None,
-    user: User | None = None,
 ) -> SAQuery[Transaction]:
-    """Apply date range filters (converting datetime to date).
+    """Apply explicit date-range filters to a transaction query.
 
-    When *user* is provided, clamps start_date to the earning start date preference.
+    Earning-start is deliberately NOT applied here: transactions
+    endpoints return factual raw data, and the caller supplies the
+    window it wants. View-layer clamping belongs on the client.
     """
-    if user is not None:
-        start_date = _apply_earning_start_date(user, start_date)
     if start_date:
         query = query.filter(Transaction.date >= start_date.date())
     if end_date:
@@ -229,7 +227,7 @@ async def get_transactions(
     """
     # Build query - filter by user and date range
     query = _base_transaction_query(db, current_user.id)
-    query = _apply_date_range(query, start_date, end_date, user=current_user)
+    query = _apply_date_range(query, start_date, end_date)
 
     # Get total count before pagination
     total = query.count()
@@ -260,7 +258,7 @@ async def get_all_transactions(
     response.
     """
     query = _base_transaction_query(db, current_user.id)
-    query = _apply_date_range(query, start_date, end_date, user=current_user)
+    query = _apply_date_range(query, start_date, end_date)
 
     transactions = query.order_by(Transaction.date.desc()).all()
 
@@ -330,7 +328,7 @@ async def export_transactions(
 ) -> Response:
     """Export all non-deleted transactions as CSV for the current user."""
     query = _base_transaction_query(db, current_user.id)
-    query = _apply_date_range(query, start_date, end_date, user=current_user)
+    query = _apply_date_range(query, start_date, end_date)
     transactions = query.all()
 
     output = io.StringIO()

--- a/backend/src/ledger_sync/core/query_helpers.py
+++ b/backend/src/ledger_sync/core/query_helpers.py
@@ -152,15 +152,21 @@ def build_transaction_query(
     start_date: datetime | None = None,
     end_date: datetime | None = None,
     *,
-    apply_earning_start: bool = True,
+    apply_earning_start: bool = False,
 ) -> Query[Transaction]:
     """Build a filtered ``Transaction`` query for *user*.
 
     Applies:
     * ``user_id`` filter
     * ``is_deleted = False`` filter
-    * Earning-start-date clamping (when *apply_earning_start* is True)
+    * Earning-start-date clamping (**opt-in** via *apply_earning_start=True*)
     * Optional *start_date* / *end_date* range filters
+
+    Earning-start is a *view* preference (chart x-axis lower bound),
+    not a data-boundary. Most callers want factual totals/balances across
+    the user's full history and should leave *apply_earning_start* at its
+    default of False. Pass True only when you want "show X since I started
+    earning" behavior.
 
     Returns an **un-executed** SQLAlchemy query that callers can further
     refine with extra filters, ``.subquery()``, ``.all()``, etc.

--- a/docs/CALCULATIONS.md
+++ b/docs/CALCULATIONS.md
@@ -68,6 +68,14 @@ Frontend pages call either:
 - `/api/analytics/v2/*` -- **pre-aggregated** tables (fast, used for default views)
 - `/api/calculations/*` -- medium-weight aggregations (totals, monthly breakdowns, category splits) with a fast path that reads from V2 tables when no date filter is active
 
+### Earning-Start-Date: View Filter, Not Data Filter
+
+The `earning_start_date` + `use_earning_start_date` preferences are a **chart x-axis lower bound**, not a data cutoff. Backend queries and the `useTransactions` hook do not honor them — underlying data (account balances, totals, historical milestones) is always derived from the user's full transaction history.
+
+The clamp is applied only at the view layer in `frontend/src/hooks/useAnalyticsTimeFilter.ts` via `clampStartToEarningStart`, which raises the chart window's `start_date` to the earning date when the preference is active. Consumers that compute historical facts (e.g. "when did I first cross ₹1L?") must scan the full unfiltered series, not the chart-windowed slice.
+
+If you need "data since I started earning" semantics for a specific query, call `build_transaction_query(..., apply_earning_start=True)` explicitly — it's opt-in, never implicit.
+
 ---
 
 ## Upload & Reconciliation

--- a/frontend/src/hooks/__tests__/useAnalyticsTimeFilter.test.ts
+++ b/frontend/src/hooks/__tests__/useAnalyticsTimeFilter.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { clampStartToEarningStart } from '../useAnalyticsTimeFilter'
+
+describe('clampStartToEarningStart', () => {
+  it('returns startDate unchanged when useEarningStartDate is false', () => {
+    expect(clampStartToEarningStart('2024-05-01', '2024-02-01', false)).toBe('2024-05-01')
+    expect(clampStartToEarningStart(null, '2024-02-01', false)).toBeNull()
+  })
+
+  it('returns startDate unchanged when earningStartDate is null', () => {
+    expect(clampStartToEarningStart('2024-05-01', null, true)).toBe('2024-05-01')
+    expect(clampStartToEarningStart(null, null, true)).toBeNull()
+  })
+
+  it('returns the earning date when startDate is null and preference is active', () => {
+    expect(clampStartToEarningStart(null, '2024-02-01', true)).toBe('2024-02-01')
+  })
+
+  it('clamps up when startDate is before the earning date', () => {
+    expect(clampStartToEarningStart('2024-01-15', '2024-02-01', true)).toBe('2024-02-01')
+    expect(clampStartToEarningStart('2023-06-01', '2024-02-01', true)).toBe('2024-02-01')
+  })
+
+  it('leaves startDate alone when it is already after the earning date', () => {
+    expect(clampStartToEarningStart('2024-03-15', '2024-02-01', true)).toBe('2024-03-15')
+    expect(clampStartToEarningStart('2025-01-01', '2024-02-01', true)).toBe('2025-01-01')
+  })
+
+  it('treats an equal start as "after" (no clamp needed)', () => {
+    expect(clampStartToEarningStart('2024-02-01', '2024-02-01', true)).toBe('2024-02-01')
+  })
+
+  it('truncates earning date with time component to YYYY-MM-DD', () => {
+    expect(clampStartToEarningStart(null, '2024-02-01T00:00:00Z', true)).toBe('2024-02-01')
+  })
+})

--- a/frontend/src/hooks/api/useTransactions.ts
+++ b/frontend/src/hooks/api/useTransactions.ts
@@ -3,7 +3,6 @@ import { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 
 import { transactionsService, type TransactionFilters } from '@/services/api/transactions'
-import { usePreferencesStore } from '@/store/preferencesStore'
 
 import { usePreferences } from './usePreferences'
 
@@ -27,18 +26,16 @@ function parseExcludedAccounts(raw: string[] | string | undefined): Set<string> 
 }
 
 /**
- * Check whether a date string represents a valid date (YYYY-MM-DD or similar).
+ * Fetch the user's transactions.
+ *
+ * Filters applied here are *account-level* data filters (excluded accounts).
+ * Earning-start-date is a **view** preference (chart x-axis lower bound) and
+ * is intentionally NOT applied here -- consumers that need view-window
+ * cropping should apply it at the chart/series level (see
+ * `useAnalyticsTimeFilter`).
  */
-function isValidDateString(s: string | null | undefined): s is string {
-  if (!s || typeof s !== 'string') return false
-  const d = new Date(s)
-  return !Number.isNaN(d.getTime())
-}
-
 export function useTransactions(filters?: TransactionFilters) {
   const { data: preferences } = usePreferences()
-  const earningStartDate = usePreferencesStore((s) => s.earningStartDate)
-  const useEarningStartDate = usePreferencesStore((s) => s.useEarningStartDate)
 
   const query = useQuery({
     queryKey: ['transactions', filters],
@@ -54,25 +51,15 @@ export function useTransactions(filters?: TransactionFilters) {
     [preferences?.excluded_accounts],
   )
 
-  // Resolve the effective earning start date cutoff (if enabled and valid)
-  const earningCutoff = useMemo(() => {
-    if (!useEarningStartDate || !isValidDateString(earningStartDate)) return null
-    // Normalize to YYYY-MM-DD for string comparison with tx.date
-    return earningStartDate.substring(0, 10)
-  }, [useEarningStartDate, earningStartDate])
-
   const filteredData = useMemo(() => {
     if (!query.data) return query.data
-    if (excludedAccounts.size === 0 && !earningCutoff) return query.data
+    if (excludedAccounts.size === 0) return query.data
     return query.data.filter((tx) => {
-      // Exclude transactions from excluded accounts
       const account = tx.account?.toLowerCase()
       if (account && excludedAccounts.has(account)) return false
-      // Exclude transactions before the earning start date
-      if (earningCutoff && tx.date < earningCutoff) return false
       return true
     })
-  }, [query.data, excludedAccounts, earningCutoff])
+  }, [query.data, excludedAccounts])
 
   return {
     ...query,

--- a/frontend/src/hooks/useAnalyticsTimeFilter.ts
+++ b/frontend/src/hooks/useAnalyticsTimeFilter.ts
@@ -9,6 +9,24 @@ import {
   type AnalyticsViewMode,
 } from '@/lib/dateUtils'
 
+/**
+ * Clamp a nullable start-date to the earning-start preference when active.
+ * This is the **view-layer** application of earning-start — charts visually
+ * start at the earning date; underlying data is untouched.
+ *
+ * Exported for unit testing only.
+ */
+export function clampStartToEarningStart(
+  startDate: string | null,
+  earningStartDate: string | null,
+  useEarningStartDate: boolean,
+): string | null {
+  if (!useEarningStartDate || !earningStartDate) return startDate
+  const cutoff = earningStartDate.substring(0, 10)
+  if (!startDate) return cutoff
+  return startDate < cutoff ? cutoff : startDate
+}
+
 interface UseAnalyticsTimeFilterOptions {
   defaultViewMode?: AnalyticsViewMode
   availableModes?: AnalyticsViewMode[]
@@ -32,6 +50,8 @@ export function useAnalyticsTimeFilter(
   const { data: preferences } = usePreferences()
   const fiscalYearStartMonth = preferences?.fiscal_year_start_month || 4
   const { displayPreferences } = usePreferencesStore()
+  const earningStartDate = usePreferencesStore((s) => s.earningStartDate)
+  const useEarningStartDate = usePreferencesStore((s) => s.useEarningStartDate)
 
   const defaultMode =
     options?.defaultViewMode ??
@@ -42,24 +62,41 @@ export function useAnalyticsTimeFilter(
   const [currentMonth, setCurrentMonth] = useState(getCurrentMonth())
   const [currentFY, setCurrentFY] = useState(getCurrentFY(fiscalYearStartMonth))
 
-  const dateRange = useMemo(
-    () =>
-      getAnalyticsDateRange(
-        viewMode,
-        currentYear,
-        currentMonth,
-        currentFY,
-        fiscalYearStartMonth,
+  const dateRange = useMemo(() => {
+    const raw = getAnalyticsDateRange(
+      viewMode,
+      currentYear,
+      currentMonth,
+      currentFY,
+      fiscalYearStartMonth,
+    )
+    return {
+      ...raw,
+      start_date: clampStartToEarningStart(
+        raw.start_date,
+        earningStartDate,
+        useEarningStartDate,
       ),
-    [viewMode, currentYear, currentMonth, currentFY, fiscalYearStartMonth],
-  )
+    }
+  }, [
+    viewMode,
+    currentYear,
+    currentMonth,
+    currentFY,
+    fiscalYearStartMonth,
+    earningStartDate,
+    useEarningStartDate,
+  ])
 
   const dataDateRange = useMemo(() => {
     if (!transactions || transactions.length === 0)
       return { minDate: undefined, maxDate: undefined }
     const dates = transactions.map((t) => t.date.substring(0, 10)).sort((a, b) => a.localeCompare(b))
-    return { minDate: dates[0], maxDate: dates.at(-1) }
-  }, [transactions])
+    const rawMin = dates[0]
+    const clampedMin =
+      clampStartToEarningStart(rawMin, earningStartDate, useEarningStartDate) ?? rawMin
+    return { minDate: clampedMin, maxDate: dates.at(-1) }
+  }, [transactions, earningStartDate, useEarningStartDate])
 
   const timeFilterProps = {
     viewMode,

--- a/frontend/src/pages/net-worth/NetWorthPage.tsx
+++ b/frontend/src/pages/net-worth/NetWorthPage.tsx
@@ -462,6 +462,19 @@ export default function NetWorthPage() {
     [filteredNetWorthData],
   )
 
+  // Milestones scan the FULL history (unfiltered) so "First Reached"
+  // stays a historical fact, not a window-bound observation. Anchor
+  // + growth still come from the filtered chart window so the
+  // projection line remains self-consistent with what the user sees.
+  const fullSeries: NetWorthPoint[] = useMemo(
+    () =>
+      netWorthData.map((p) => ({
+        date: p.date as string,
+        netWorth: p.netWorth as number,
+      })),
+    [netWorthData],
+  )
+
   const anchor: NetWorthPoint | null = useMemo(
     () => (chartSeries.length > 0 ? chartSeries[chartSeries.length - 1] : null),
     [chartSeries],
@@ -473,8 +486,8 @@ export default function NetWorthPage() {
   )
 
   const milestoneRows = useMemo(
-    () => buildMilestoneRows(chartSeries, anchor, avgMonthlyGrowth),
-    [chartSeries, anchor, avgMonthlyGrowth],
+    () => buildMilestoneRows(fullSeries, anchor, avgMonthlyGrowth),
+    [fullSeries, anchor, avgMonthlyGrowth],
   )
 
   /**

--- a/frontend/src/pages/net-worth/__tests__/netWorthProjection.test.ts
+++ b/frontend/src/pages/net-worth/__tests__/netWorthProjection.test.ts
@@ -83,6 +83,27 @@ describe('buildMilestoneRows', () => {
     const oneL = requireRow(rows, '₹1L')
     expect(oneL.date).toBe('2024-01-01')
   })
+
+  it('preserves milestones crossed before any view/earning-start cutoff', () => {
+    // The caller is expected to pass the FULL history (not a view-filtered
+    // slice) so historical crossings remain visible even after the user
+    // sets an earning-start preference that would otherwise hide them.
+    const fullHistory = [
+      { date: '2023-06-01', netWorth: 150_000 }, // crossed ₹1L in 2023
+      { date: '2023-12-01', netWorth: 400_000 },
+      { date: '2024-06-01', netWorth: 700_000 }, // crossed ₹5L in 2024
+    ]
+    const anchor = { date: '2024-06-01', netWorth: 700_000 }
+    const rows = buildMilestoneRows(fullHistory, anchor, 50_000)
+
+    const oneL = requireRow(rows, '₹1L')
+    expect(oneL.status).toBe('achieved')
+    expect(oneL.date).toBe('2023-06-01')
+
+    const fiveL = requireRow(rows, '₹5L')
+    expect(fiveL.status).toBe('achieved')
+    expect(fiveL.date).toBe('2024-06-01')
+  })
 })
 
 describe('computeAvgMonthlyGrowth', () => {


### PR DESCRIPTION
## The bug

Toggling "Use as analytics start" with a date like `2024-02-01` made the Net Worth chart drop to zero on that date. Account balances shrank. Historical milestones vanished.

**Root cause:** the preference was implemented as a **data filter** (drop all pre-earning-start transactions from every query) when it should have been a **view filter** (x-axis lower bound for charts). Both backend (`build_transaction_query` + v2 endpoints) and frontend (`useTransactions`) silently filtered, so every consumer -- including balance totals and historical scans -- saw a truncated history.

The cumulative net worth algorithm runs `cumNW = 0` starting from the first observed transaction, so dropping pre-earning-start transactions reset the chart to zero on the earning date.

## The fix

**Backend (stop filtering):**
- `build_transaction_query(apply_earning_start=True)` default flipped to **`False`**. Opt-in now, not opt-out. Any internal caller can still request clamping explicitly.
- `_apply_date_range` in `transactions.py` no longer takes/honors a `user` parameter. Transactions endpoints return raw data.
- `analytics_v2` endpoints (`/monthly-summaries`, `/daily-summaries`, `/category-trends`) stop clamping `start_period` by earning-start. `_get_earning_start_period` helper removed (dead code).

**Frontend (apply only at view layer):**
- `useTransactions` hook no longer filters by earning-start-date. Only excluded-accounts filtering remains.
- `useAnalyticsTimeFilter` now applies earning-start to `dateRange.start_date` via a new pure helper `clampStartToEarningStart`. This is the one place where the preference takes effect -- charts using the shared time filter visually start at the earning date.
- `NetWorthPage` milestones now scan the full unfiltered history (`fullSeries`) so "First Reached" stays a historical fact. Anchor/growth still come from the filtered chart window for self-consistency with the projection line.

## Why this is the right shape

Earning-start semantically means "hide pre-this-date on my charts." It doesn't mean "pretend those transactions don't exist" -- the user's ₹5L in savings from 2023 is still real money, and their milestone crossings are still historical facts. Making it a view filter matches the preference's label ("Use as **analytics start**") and stops corrupting factual totals.

## Verified working

- `pnpm run check`: all 96 frontend tests + 75 backend tests pass
- 8 new tests (7 `clampStartToEarningStart` unit tests + 1 regression for milestone preservation across earning-start boundary)
- Type-check + lint clean
- Build clean (25.38s)

## Do not merge

You said not until you say so. Reviewing the PR + manually verifying the Net Worth chart with earning-start toggled are the final checks.