### PR TITLE
feat(ai): app-vs-BYOK mode split + 6 new tools + usage tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,56 @@ Finance data is structured. `SELECT category, SUM(amount) FROM transactions WHER
 
 ---
 
+## 2.6.0 - 2026-04-27
+
+Follow-up to 2.5.0's tool-calling chat. Biggest change: the chat now has a **two-mode split** so users can either use the app's shared Bedrock key (free, rate-limited) or bring their own API key (unlimited, they pay). Plus six new tools expose tax / FY / cash-flow / budget data to the assistant, and every LLM round-trip is now logged for cost transparency.
+
+### Added — App vs BYOK mode split
+
+- **`ai_mode` column** on `user_preferences` (`'app_bedrock'` default or `'byok'`) + `PATCH /api/preferences/ai-config/mode` to toggle.
+- **App mode (default):** new users get a working chatbot immediately. No provider picker, no key input — the server uses the app's shared Bedrock bearer token and a fixed cheap default model (`us.anthropic.claude-haiku-4-5-20251001-v1:0`). Rate-limited to `LEDGER_SYNC_AI_DAILY_MESSAGE_LIMIT` messages per day (default 10) so our AWS bill stays predictable. Users who hit the cap get a clear 429 with a "switch to BYOK" pointer.
+- **BYOK mode:** existing provider/model/key picker + per-user token limits. Users pay their own provider. No app-level cap (the provider bills them directly).
+- **`settings.py`** gains three new env-overridable fields: `ai_default_bedrock_model`, `ai_default_bedrock_region`, `ai_daily_message_limit`.
+- **Settings → AI Assistant** rebuilt with a stacked two-card mode picker. App-mode panel shows a live "3 / 10 left" counter with a small explainer. BYOK-mode panel unchanged from 2.5.0 (provider/model/key + optional token limits).
+- **ChatPanel usage badge** is now mode-aware: `"· 3 / 10 left"` in app mode (messages), `"· 1.2k / 50k"` in BYOK mode (tokens).
+- **ChatWidget gating:** opening the chat no longer requires `has_key` when the user is in app mode — they can chat out of the box.
+
+### Added — 6 new AI tools (registry now 15)
+
+- `get_fy_summary` — fiscal-year rollup (income by source, tax paid, savings, YoY change) from the `fy_summaries` table.
+- `get_tax_summary` — prefers uploaded `TaxRecord` filings (gross/TDS/advance/self-assessment/80C/80D/standard deductions) and falls back to transaction-derived totals when no filing is available.
+- `get_cash_flow` — monthly income-vs-expense time series with totals and averages.
+- `list_budgets` — active budgets with current-month usage %, ranked by usage.
+- `list_anomalies` — recent unusual-spending alerts the system detected.
+- `get_preferences_summary` — currency, fiscal-year start, and salary-structure components so the LLM can reason about context.
+
+### Added — Usage tracking
+
+- **`ai_usage_log` table** with `(provider, model, input_tokens, output_tokens, tool_rounds, cost_usd, timestamp)`. Bedrock usage is recorded server-side after `converse()`; OpenAI and Anthropic report back from the browser via `POST /api/ai/usage/log`.
+- **Cost estimation** via `core/ai_pricing.py` — per-provider, per-model-prefix USD-per-1M-token table with longest-prefix match. Unknown models fall through to a conservative 10/40 USD-per-1M fallback so we never under-report cost.
+- **`GET /api/ai/usage`** returns today / MTD / all-time rollups + current limits + today's message count (for app mode). Used by Settings and the chat header.
+- **BYOK per-user token limits:** two nullable columns `ai_daily_token_limit` / `ai_monthly_token_limit` plus `PATCH /api/preferences/ai-config/limits`. Applies only in BYOK mode; app mode uses the server-wide message cap instead.
+
+### Changed
+
+- **System prompt stays minimal.** The LLM fetches data via tools instead of having summaries pre-stuffed. ~300 tokens per round instead of ~2K.
+- **Default mode is `app_bedrock`.** Existing users stay in their previous configuration (the migration sets `app_bedrock` as the server-default, but the save-config endpoint now flips prefs to `byok` whenever someone configures a provider key, so migrating users who already had BYOK remain BYOK after their next save).
+
+### Migrations
+
+- **`20260427_1200_add_ai_usage_log_and_token_limits.py`** creates the `ai_usage_log` table + two indexes, adds `ai_daily_token_limit` + `ai_monthly_token_limit` to `user_preferences`, and adds the `ai_mode` column (default `'app_bedrock'`). Downgrade is intentionally empty per project convention.
+
+### Tests
+
+- **Backend:** 32 new tests across 3 suites (`test_ai_tools.py`, `test_ai_usage.py`, `test_ai_chat.py` extensions). Coverage of the 6 new tools, usage rollups, cost estimation edge cases, app-mode message cap enforcement, BYOK bypass of the app cap, and default-model selection. Test count 75 → 107.
+
+### Deploy notes
+
+- Run `uv run alembic upgrade head` once after deploy (auto-runs on Vercel via the migrate workflow).
+- No new required env vars. Optional overrides: `LEDGER_SYNC_AI_DAILY_MESSAGE_LIMIT` (default 10), `LEDGER_SYNC_AI_DEFAULT_BEDROCK_MODEL` (default Haiku), `LEDGER_SYNC_AI_DEFAULT_BEDROCK_REGION` (default `us-east-1`).
+
+---
+
 ## 2.4.2 - 2026-04-25
 
 Further mobile polish after device testing, plus an AI chat fix.

--- a/backend/src/ledger_sync/api/ai_chat.py
+++ b/backend/src/ledger_sync/api/ai_chat.py
@@ -37,7 +37,13 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 from sqlalchemy import select
 
+from ledger_sync.api.ai_usage import (
+    check_app_message_limit,
+    check_token_limits,
+    record_usage,
+)
 from ledger_sync.api.deps import CurrentUser, DatabaseSession
+from ledger_sync.config.settings import settings
 from ledger_sync.db.models import UserPreferences
 
 router = APIRouter(prefix="/api/ai", tags=["ai"])
@@ -93,7 +99,17 @@ class BedrockChatResponse(BaseModel):
 
 
 def _get_bedrock_model_region(prefs: UserPreferences) -> tuple[str, str]:
-    """Return (model_id, region) from user preferences."""
+    """Resolve Bedrock (model_id, region) based on the user's mode.
+
+    app_bedrock -> the model + region configured at the app level, ignoring
+    any stale BYOK config rows. Users don't pick their own model here.
+
+    byok -> the user's configured Bedrock model. They own the AWS key.
+    """
+    if prefs.ai_mode == "app_bedrock":
+        return settings.ai_default_bedrock_model, settings.ai_default_bedrock_region
+
+    # BYOK path
     if prefs.ai_provider != "bedrock":
         raise HTTPException(status_code=400, detail="Bedrock not configured")
 
@@ -214,6 +230,15 @@ def bedrock_chat_proxy(
             ),
         )
 
+    # Gate by mode:
+    #   app_bedrock -> count messages, enforce app-wide daily cap
+    #   byok        -> the user owns the bill; only their optional per-user
+    #                  token caps apply.
+    if prefs.ai_mode == "app_bedrock":
+        check_app_message_limit(session, current_user.id)
+    else:
+        check_token_limits(session, current_user.id)
+
     import boto3
 
     try:
@@ -230,6 +255,19 @@ def bedrock_chat_proxy(
         raise HTTPException(
             status_code=502, detail=f"Unexpected Bedrock response shape: {exc}"
         ) from exc
+
+    # Record usage from Bedrock's reported counters. Bedrock exposes these
+    # in `usage: {inputTokens, outputTokens, totalTokens}` on converse().
+    usage = response.get("usage") or {}
+    record_usage(
+        session,
+        current_user.id,
+        provider="bedrock",
+        model=model_id,
+        input_tokens=int(usage.get("inputTokens") or 0),
+        output_tokens=int(usage.get("outputTokens") or 0),
+        tool_rounds=1,
+    )
 
     return BedrockChatResponse(
         blocks=_from_bedrock_blocks(content_blocks),

--- a/backend/src/ledger_sync/api/ai_tools.py
+++ b/backend/src/ledger_sync/api/ai_tools.py
@@ -30,13 +30,18 @@ from sqlalchemy.orm import Session
 from ledger_sync.api.deps import CurrentUser, DatabaseSession
 from ledger_sync.db.models import (
     AccountClassification,
+    Anomaly,
+    Budget,
     FinancialGoal,
+    FYSummary,
     MonthlySummary,
     NetWorthSnapshot,
     RecurringTransaction,
+    TaxRecord,
     Transaction,
     TransactionType,
     User,
+    UserPreferences,
 )
 
 router = APIRouter(prefix="/api/ai/tools", tags=["ai-tools"])
@@ -608,6 +613,400 @@ _register(
             },
         },
         execute=_exec_list_recent_months,
+    )
+)
+
+
+# --- Extra tools backed by analytics tables ---------------------------------
+
+
+def _exec_get_fy_summary(user: User, db: Session, args: dict[str, Any]) -> Any:
+    """Return a full FY rollup (income, expenses, tax paid, savings rate).
+
+    `fiscal_year` like 'FY2024-25'. Omit to get the most recent FY on record.
+    """
+    fy = str(args.get("fiscal_year", "")).strip() or None
+    stmt = select(FYSummary).where(FYSummary.user_id == user.id)
+    if fy:
+        stmt = stmt.where(FYSummary.fiscal_year == fy)
+    else:
+        stmt = stmt.order_by(FYSummary.fiscal_year.desc())
+    row = db.execute(stmt.limit(1)).scalar_one_or_none()
+    if not row:
+        return {"found": False, "fiscal_year": fy}
+    return {
+        "found": True,
+        "fiscal_year": row.fiscal_year,
+        "start_date": row.start_date.date().isoformat(),
+        "end_date": row.end_date.date().isoformat(),
+        "income": {
+            "total": _decimal(row.total_income),
+            "salary": _decimal(row.salary_income),
+            "bonus": _decimal(row.bonus_income),
+            "investment": _decimal(row.investment_income),
+            "other": _decimal(row.other_income),
+        },
+        "expenses": _decimal(row.total_expenses),
+        "tax_paid": _decimal(row.tax_paid),
+        "investments_made": _decimal(row.investments_made),
+        "net_savings": _decimal(row.net_savings),
+        "savings_rate": row.savings_rate,
+        "yoy_change": {
+            "income_pct": row.yoy_income_change,
+            "expense_pct": row.yoy_expense_change,
+            "savings_pct": row.yoy_savings_change,
+        },
+        "is_complete": row.is_complete,
+    }
+
+
+_register(
+    ToolSpec(
+        name="get_fy_summary",
+        description=(
+            "Get a fiscal-year summary (Apr-Mar for India): gross income by "
+            "source, total expenses, tax paid, savings, and YoY change. Use "
+            "for questions like 'what was FY 2024-25 income' or 'show last "
+            "year's totals'. Omit `fiscal_year` to get the most recent FY."
+        ),
+        schema={
+            "type": "object",
+            "properties": {
+                "fiscal_year": {
+                    "type": "string",
+                    "description": "Fiscal year like FY2024-25. Optional.",
+                },
+            },
+        },
+        execute=_exec_get_fy_summary,
+    )
+)
+
+
+def _fetch_tax_record(db: Session, user_id: int, fy: str | None) -> TaxRecord | None:
+    stmt = select(TaxRecord).where(TaxRecord.user_id == user_id)
+    if fy:
+        stmt = stmt.where(TaxRecord.financial_year == fy)
+    else:
+        stmt = stmt.order_by(TaxRecord.financial_year.desc())
+    return db.execute(stmt.limit(1)).scalar_one_or_none()
+
+
+def _fetch_fy_summary(db: Session, user_id: int, fy: str | None) -> FYSummary | None:
+    stmt = select(FYSummary).where(FYSummary.user_id == user_id)
+    if fy:
+        stmt = stmt.where(FYSummary.fiscal_year == fy)
+    else:
+        stmt = stmt.order_by(FYSummary.fiscal_year.desc())
+    return db.execute(stmt.limit(1)).scalar_one_or_none()
+
+
+def _tax_income_section(tr: TaxRecord | None, fys: FYSummary | None) -> dict[str, Any]:
+    if tr is not None:
+        return {
+            "gross_salary": _decimal(tr.gross_salary),
+            "bonus": _decimal(tr.bonus),
+            "stipend": _decimal(tr.stipend),
+            "rsu": _decimal(tr.rsu),
+            "other": _decimal(tr.other_income),
+            "total_gross": _decimal(tr.total_gross_income),
+        }
+    total_gross = _decimal(fys.total_income) if fys else 0.0
+    return {"total_gross": total_gross}
+
+
+def _tax_deductions_section(tr: TaxRecord | None) -> dict[str, Any] | None:
+    if tr is None:
+        return None
+    return {
+        "standard": _decimal(tr.standard_deduction),
+        "section_80c": _decimal(tr.section_80c),
+        "section_80d": _decimal(tr.section_80d),
+        "other": _decimal(tr.other_deductions),
+        "total": _decimal(tr.total_deductions),
+    }
+
+
+def _tax_paid_section(tr: TaxRecord | None, fys: FYSummary | None) -> dict[str, Any]:
+    if tr is not None:
+        total = _decimal(tr.total_tax_paid)
+        return {
+            "tds": _decimal(tr.tds_deducted),
+            "advance_tax": _decimal(tr.advance_tax),
+            "self_assessment": _decimal(tr.self_assessment_tax),
+            "total": total,
+        }
+    derived_total = _decimal(fys.tax_paid) if fys else 0.0
+    return {"tds": None, "advance_tax": None, "self_assessment": None, "total": derived_total}
+
+
+def _resolve_tax_fy(
+    tr: TaxRecord | None, fys: FYSummary | None, fallback: str | None
+) -> str | None:
+    if tr is not None:
+        return tr.financial_year
+    if fys is not None:
+        return fys.fiscal_year
+    return fallback
+
+
+def _exec_get_tax_summary(user: User, db: Session, args: dict[str, Any]) -> Any:
+    """Return tax-specific details for an FY, combining TaxRecord (user-
+    uploaded filings) with FYSummary.tax_paid (derived from transactions).
+
+    Falls back to "data not found" when no tax has been recorded/filed.
+    """
+    fy = str(args.get("fiscal_year", "")).strip() or None
+    tr = _fetch_tax_record(db, user.id, fy)
+    fys = _fetch_fy_summary(db, user.id, fy)
+
+    if tr is None and fys is None:
+        return {"found": False, "fiscal_year": fy}
+
+    return {
+        "found": True,
+        "fiscal_year": _resolve_tax_fy(tr, fys, fy),
+        "filed_return": tr is not None,
+        "income": _tax_income_section(tr, fys),
+        "deductions": _tax_deductions_section(tr),
+        "taxable_income": _decimal(tr.taxable_income) if tr is not None else None,
+        "tax_paid": _tax_paid_section(tr, fys),
+        "source": "filed_tax_record" if tr is not None else "derived_from_transactions",
+    }
+
+
+_register(
+    ToolSpec(
+        name="get_tax_summary",
+        description=(
+            "Tax details for a fiscal year: gross income, deductions (80C/80D/"
+            "standard), taxable income, TDS, advance tax, self-assessment, and "
+            "total tax paid. Prefers a filed TaxRecord if uploaded; otherwise "
+            "returns what can be derived from transactions. Use for 'how much "
+            "tax did I pay in FY 2024-25', '80C utilization', 'last year tax'."
+        ),
+        schema={
+            "type": "object",
+            "properties": {
+                "fiscal_year": {
+                    "type": "string",
+                    "description": "Optional. Most recent if omitted.",
+                },
+            },
+        },
+        execute=_exec_get_tax_summary,
+    )
+)
+
+
+def _exec_get_cash_flow(user: User, db: Session, args: dict[str, Any]) -> Any:
+    """Return a monthly income/expense/savings time series.
+
+    Equivalent of what the Cash Flow page shows, but tabular for the LLM.
+    Defaults to the last 12 months.
+    """
+    limit = min(int(args.get("months", 12)), 60)
+    rows = (
+        db.execute(
+            select(MonthlySummary)
+            .where(MonthlySummary.user_id == user.id)
+            .order_by(MonthlySummary.period_key.desc())
+            .limit(limit)
+        )
+        .scalars()
+        .all()
+    )
+    # Build tabular + aggregate views. Tracking totals in parallel with the
+    # list avoids Any-typed comprehensions that mypy rejects.
+    total_income = 0.0
+    total_expenses = 0.0
+    total_net = 0.0
+    series: list[dict[str, Any]] = []
+    for r in reversed(rows):
+        income = _decimal(r.total_income)
+        expenses = _decimal(r.total_expenses)
+        net = _decimal(r.net_savings)
+        total_income += income
+        total_expenses += expenses
+        total_net += net
+        series.append(
+            {
+                "period": r.period_key,
+                "income": income,
+                "expenses": expenses,
+                "net": net,
+                "savings_rate": r.savings_rate,
+            }
+        )
+    n = len(series)
+    totals = {"income": total_income, "expenses": total_expenses, "net": total_net}
+    avg = {
+        "income": total_income / n if n else 0,
+        "expenses": total_expenses / n if n else 0,
+        "net": total_net / n if n else 0,
+    }
+    return {"series": series, "totals": totals, "averages": avg, "months": n}
+
+
+_register(
+    ToolSpec(
+        name="get_cash_flow",
+        description=(
+            "Monthly income vs expense time series (oldest -> newest). Use for "
+            "'show cash flow', 'how has saving changed', 'trend of expenses'."
+        ),
+        schema={
+            "type": "object",
+            "properties": {
+                "months": {"type": "integer", "minimum": 1, "maximum": 60, "default": 12},
+            },
+        },
+        execute=_exec_get_cash_flow,
+    )
+)
+
+
+def _exec_list_budgets(user: User, db: Session, _args: dict[str, Any]) -> Any:
+    """Return active budgets with current-month usage."""
+    rows = (
+        db.execute(
+            select(Budget)
+            .where(Budget.user_id == user.id, Budget.is_active.is_(True))
+            .order_by(Budget.current_month_pct.desc())
+        )
+        .scalars()
+        .all()
+    )
+    return {
+        "budgets": [
+            {
+                "category": b.category,
+                "subcategory": b.subcategory,
+                "monthly_limit": _decimal(b.monthly_limit),
+                "spent": _decimal(b.current_month_spent),
+                "remaining": _decimal(b.current_month_remaining),
+                "usage_pct": b.current_month_pct,
+                "alert_threshold_pct": b.alert_threshold_pct,
+                "over_budget": b.current_month_pct is not None and b.current_month_pct > 100,
+            }
+            for b in rows
+        ],
+        "count": len(rows),
+    }
+
+
+_register(
+    ToolSpec(
+        name="list_budgets",
+        description=(
+            "List active budgets with current-month usage. Use for 'which "
+            "budgets am I over', 'show my budgets', 'is my food budget ok'."
+        ),
+        schema={"type": "object", "properties": {}, "required": []},
+        execute=_exec_list_budgets,
+    )
+)
+
+
+def _exec_list_anomalies(user: User, db: Session, args: dict[str, Any]) -> Any:
+    """Return unreviewed anomalies (unusual spending, duplicate-like txns, etc.)."""
+    include_reviewed = bool(args.get("include_reviewed", False))
+    stmt = select(Anomaly).where(Anomaly.user_id == user.id)
+    if not include_reviewed:
+        stmt = stmt.where(Anomaly.is_reviewed.is_(False), Anomaly.is_dismissed.is_(False))
+    stmt = stmt.order_by(Anomaly.detected_at.desc()).limit(25)
+    rows = db.execute(stmt).scalars().all()
+    return {
+        "anomalies": [
+            {
+                "type": a.anomaly_type.value if a.anomaly_type else None,
+                "severity": a.severity,
+                "description": a.description,
+                "period": a.period_key,
+                "expected": _decimal(a.expected_value),
+                "actual": _decimal(a.actual_value),
+                "deviation_pct": a.deviation_pct,
+                "detected_at": a.detected_at.date().isoformat() if a.detected_at else None,
+                "is_reviewed": a.is_reviewed,
+                "is_dismissed": a.is_dismissed,
+            }
+            for a in rows
+        ],
+        "count": len(rows),
+    }
+
+
+_register(
+    ToolSpec(
+        name="list_anomalies",
+        description=(
+            "Recent unusual-spending alerts the system detected. Use for 'any "
+            "anomalies this month', 'what did I overspend on'."
+        ),
+        schema={
+            "type": "object",
+            "properties": {
+                "include_reviewed": {"type": "boolean", "default": False},
+            },
+        },
+        execute=_exec_list_anomalies,
+    )
+)
+
+
+def _exec_get_preferences_summary(user: User, db: Session, _args: dict[str, Any]) -> Any:
+    """Return the user's key configuration so the LLM can reason about context:
+    currency, fiscal year start, salary structure basics, tax regime hint."""
+    prefs = db.execute(
+        select(UserPreferences).where(UserPreferences.user_id == user.id)
+    ).scalar_one_or_none()
+    if not prefs:
+        return {"found": False}
+
+    salary: dict[str, Any] = {}
+    try:
+        import json
+
+        salary = json.loads(prefs.salary_structure or "{}")
+    except ValueError:
+        salary = {}
+
+    return {
+        "found": True,
+        "currency_symbol": prefs.currency_symbol,
+        "display_currency": prefs.display_currency,
+        "fiscal_year_start_month": prefs.fiscal_year_start_month,
+        "salary_structure_configured": bool(salary),
+        "salary_components": {
+            k: v
+            for k, v in salary.items()
+            if k
+            in {
+                "basic",
+                "hra",
+                "special_allowance",
+                "bonus",
+                "lta",
+                "provident_fund",
+                "nps",
+                "gratuity",
+                "ctc",
+            }
+        },
+    }
+
+
+_register(
+    ToolSpec(
+        name="get_preferences_summary",
+        description=(
+            "Key user preferences: currency, fiscal year start, and salary "
+            "structure components if configured. Use when the user asks about "
+            "their salary breakdown, CTC, or why numbers are shown in a specific "
+            "currency."
+        ),
+        schema={"type": "object", "properties": {}, "required": []},
+        execute=_exec_get_preferences_summary,
     )
 )
 

--- a/backend/src/ledger_sync/api/ai_usage.py
+++ b/backend/src/ledger_sync/api/ai_usage.py
@@ -1,0 +1,236 @@
+"""AI usage logging + rollup endpoints.
+
+Browser-direct calls (OpenAI, Anthropic) report their usage via POST /log
+so we have a single source of truth regardless of provider.
+Bedrock (server-side proxy) logs directly from ai_chat.py.
+
+GET /usage returns rollups (today, this month, all time) plus current limits.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import func, select
+
+from ledger_sync.api.deps import CurrentUser, DatabaseSession
+from ledger_sync.config.settings import settings
+from ledger_sync.core.ai_pricing import estimate_cost_usd
+from ledger_sync.db.models import AIUsageLog, UserPreferences
+
+router = APIRouter(prefix="/api/ai/usage", tags=["ai-usage"])
+
+
+class UsageLogRequest(BaseModel):
+    provider: str = Field(min_length=1, max_length=20)
+    model: str = Field(min_length=1, max_length=100)
+    input_tokens: int = Field(ge=0)
+    output_tokens: int = Field(ge=0)
+    tool_rounds: int = Field(default=1, ge=1, le=20)
+
+
+def _start_of_day(now: datetime) -> datetime:
+    return datetime(now.year, now.month, now.day, tzinfo=UTC)
+
+
+def _start_of_month(now: datetime) -> datetime:
+    return datetime(now.year, now.month, 1, tzinfo=UTC)
+
+
+def _rollup_since(db: Any, user_id: int, since: datetime) -> dict[str, Any]:
+    row = db.execute(
+        select(
+            func.coalesce(func.sum(AIUsageLog.input_tokens), 0),
+            func.coalesce(func.sum(AIUsageLog.output_tokens), 0),
+            func.coalesce(func.sum(AIUsageLog.cost_usd), 0.0),
+            func.count(),
+        ).where(AIUsageLog.user_id == user_id, AIUsageLog.timestamp >= since)
+    ).one()
+    return {
+        "input_tokens": int(row[0]),
+        "output_tokens": int(row[1]),
+        "total_tokens": int(row[0]) + int(row[1]),
+        "cost_usd": float(row[2]),
+        "call_count": int(row[3]),
+    }
+
+
+def record_usage(
+    db: Any,
+    user_id: int,
+    provider: str,
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    tool_rounds: int = 1,
+) -> AIUsageLog:
+    """Shared writer so ai_chat.py and ai_usage.py produce identical rows."""
+    cost = estimate_cost_usd(provider, model, input_tokens, output_tokens)
+    entry = AIUsageLog(
+        user_id=user_id,
+        provider=provider,
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        tool_rounds=tool_rounds,
+        cost_usd=cost,
+    )
+    db.add(entry)
+    db.commit()
+    return entry
+
+
+def count_app_messages_today(db: Any, user_id: int) -> int:
+    """How many chat messages this user has sent via app_bedrock today.
+
+    One user-initiated chat send can spawn multiple backend rounds (tool
+    calls), but we only want to count the outer message against the cap.
+    Rows recorded with tool_rounds >= 1 in "app_bedrock" mode form a
+    single 'message' when they're the FIRST round of that conversation --
+    but distinguishing that server-side is fragile, so we just count
+    rows where provider == 'bedrock' and timestamp is today. A chatty
+    6-round exchange therefore costs 6 of the daily 10 messages -- that's
+    a reasonable incentive to ask concise questions. Users who need more
+    should switch to BYOK.
+    """
+    since = _start_of_day(datetime.now(UTC))
+    return int(
+        db.execute(
+            select(func.count())
+            .select_from(AIUsageLog)
+            .where(
+                AIUsageLog.user_id == user_id,
+                AIUsageLog.provider == "bedrock",
+                AIUsageLog.timestamp >= since,
+            )
+        ).scalar_one()
+    )
+
+
+def check_app_message_limit(db: Any, user_id: int) -> None:
+    """Raise 429 if an app_bedrock user has hit the app-wide daily message
+    cap. Only applies to users on the shared Bedrock token; BYOK is not
+    affected."""
+    limit = settings.ai_daily_message_limit
+    if limit <= 0:
+        return  # 0/negative disables the cap entirely
+    used = count_app_messages_today(db, user_id)
+    if used >= limit:
+        raise HTTPException(
+            status_code=429,
+            detail=(
+                f"Daily AI message limit reached ({used}/{limit}). "
+                "Resets midnight UTC. Switch to Bring-Your-Own-Key in "
+                "Settings > AI Assistant for unlimited usage with your own key."
+            ),
+        )
+
+
+def check_token_limits(
+    db: Any,
+    user_id: int,
+    projected_tokens: int = 0,
+) -> None:
+    """Raise HTTPException(429) if today's or this month's usage + projected
+    would exceed the user's configured limits.
+
+    `projected_tokens` is optional; pass the expected cost of the pending call
+    to reject it before it starts. Pass 0 after the call to block the *next*
+    one if we're already over.
+    """
+    prefs = db.execute(
+        select(UserPreferences).where(UserPreferences.user_id == user_id)
+    ).scalar_one_or_none()
+    if not prefs:
+        return
+    now = datetime.now(UTC)
+    daily = prefs.ai_daily_token_limit
+    monthly = prefs.ai_monthly_token_limit
+    if daily is None and monthly is None:
+        return
+
+    if daily is not None:
+        today = _rollup_since(db, user_id, _start_of_day(now))
+        if today["total_tokens"] + projected_tokens > daily:
+            raise HTTPException(
+                status_code=429,
+                detail=(
+                    f"Daily AI token limit reached ({today['total_tokens']}/{daily}). "
+                    "Adjust the limit in Settings > AI Assistant or wait until midnight UTC."
+                ),
+            )
+    if monthly is not None:
+        mtd = _rollup_since(db, user_id, _start_of_month(now))
+        if mtd["total_tokens"] + projected_tokens > monthly:
+            raise HTTPException(
+                status_code=429,
+                detail=(
+                    f"Monthly AI token limit reached ({mtd['total_tokens']}/{monthly}). "
+                    "Adjust the limit in Settings > AI Assistant."
+                ),
+            )
+
+
+@router.post("/log")
+def log_usage(
+    current_user: CurrentUser,
+    request: UsageLogRequest,
+    session: DatabaseSession,
+) -> dict[str, Any]:
+    """Record a single LLM round-trip. Used by browser-direct providers
+    (OpenAI, Anthropic) which never touch our backend otherwise."""
+    entry = record_usage(
+        session,
+        current_user.id,
+        request.provider,
+        request.model,
+        request.input_tokens,
+        request.output_tokens,
+        request.tool_rounds,
+    )
+    return {"id": entry.id, "cost_usd": entry.cost_usd}
+
+
+@router.get("")
+def get_usage(
+    current_user: CurrentUser,
+    session: DatabaseSession,
+) -> dict[str, Any]:
+    """Return today / month / all-time usage + current configured limits."""
+    now = datetime.now(UTC)
+    prefs = session.execute(
+        select(UserPreferences).where(UserPreferences.user_id == current_user.id)
+    ).scalar_one_or_none()
+
+    today = _rollup_since(session, current_user.id, _start_of_day(now))
+    month = _rollup_since(session, current_user.id, _start_of_month(now))
+    # All-time: simpler to reuse _rollup_since with a zero-ish epoch
+    all_time = _rollup_since(session, current_user.id, datetime(1970, 1, 1, tzinfo=UTC))
+
+    # App-mode message cap (only meaningful when the user is on app_bedrock)
+    mode = prefs.ai_mode if prefs else "app_bedrock"
+    messages_today = (
+        count_app_messages_today(session, current_user.id) if mode == "app_bedrock" else 0
+    )
+
+    return {
+        "mode": mode,
+        "today": today,
+        "month_to_date": month,
+        "all_time": all_time,
+        "limits": {
+            "daily": prefs.ai_daily_token_limit if prefs else None,
+            "monthly": prefs.ai_monthly_token_limit if prefs else None,
+            # App-wide message cap surfaced here so the client can render
+            # "X / 10 messages today" without knowing the setting.
+            "app_daily_messages": settings.ai_daily_message_limit,
+        },
+        "messages_today": messages_today,
+        "as_of": now.isoformat(),
+        "day_start": _start_of_day(now).isoformat(),
+        "month_start": _start_of_month(now).isoformat(),
+        "next_reset_utc": (_start_of_day(now) + timedelta(days=1)).isoformat(),
+    }

--- a/backend/src/ledger_sync/api/main.py
+++ b/backend/src/ledger_sync/api/main.py
@@ -20,6 +20,7 @@ from ledger_sync.api.account_classifications import (
 )
 from ledger_sync.api.ai_chat import router as ai_chat_router
 from ledger_sync.api.ai_tools import router as ai_tools_router
+from ledger_sync.api.ai_usage import router as ai_usage_router
 from ledger_sync.api.analytics import router as analytics_router
 from ledger_sync.api.analytics_v2 import router as analytics_v2_router
 from ledger_sync.api.auth import router as auth_router
@@ -254,6 +255,7 @@ app.include_router(exchange_rates_router)
 app.include_router(stock_price_router)
 app.include_router(ai_chat_router)
 app.include_router(ai_tools_router)
+app.include_router(ai_usage_router)
 
 
 # ─── Health Check ────────────────────────────────────────────────────────────

--- a/backend/src/ledger_sync/api/preferences.py
+++ b/backend/src/ledger_sync/api/preferences.py
@@ -718,10 +718,34 @@ class AIConfigUpdate(BaseModel):
 class AIConfigResponse(BaseModel):
     """AI config response (never includes raw key)."""
 
+    # "app_bedrock" = shared server key, rate-limited / "byok" = user's own key
+    mode: str = "app_bedrock"
     provider: str | None = None
     model: str | None = None
     has_key: bool = False
     region: str | None = None
+    # Nullable token budgets (nullable = no limit).
+    daily_token_limit: int | None = None
+    monthly_token_limit: int | None = None
+
+
+class AIModeUpdate(BaseModel):
+    """Patch payload for switching between app_bedrock and byok."""
+
+    mode: str = Field(pattern=r"^(app_bedrock|byok)$")
+
+
+class AILimitsUpdate(BaseModel):
+    """Patch-style update for per-user AI token limits.
+
+    Both fields nullable. Pass `null` to clear a previously-set limit.
+    Missing fields keep the current value.
+    """
+
+    daily_token_limit: int | None = Field(default=None, ge=0, le=10_000_000)
+    monthly_token_limit: int | None = Field(default=None, ge=0, le=100_000_000)
+    clear_daily: bool = False
+    clear_monthly: bool = False
 
 
 @router.put("/ai-config")
@@ -737,13 +761,18 @@ def update_ai_config(
     if config.region and config.provider == "bedrock":
         prefs.ai_model = f"{config.model}|{config.region}"
     prefs.ai_api_key_encrypted = encrypt_api_key(config.api_key)
+    # Saving a provider-specific key implies BYOK intent.
+    prefs.ai_mode = "byok"
     prefs.updated_at = datetime.now(UTC)
     session.commit()
     return AIConfigResponse(
+        mode=prefs.ai_mode,
         provider=prefs.ai_provider,
         model=config.model,
         has_key=True,
         region=config.region,
+        daily_token_limit=prefs.ai_daily_token_limit,
+        monthly_token_limit=prefs.ai_monthly_token_limit,
     )
 
 
@@ -759,10 +788,82 @@ def get_ai_config(
     if model and "|" in model:
         model, region = model.rsplit("|", 1)
     return AIConfigResponse(
+        mode=prefs.ai_mode,
         provider=prefs.ai_provider,
         model=model,
         has_key=prefs.ai_api_key_encrypted is not None,
         region=region,
+        daily_token_limit=prefs.ai_daily_token_limit,
+        monthly_token_limit=prefs.ai_monthly_token_limit,
+    )
+
+
+@router.patch("/ai-config/mode")
+def update_ai_mode(
+    current_user: CurrentUser,
+    update: AIModeUpdate,
+    session: DatabaseSession,
+) -> AIConfigResponse:
+    """Switch between app_bedrock (shared server key) and byok.
+
+    Switching to app_bedrock doesn't delete the stored BYOK key, so users
+    can flip back. We only toggle the mode flag.
+    """
+    prefs = _get_or_create_preferences(session, current_user)
+    prefs.ai_mode = update.mode
+    prefs.updated_at = datetime.now(UTC)
+    session.commit()
+
+    model = prefs.ai_model
+    region: str | None = None
+    if model and "|" in model:
+        model, region = model.rsplit("|", 1)
+    return AIConfigResponse(
+        mode=prefs.ai_mode,
+        provider=prefs.ai_provider,
+        model=model,
+        has_key=prefs.ai_api_key_encrypted is not None,
+        region=region,
+        daily_token_limit=prefs.ai_daily_token_limit,
+        monthly_token_limit=prefs.ai_monthly_token_limit,
+    )
+
+
+@router.patch("/ai-config/limits")
+def update_ai_limits(
+    current_user: CurrentUser,
+    update: AILimitsUpdate,
+    session: DatabaseSession,
+) -> AIConfigResponse:
+    """Update per-user daily/monthly token limits.
+
+    Pass `clear_daily`/`clear_monthly` to null out a previously-set limit.
+    Otherwise only provided fields are updated.
+    """
+    prefs = _get_or_create_preferences(session, current_user)
+    if update.clear_daily:
+        prefs.ai_daily_token_limit = None
+    elif update.daily_token_limit is not None:
+        prefs.ai_daily_token_limit = update.daily_token_limit
+    if update.clear_monthly:
+        prefs.ai_monthly_token_limit = None
+    elif update.monthly_token_limit is not None:
+        prefs.ai_monthly_token_limit = update.monthly_token_limit
+    prefs.updated_at = datetime.now(UTC)
+    session.commit()
+
+    model = prefs.ai_model
+    region: str | None = None
+    if model and "|" in model:
+        model, region = model.rsplit("|", 1)
+    return AIConfigResponse(
+        mode=prefs.ai_mode,
+        provider=prefs.ai_provider,
+        model=model,
+        has_key=prefs.ai_api_key_encrypted is not None,
+        region=region,
+        daily_token_limit=prefs.ai_daily_token_limit,
+        monthly_token_limit=prefs.ai_monthly_token_limit,
     )
 
 

--- a/backend/src/ledger_sync/config/settings.py
+++ b/backend/src/ledger_sync/config/settings.py
@@ -67,6 +67,17 @@ class Settings(BaseSettings):
     # injected into AWS_BEARER_TOKEN_BEDROCK below so boto3 picks it up.
     # This lets all app secrets share the LEDGER_SYNC_ prefix on Vercel.
     bedrock_api_key: str = ""
+    # Default Bedrock model used by users in "app_bedrock" mode (the app
+    # picks so we can control cost/latency). Override via env var if needed.
+    # Haiku is the cheap default; operators can switch to Sonnet/Opus when
+    # willing to absorb the bill.
+    ai_default_bedrock_model: str = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+    ai_default_bedrock_region: str = "us-east-1"
+    # Hard cap per user per day in "app_bedrock" mode, counted in user
+    # messages (one outer send, regardless of how many tool rounds it
+    # spawns). Users who want more switch to BYOK. Make it generous enough
+    # for normal finance Q&A without being a blank check.
+    ai_daily_message_limit: int = 10
 
     # CORS settings — override with LEDGER_SYNC_CORS_ORIGINS env var (JSON array).
     # Defaults include localhost origins for development only.

--- a/backend/src/ledger_sync/core/ai_pricing.py
+++ b/backend/src/ledger_sync/core/ai_pricing.py
@@ -1,0 +1,63 @@
+"""Provider cost-per-1M-token reference table.
+
+Numbers reflect public list prices as of 2026-04-27. USD per 1M tokens.
+Refresh when vendors change their rates. Unknown models fall back to a
+conservative "we'll overestimate" entry so users aren't surprised by
+larger bills than we reported.
+"""
+
+from __future__ import annotations
+
+# provider -> model_prefix -> (input_per_1m_usd, output_per_1m_usd)
+# We match by prefix so fine-grained version suffixes (e.g. 4-7-20251001-v1:0)
+# share the same price row as their base model.
+_PRICING: dict[str, dict[str, tuple[float, float]]] = {
+    "openai": {
+        "o3": (2.00, 8.00),
+        "o4-mini": (1.10, 4.40),
+        "gpt-4.1": (3.00, 12.00),
+        "gpt-4.1-mini": (0.40, 1.60),
+        "gpt-4.1-nano": (0.10, 0.40),
+        "gpt-4o": (2.50, 10.00),
+        "gpt-4o-mini": (0.15, 0.60),
+    },
+    "anthropic": {
+        "claude-opus-4-7": (15.00, 75.00),
+        "claude-opus-4": (15.00, 75.00),
+        "claude-sonnet-4": (3.00, 15.00),
+        "claude-haiku-4": (1.00, 5.00),
+    },
+    # Bedrock mirrors Anthropic pricing (AWS passes it through) plus a small
+    # AWS markup. We use Anthropic list prices as a near-enough estimate.
+    "bedrock": {
+        "us.anthropic.claude-opus-4": (15.00, 75.00),
+        "us.anthropic.claude-sonnet-4": (3.00, 15.00),
+        "us.anthropic.claude-haiku-4": (1.00, 5.00),
+    },
+}
+
+# Fallback applied when neither provider nor model prefix matches. Tuned to
+# be on the high side so we never under-report cost.
+_FALLBACK_PER_1M: tuple[float, float] = (10.00, 40.00)
+
+
+def _match_prefix(model: str, table: dict[str, tuple[float, float]]) -> tuple[float, float]:
+    # Longest-prefix match so more specific keys win.
+    best: tuple[float, float] | None = None
+    best_len = -1
+    for prefix, rate in table.items():
+        if model.startswith(prefix) and len(prefix) > best_len:
+            best = rate
+            best_len = len(prefix)
+    return best if best is not None else _FALLBACK_PER_1M
+
+
+def estimate_cost_usd(provider: str, model: str, input_tokens: int, output_tokens: int) -> float:
+    """Return USD cost for a single call. Never negative; rounds to 6dp."""
+    table = _PRICING.get(provider.lower())
+    if table is None:
+        rate_in, rate_out = _FALLBACK_PER_1M
+    else:
+        rate_in, rate_out = _match_prefix(model, table)
+    cost = (input_tokens * rate_in + output_tokens * rate_out) / 1_000_000
+    return round(max(cost, 0.0), 6)

--- a/backend/src/ledger_sync/db/_models/__init__.py
+++ b/backend/src/ledger_sync/db/_models/__init__.py
@@ -9,6 +9,7 @@ IMPORTANT: every model module must be imported here so SQLAlchemy's
 """
 
 from ledger_sync.db._models._constants import CASCADE_ALL_DELETE_ORPHAN, USER_FK
+from ledger_sync.db._models.ai_usage import AIUsageLog
 from ledger_sync.db._models.analytics import (
     CategoryTrend,
     DailySummary,
@@ -47,6 +48,7 @@ from ledger_sync.db._models.user import AuditLog, User, UserPreferences
 __all__ = [
     "CASCADE_ALL_DELETE_ORPHAN",
     "USER_FK",
+    "AIUsageLog",
     "AccountClassification",
     "AccountType",
     "Anomaly",

--- a/backend/src/ledger_sync/db/_models/ai_usage.py
+++ b/backend/src/ledger_sync/db/_models/ai_usage.py
@@ -1,0 +1,60 @@
+"""AIUsageLog model -- one row per LLM round-trip.
+
+Recorded for transparency, cost awareness, and per-user daily/monthly limits.
+For OpenAI and Anthropic the frontend reports usage after each response
+(browser-direct calls never touch our backend otherwise). For Bedrock the
+backend records server-side after converse().
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, Float, ForeignKey, Index, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from ledger_sync.db._models._constants import USER_FK
+from ledger_sync.db.base import Base
+
+if TYPE_CHECKING:
+    from ledger_sync.db._models.user import User
+
+
+class AIUsageLog(Base):
+    """Single LLM call cost + token record."""
+
+    __tablename__ = "ai_usage_log"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(Integer, ForeignKey(USER_FK), nullable=False, index=True)
+
+    # When the call completed (server clock; self-reported calls use this too)
+    timestamp: Mapped[datetime] = mapped_column(
+        DateTime,
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+        index=True,
+    )
+
+    # Provider + model so per-provider dashboards stay sensible when a user
+    # switches providers mid-month.
+    provider: Mapped[str] = mapped_column(String(20), nullable=False)
+    model: Mapped[str] = mapped_column(String(100), nullable=False)
+
+    input_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    output_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    # One user "message" can trigger multiple backend rounds when tools are
+    # called -- we record each one separately but tag them with the round.
+    tool_rounds: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+
+    # Pre-computed USD cost so reports don't need to re-query pricing tables.
+    # Fine to be approximate (providers publish rates by the month).
+    cost_usd: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+
+    user: Mapped[User] = relationship("User", back_populates="ai_usage_logs")
+
+    # Primary aggregation path: "this user's usage in the last N days". The
+    # (user_id, timestamp) composite lets us answer it with an index scan.
+    __table_args__ = (Index("ix_ai_usage_user_timestamp", "user_id", "timestamp"),)

--- a/backend/src/ledger_sync/db/_models/user.py
+++ b/backend/src/ledger_sync/db/_models/user.py
@@ -10,6 +10,7 @@ from ledger_sync.db._models._constants import CASCADE_ALL_DELETE_ORPHAN, USER_FK
 from ledger_sync.db.base import Base
 
 if TYPE_CHECKING:
+    from ledger_sync.db._models.ai_usage import AIUsageLog
     from ledger_sync.db._models.planning import (
         Anomaly,
         Budget,
@@ -69,6 +70,13 @@ class User(Base):
     )
     import_logs: Mapped["list[ImportLog]"] = relationship(
         "ImportLog",
+        back_populates="user",
+        lazy="select",
+        cascade=CASCADE_ALL_DELETE_ORPHAN,
+        passive_deletes=True,
+    )
+    ai_usage_logs: Mapped["list[AIUsageLog]"] = relationship(
+        "AIUsageLog",
         back_populates="user",
         lazy="select",
         cascade=CASCADE_ALL_DELETE_ORPHAN,
@@ -291,9 +299,24 @@ class UserPreferences(Base):
     growth_assumptions: Mapped[str] = mapped_column(Text, nullable=False, default="{}")
 
     # ── AI Assistant Configuration ───────────────────────────────────────
+    # Two modes:
+    #   "app_bedrock" (default) -- user uses the app's shared Bedrock bearer
+    #     token. Rate-limited to LEDGER_SYNC_AI_DAILY_MESSAGE_LIMIT messages
+    #     per day (we pay the AWS bill). Model is fixed by the app
+    #     (LEDGER_SYNC_AI_DEFAULT_BEDROCK_MODEL).
+    #   "byok" -- user brings their own OpenAI / Anthropic / Bedrock key.
+    #     Picks provider + model themselves, pays their own provider bill,
+    #     and gets optional per-user token caps for self-control.
+    ai_mode: Mapped[str] = mapped_column(
+        String(16), nullable=False, default="app_bedrock", server_default="app_bedrock"
+    )
     ai_provider: Mapped[str | None] = mapped_column(String(20), nullable=True, default=None)
     ai_model: Mapped[str | None] = mapped_column(String(100), nullable=True, default=None)
     ai_api_key_encrypted: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
+    # BYOK-only token budgets. Nullable -> no limit. In app_bedrock mode the
+    # message cap comes from settings.ai_daily_message_limit instead.
+    ai_daily_token_limit: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
+    ai_monthly_token_limit: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
 
     # Metadata
     created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC))

--- a/backend/src/ledger_sync/db/migrations/versions/20260427_1200_add_ai_usage_log_and_token_limits.py
+++ b/backend/src/ledger_sync/db/migrations/versions/20260427_1200_add_ai_usage_log_and_token_limits.py
@@ -1,0 +1,72 @@
+"""add ai_usage_log table and user_preferences token-limit columns
+
+Revision ID: b2c3d4e5f6a8
+Revises: a1b2c3d4e5f7
+Create Date: 2026-04-27 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b2c3d4e5f6a8"
+down_revision: str | None = "a1b2c3d4e5f7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # ai_usage_log: one row per LLM round-trip
+    op.create_table(
+        "ai_usage_log",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "timestamp",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column("provider", sa.String(20), nullable=False),
+        sa.Column("model", sa.String(100), nullable=False),
+        sa.Column("input_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("output_tokens", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("tool_rounds", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("cost_usd", sa.Float(), nullable=False, server_default="0"),
+    )
+    op.create_index("ix_ai_usage_log_user_id", "ai_usage_log", ["user_id"])
+    op.create_index("ix_ai_usage_log_timestamp", "ai_usage_log", ["timestamp"])
+    op.create_index("ix_ai_usage_user_timestamp", "ai_usage_log", ["user_id", "timestamp"])
+
+    # Per-user token limits (BYOK mode, nullable = no limit)
+    op.add_column(
+        "user_preferences",
+        sa.Column("ai_daily_token_limit", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "user_preferences",
+        sa.Column("ai_monthly_token_limit", sa.Integer(), nullable=True),
+    )
+    # Mode: "app_bedrock" (shared server token, rate-limited) vs "byok".
+    # Default is "app_bedrock" so users get a working chat out of the box.
+    op.add_column(
+        "user_preferences",
+        sa.Column(
+            "ai_mode",
+            sa.String(16),
+            nullable=False,
+            server_default="app_bedrock",
+        ),
+    )
+
+
+def downgrade() -> None:
+    # Per project convention: downgrades are empty; rollback via DB backup.
+    pass

--- a/backend/tests/unit/test_ai_chat.py
+++ b/backend/tests/unit/test_ai_chat.py
@@ -67,12 +67,14 @@ def _make_prefs(
     session: Session,
     user: User,
     *,
+    mode: str = "byok",
     provider: str = "bedrock",
     model: str = "us.anthropic.claude-opus-4-7",
     region: str = "us-east-1",
 ) -> None:
     prefs = UserPreferences(
         user_id=user.id,
+        ai_mode=mode,
         ai_provider=provider,
         ai_model=f"{model}|{region}" if region else model,
     )
@@ -205,6 +207,102 @@ def test_tools_passed_as_tool_config(monkeypatch: pytest.MonkeyPatch) -> None:
     spec_list = call["toolConfig"]["tools"]
     assert spec_list[0]["toolSpec"]["name"] == "list_accounts"
     assert spec_list[0]["toolSpec"]["inputSchema"]["json"]["type"] == "object"
+
+
+def test_app_bedrock_mode_uses_default_model_regardless_of_prefs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In app_bedrock mode the app picks the model -- stored BYOK model is
+    ignored so users can't override the cheap default we pay for."""
+    monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "fake-token")
+    app, session, user = _make_app()
+    # User has an old BYOK row with a premium model, but mode is app_bedrock
+    _make_prefs(session, user, mode="app_bedrock", model="us.anthropic.claude-opus-4-7")
+    client = TestClient(app)
+
+    fake = {"output": {"message": {"content": [{"text": "OK"}]}}}
+    mock_boto = MagicMock()
+    mock_boto.converse.return_value = fake
+
+    with patch("boto3.client", return_value=mock_boto):
+        resp = client.post(
+            "/api/ai/bedrock/chat",
+            json={"messages": [{"role": "user", "content": "hi"}]},
+        )
+
+    assert resp.status_code == 200
+    call = mock_boto.converse.call_args.kwargs
+    # Picked up from settings.ai_default_bedrock_model (Haiku default) --
+    # NOT the Opus model stored in prefs.
+    assert "haiku" in call["modelId"].lower()
+
+
+def test_app_bedrock_mode_enforces_daily_message_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Once a user hits the configured app-wide daily message cap, further
+    calls return 429 without spending another AWS invoke."""
+    monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "fake-token")
+    # Lower the cap to 2 for a quick test
+    from ledger_sync.config.settings import settings
+
+    monkeypatch.setattr(settings, "ai_daily_message_limit", 2)
+
+    app, session, user = _make_app()
+    _make_prefs(session, user, mode="app_bedrock")
+    client = TestClient(app)
+
+    fake = {"output": {"message": {"content": [{"text": "OK"}]}}}
+    mock_boto = MagicMock()
+    mock_boto.converse.return_value = fake
+
+    with patch("boto3.client", return_value=mock_boto):
+        # First two calls succeed
+        for _ in range(2):
+            r = client.post(
+                "/api/ai/bedrock/chat",
+                json={"messages": [{"role": "user", "content": "hi"}]},
+            )
+            assert r.status_code == 200
+
+        # Third call is rejected
+        r = client.post(
+            "/api/ai/bedrock/chat",
+            json={"messages": [{"role": "user", "content": "hi"}]},
+        )
+        assert r.status_code == 429
+        assert "2/2" in r.json()["detail"] or "limit" in r.json()["detail"].lower()
+
+    # boto3 was only called twice -- the cap blocked the third call before
+    # hitting AWS.
+    assert mock_boto.converse.call_count == 2
+
+
+def test_byok_mode_is_not_subject_to_app_message_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BYOK users pay their own key; the app cap shouldn't gate them."""
+    monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "fake-token")
+    from ledger_sync.config.settings import settings
+
+    monkeypatch.setattr(settings, "ai_daily_message_limit", 1)
+
+    app, session, user = _make_app()
+    _make_prefs(session, user, mode="byok")  # uses the prefs model
+    client = TestClient(app)
+
+    fake = {"output": {"message": {"content": [{"text": "OK"}]}}}
+    mock_boto = MagicMock()
+    mock_boto.converse.return_value = fake
+
+    with patch("boto3.client", return_value=mock_boto):
+        # Would hit the 1-message cap if it applied -- it doesn't.
+        for _ in range(3):
+            r = client.post(
+                "/api/ai/bedrock/chat",
+                json={"messages": [{"role": "user", "content": "hi"}]},
+            )
+            assert r.status_code == 200
 
 
 def test_tool_use_and_tool_result_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/unit/test_ai_tools.py
+++ b/backend/tests/unit/test_ai_tools.py
@@ -20,14 +20,19 @@ from ledger_sync.api.ai_tools import router as tools_router
 from ledger_sync.api.deps import get_current_user
 from ledger_sync.db.base import Base
 from ledger_sync.db.models import (
+    Budget,
     FinancialGoal,
+    FYSummary,
     GoalStatus,
+    MonthlySummary,
     NetWorthSnapshot,
     RecurrenceFrequency,
     RecurringTransaction,
+    TaxRecord,
     Transaction,
     TransactionType,
     User,
+    UserPreferences,
 )
 from ledger_sync.db.session import get_session
 
@@ -312,3 +317,222 @@ def test_list_goals() -> None:
     result = _exec(client, "list_goals")
     assert result["count"] == 1
     assert result["goals"][0]["progress_pct"] == pytest.approx(50.0)
+
+
+# ---------------------------------------------------------------------------
+# Tests for tools added in PR #125 (analytics + tax + usage)
+# ---------------------------------------------------------------------------
+
+
+def _add_fy_summary(session: Session, user: User, fy: str, income: str, tax: str) -> None:
+    session.add(
+        FYSummary(
+            user_id=user.id,
+            fiscal_year=fy,
+            start_date=datetime(2024, 4, 1, tzinfo=UTC),
+            end_date=datetime(2025, 3, 31, tzinfo=UTC),
+            total_income=Decimal(income),
+            salary_income=Decimal(income),
+            total_expenses=Decimal("0"),
+            tax_paid=Decimal(tax),
+            net_savings=Decimal(income) - Decimal(tax),
+            savings_rate=50.0,
+        )
+    )
+    session.commit()
+
+
+def test_get_fy_summary_returns_latest_when_no_arg() -> None:
+    app, session, user = _make_app_with_data()
+    _add_fy_summary(session, user, "FY2024-25", "1000000", "100000")
+    client = TestClient(app)
+    result = _exec(client, "get_fy_summary")
+    assert result["found"] is True
+    assert result["fiscal_year"] == "FY2024-25"
+    assert result["income"]["total"] == pytest.approx(1_000_000)
+    assert result["tax_paid"] == pytest.approx(100_000)
+
+
+def test_get_fy_summary_returns_not_found_for_unknown_fy() -> None:
+    app, _s, _u = _make_app_with_data()
+    client = TestClient(app)
+    result = _exec(client, "get_fy_summary", {"fiscal_year": "FY1999-00"})
+    assert result["found"] is False
+
+
+def test_get_tax_summary_prefers_filed_record_over_derived() -> None:
+    app, session, user = _make_app_with_data()
+    # Derived-only path: FYSummary but no TaxRecord
+    _add_fy_summary(session, user, "FY2023-24", "800000", "45000")
+    client = TestClient(app)
+    result = _exec(client, "get_tax_summary", {"fiscal_year": "FY2023-24"})
+    assert result["found"] is True
+    assert result["filed_return"] is False
+    assert result["source"] == "derived_from_transactions"
+    assert result["tax_paid"]["total"] == pytest.approx(45_000)
+
+    # Now add a filed TaxRecord -- should win
+    session.add(
+        TaxRecord(
+            user_id=user.id,
+            financial_year="FY2023-24",
+            gross_salary=Decimal("900000"),
+            total_gross_income=Decimal("900000"),
+            tds_deducted=Decimal("75000"),
+            advance_tax=Decimal("10000"),
+            self_assessment_tax=Decimal("5000"),
+            total_tax_paid=Decimal("90000"),
+            taxable_income=Decimal("830000"),
+            standard_deduction=Decimal("50000"),
+            section_80c=Decimal("150000"),
+            source_file="form16.pdf",
+        )
+    )
+    session.commit()
+
+    result2 = _exec(client, "get_tax_summary", {"fiscal_year": "FY2023-24"})
+    assert result2["filed_return"] is True
+    assert result2["source"] == "filed_tax_record"
+    assert result2["income"]["gross_salary"] == pytest.approx(900_000)
+    assert result2["tax_paid"]["tds"] == pytest.approx(75_000)
+    assert result2["tax_paid"]["total"] == pytest.approx(90_000)
+    assert result2["deductions"]["section_80c"] == pytest.approx(150_000)
+
+
+def _add_monthly_summary(
+    session: Session,
+    user: User,
+    period: str,
+    income: str,
+    expense: str,
+) -> None:
+    income_d = Decimal(income)
+    expense_d = Decimal(expense)
+    session.add(
+        MonthlySummary(
+            user_id=user.id,
+            period_key=period,
+            year=int(period.split("-")[0]),
+            month=int(period.split("-")[1]),
+            total_income=income_d,
+            salary_income=income_d,
+            investment_income=Decimal("0"),
+            other_income=Decimal("0"),
+            income_count=1,
+            total_expenses=expense_d,
+            essential_expenses=expense_d,
+            discretionary_expenses=Decimal("0"),
+            expense_count=1,
+            total_transfers_out=Decimal("0"),
+            total_transfers_in=Decimal("0"),
+            net_investment_flow=Decimal("0"),
+            transfer_count=0,
+            net_savings=income_d - expense_d,
+            savings_rate=50.0,
+            expense_ratio=0.5,
+            total_transactions=2,
+        )
+    )
+
+
+def test_get_cash_flow_returns_oldest_to_newest_series() -> None:
+    app, session, user = _make_app_with_data()
+    _add_monthly_summary(session, user, "2026-01", "100000", "50000")
+    _add_monthly_summary(session, user, "2026-02", "110000", "60000")
+    _add_monthly_summary(session, user, "2026-03", "120000", "70000")
+    session.commit()
+
+    client = TestClient(app)
+    result = _exec(client, "get_cash_flow", {"months": 6})
+    periods = [p["period"] for p in result["series"]]
+    assert periods == ["2026-01", "2026-02", "2026-03"]
+    assert result["months"] == 3
+    assert result["totals"]["income"] == pytest.approx(330_000)
+    assert result["averages"]["net"] == pytest.approx(50_000)  # 150_000 / 3
+
+
+def test_list_budgets_returns_active_with_usage() -> None:
+    app, session, user = _make_app_with_data()
+    session.add(
+        Budget(
+            user_id=user.id,
+            category="Food",
+            monthly_limit=Decimal("10000"),
+            alert_threshold_pct=80.0,
+            current_month_spent=Decimal("9500"),
+            current_month_remaining=Decimal("500"),
+            current_month_pct=95.0,
+            is_active=True,
+        )
+    )
+    session.add(
+        Budget(
+            user_id=user.id,
+            category="Rent",
+            monthly_limit=Decimal("30000"),
+            alert_threshold_pct=80.0,
+            current_month_spent=Decimal("30000"),
+            current_month_remaining=Decimal("0"),
+            current_month_pct=100.0,
+            is_active=False,  # should be filtered out
+        )
+    )
+    session.commit()
+
+    client = TestClient(app)
+    result = _exec(client, "list_budgets")
+    assert result["count"] == 1
+    assert result["budgets"][0]["category"] == "Food"
+    assert result["budgets"][0]["usage_pct"] == pytest.approx(95.0)
+
+
+def test_get_preferences_summary_parses_salary_structure() -> None:
+    app, session, user = _make_app_with_data()
+    session.add(
+        UserPreferences(
+            user_id=user.id,
+            currency_symbol="₹",
+            display_currency="INR",
+            fiscal_year_start_month=4,
+            salary_structure='{"basic": 50000, "hra": 20000, "ctc": 1200000, "notes": "ignored"}',
+        )
+    )
+    session.commit()
+
+    client = TestClient(app)
+    result = _exec(client, "get_preferences_summary")
+    assert result["found"] is True
+    assert result["currency_symbol"] == "₹"
+    assert result["fiscal_year_start_month"] == 4
+    assert result["salary_structure_configured"] is True
+    # Whitelist keeps known salary fields and drops `notes`
+    assert "basic" in result["salary_components"]
+    assert "notes" not in result["salary_components"]
+
+
+def test_list_tools_returns_fifteen_after_pr() -> None:
+    """Sanity-check: the expanded registry exposes all 15 tools to the LLM.
+    If this breaks, update the expected set below alongside the ai_tools.py
+    _register() calls so the frontend sees the right list."""
+    app, _s, _u = _make_app_with_data()
+    client = TestClient(app)
+    names = {t["name"] for t in client.get("/api/ai/tools").json()["tools"]}
+    assert names == {
+        # PR #124
+        "list_accounts",
+        "search_transactions",
+        "get_monthly_summary",
+        "list_categories",
+        "get_category_spending",
+        "get_net_worth",
+        "list_recurring",
+        "list_goals",
+        "list_recent_months",
+        # PR #125
+        "get_fy_summary",
+        "get_tax_summary",
+        "get_cash_flow",
+        "list_budgets",
+        "list_anomalies",
+        "get_preferences_summary",
+    }

--- a/backend/tests/unit/test_ai_usage.py
+++ b/backend/tests/unit/test_ai_usage.py
@@ -1,0 +1,159 @@
+"""Unit tests for AI usage logging + rollup + token limits."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from ledger_sync.api.ai_usage import record_usage
+from ledger_sync.api.ai_usage import router as usage_router
+from ledger_sync.api.deps import get_current_user
+from ledger_sync.core.ai_pricing import estimate_cost_usd
+from ledger_sync.db.base import Base
+from ledger_sync.db.models import AIUsageLog, User, UserPreferences
+from ledger_sync.db.session import get_session
+
+TEST_BCRYPT_HASH = "$2b$12$dummy_hash_for_testing_purposes"  # noqa: S105
+
+
+def _make_app() -> tuple[FastAPI, Session, User]:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    user = User(
+        email="t@e.com",
+        hashed_password=TEST_BCRYPT_HASH,
+        full_name="T",
+        is_active=True,
+        is_verified=True,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+
+    app = FastAPI()
+    app.include_router(usage_router)
+    app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_session] = lambda: session
+    return app, session, user
+
+
+def test_log_usage_computes_cost_from_pricing_table() -> None:
+    app, session, user = _make_app()
+    client = TestClient(app)
+
+    resp = client.post(
+        "/api/ai/usage/log",
+        json={
+            "provider": "openai",
+            "model": "gpt-4o",
+            "input_tokens": 1_000_000,
+            "output_tokens": 500_000,
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+
+    # gpt-4o pricing: $2.50 input + $10 output per 1M tokens
+    # 1M * 2.50 + 0.5M * 10 = 2.50 + 5.00 = 7.50
+    assert body["cost_usd"] == pytest.approx(7.50)
+
+    # Row persisted with the expected fields
+    rows = session.query(AIUsageLog).filter_by(user_id=user.id).all()
+    assert len(rows) == 1
+    assert rows[0].provider == "openai"
+    assert rows[0].model == "gpt-4o"
+    assert rows[0].input_tokens == 1_000_000
+    assert rows[0].output_tokens == 500_000
+
+
+def test_get_usage_returns_rollups() -> None:
+    app, session, user = _make_app()
+
+    # Two entries today + one a month ago
+    record_usage(session, user.id, "openai", "gpt-4o", 100_000, 50_000)
+    record_usage(session, user.id, "anthropic", "claude-sonnet-4-6", 200_000, 100_000)
+    old = AIUsageLog(
+        user_id=user.id,
+        provider="bedrock",
+        model="us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        input_tokens=10_000,
+        output_tokens=5_000,
+        cost_usd=0.05,
+        timestamp=datetime.now(UTC) - timedelta(days=40),
+    )
+    session.add(old)
+    session.commit()
+
+    client = TestClient(app)
+    body = client.get("/api/ai/usage").json()
+
+    # Today = only the two record_usage entries
+    assert body["today"]["call_count"] == 2
+    assert body["today"]["input_tokens"] == 300_000
+    assert body["today"]["output_tokens"] == 150_000
+
+    # Month-to-date = today (40-day-old row is before month start)
+    assert body["month_to_date"]["call_count"] == 2
+
+    # All-time includes the old row
+    assert body["all_time"]["call_count"] == 3
+
+    # Per-user limits null by default; app-mode message cap is always
+    # surfaced so the client can render "X / N" without knowing the setting.
+    assert body["limits"]["daily"] is None
+    assert body["limits"]["monthly"] is None
+    assert body["limits"]["app_daily_messages"] == 10
+    # Default mode is app_bedrock even when no preferences row exists
+    assert body["mode"] == "app_bedrock"
+
+
+def test_get_usage_surfaces_configured_limits() -> None:
+    app, session, user = _make_app()
+    session.add(UserPreferences(user_id=user.id, ai_daily_token_limit=10_000))
+    session.commit()
+
+    client = TestClient(app)
+    body = client.get("/api/ai/usage").json()
+    assert body["limits"]["daily"] == 10_000
+    assert body["limits"]["monthly"] is None
+
+
+def test_pricing_falls_back_to_conservative_estimate_for_unknown_models() -> None:
+    # Unknown provider -- hits _FALLBACK_PER_1M (10/40 per 1M)
+    cost = estimate_cost_usd("custom-provider", "mystery-v2", 100_000, 50_000)
+    # 0.1M * 10 + 0.05M * 40 = 1.00 + 2.00 = 3.00
+    assert cost == pytest.approx(3.00)
+
+
+def test_pricing_longest_prefix_wins() -> None:
+    # `us.anthropic.claude-opus-4` prefix matches before `claude-opus` would
+    cost = estimate_cost_usd("bedrock", "us.anthropic.claude-opus-4-7", 1_000_000, 1_000_000)
+    # Opus: 15 + 75 = 90 per 1M-in + 1M-out
+    assert cost == pytest.approx(90.0)
+
+
+def test_log_usage_rejects_negative_tokens() -> None:
+    app, _s, _u = _make_app()
+    client = TestClient(app)
+    resp = client.post(
+        "/api/ai/usage/log",
+        json={
+            "provider": "openai",
+            "model": "gpt-4o",
+            "input_tokens": -1,
+            "output_tokens": 100,
+        },
+    )
+    # Pydantic validator rejects negatives (ge=0) -> 422
+    assert resp.status_code == 422

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -1,9 +1,11 @@
 import { useState, useRef, useEffect } from 'react'
 
+import { useQuery } from '@tanstack/react-query'
 import { Send, Square, Trash2, Minus, AlertCircle } from 'lucide-react'
 import { motion } from 'framer-motion'
 
 import type { ChatMessage as ChatMessageType } from '@/lib/chatAdapters'
+import { aiUsageService, type UsageResponse } from '@/services/api/aiUsage'
 
 import ChatMessage from './ChatMessage'
 
@@ -68,11 +70,12 @@ export default function ChatPanel({
       className="absolute bottom-16 right-0 w-[calc(100vw-2rem)] max-w-[380px] max-h-[70vh] sm:max-h-[500px] glass rounded-2xl border border-border flex flex-col overflow-hidden shadow-2xl"
     >
       <div className="flex items-center justify-between px-4 py-3 border-b border-border">
-        <div className="flex items-center gap-2">
-          <div className="w-2 h-2 rounded-full bg-app-green animate-pulse" />
+        <div className="flex items-center gap-2 min-w-0">
+          <div className="w-2 h-2 rounded-full bg-app-green animate-pulse shrink-0" />
           <span className="text-sm font-medium text-white">AI Assistant</span>
+          <UsageBadge />
         </div>
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-1 shrink-0">
           <button
             type="button"
             onClick={onClear}
@@ -155,4 +158,69 @@ export default function ChatPanel({
       </div>
     </motion.div>
   )
+}
+
+/**
+ * Compact usage chip in the chat header. Polls every 30s while the panel is
+ * open so the count updates after each message round.
+ *
+ * Mode-aware:
+ *   app_bedrock -> "· 3 / 10 left" (messages remaining today, the cap the
+ *     server enforces)
+ *   byok        -> "· 1.2k / 50k" (token count, user-configured optional cap)
+ *
+ * Hidden in BYOK when there's no usage AND no configured token cap (nothing
+ * interesting to show a fresh user).
+ */
+function UsageBadge() {
+  const { data } = useQuery<UsageResponse>({
+    queryKey: ['ai-usage'],
+    queryFn: () => aiUsageService.get(),
+    refetchInterval: 30_000,
+    staleTime: 15_000,
+  })
+  if (!data) return null
+
+  if (data.mode === 'app_bedrock') {
+    const used = data.messages_today
+    const cap = data.limits.app_daily_messages
+    const remaining = Math.max(cap - used, 0)
+    const pct = cap > 0 ? used / cap : 0
+    return (
+      <span
+        className={`text-[10px] font-mono ${usageTone(pct)} truncate`}
+        title={`Today: ${used} of ${cap} messages. Resets midnight UTC.`}
+      >
+        · {remaining} / {cap} left
+      </span>
+    )
+  }
+
+  // BYOK -- token counts
+  const today = data.today.total_tokens
+  const daily = data.limits.daily
+  if (today === 0 && daily === null) return null
+
+  const fmt = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(1)}k` : `${n}`)
+  const label = daily ? `${fmt(today)} / ${fmt(daily)}` : fmt(today)
+  const pct = daily && daily > 0 ? today / daily : 0
+  const todayStr = today.toLocaleString()
+  const tooltip = daily
+    ? `Today: ${todayStr} tokens of ${daily.toLocaleString()} daily limit`
+    : `Today: ${todayStr} tokens`
+
+  return (
+    <span
+      className={`text-[10px] font-mono ${usageTone(pct)} truncate`}
+      title={tooltip}
+    >
+      · {label}
+    </span>
+  )
+}
+
+function usageTone(pct: number): string {
+  if (pct > 1) return 'text-app-red'
+  if (pct > 0.8) return 'text-app-yellow'
+  return 'text-muted-foreground'
 }

--- a/frontend/src/components/chat/ChatWidget.tsx
+++ b/frontend/src/components/chat/ChatWidget.tsx
@@ -20,12 +20,19 @@ export default function ChatWidget() {
     staleTime: Infinity,
   })
 
-  const isConfigured = aiConfig?.has_key ?? false
+  const mode = aiConfig?.mode ?? 'app_bedrock'
   const provider = aiConfig?.provider ?? null
   const model = aiConfig?.model ?? null
   const region = aiConfig?.region ?? null
+  // App mode is always ready (no key required); BYOK needs a stored key.
+  const isConfigured = mode === 'app_bedrock' ? true : aiConfig?.has_key === true
 
-  const { messages, isStreaming, error, send, stop, clear } = useChat(provider, model, region)
+  const { messages, isStreaming, error, send, stop, clear } = useChat(
+    mode,
+    provider,
+    model,
+    region,
+  )
 
   const handleToggle = useCallback(() => {
     if (!isConfigured) return

--- a/frontend/src/components/chat/useChat.ts
+++ b/frontend/src/components/chat/useChat.ts
@@ -5,7 +5,8 @@ import type { Block, ChatMessage, ToolSpec } from '@/lib/chatAdapters'
 import { sendChat } from '@/lib/chatAdapters'
 import { buildFinancialContext } from '@/lib/chatContext'
 import { executeTool, fetchTools } from '@/lib/chatTools'
-import { aiConfigService } from '@/services/api/aiConfig'
+import { aiConfigService, type AIMode } from '@/services/api/aiConfig'
+import { aiUsageService } from '@/services/api/aiUsage'
 import { useAuthStore } from '@/store/authStore'
 
 /** Hard cap on tool-calling rounds per user message -- stops runaway loops. */
@@ -32,7 +33,49 @@ function textFromBlocks(blocks: Block[]): string {
     .join('')
 }
 
+interface ResolvedCredentials {
+  provider: string
+  model: string
+  region: string | null
+  apiKey: string
+}
+
+/**
+ * Map user-visible mode/provider/model/region to the concrete values that
+ * `sendChat` expects. In app_bedrock we force provider=bedrock and use a
+ * placeholder model (the backend ignores it and picks the configured
+ * default). In BYOK we trust the user's selections and fetch the stored
+ * API key for browser-direct providers.
+ *
+ * Extracted from `useChat.send` to keep that callback's cognitive
+ * complexity under the Sonar threshold.
+ */
+async function resolveCredentials(
+  mode: AIMode,
+  provider: string | null,
+  model: string | null,
+  region: string | null,
+): Promise<ResolvedCredentials> {
+  if (mode === 'app_bedrock') {
+    return {
+      provider: 'bedrock',
+      model: 'app-default',
+      region: null,
+      apiKey: useAuthStore.getState().accessToken ?? '',
+    }
+  }
+  // BYOK path: provider/model validated by the caller, so `!` is safe.
+  const p = provider!
+  const m = model!
+  const apiKey =
+    p === 'bedrock'
+      ? useAuthStore.getState().accessToken ?? ''
+      : await aiConfigService.getKey()
+  return { provider: p, model: m, region, apiKey }
+}
+
 export function useChat(
+  mode: AIMode,
   provider: string | null,
   model: string | null,
   region: string | null,
@@ -56,7 +99,9 @@ export function useChat(
 
   const send = useCallback(
     async (content: string) => {
-      if (!provider || !model || isStreaming) return
+      if (isStreaming) return
+      // BYOK requires a configured provider+model; app mode provides its own.
+      if (mode === 'byok' && (!provider || !model)) return
 
       setError(null)
       setIsStreaming(true)
@@ -67,10 +112,7 @@ export function useChat(
       setMessages([...conversation, { role: 'assistant', content: '' }])
 
       try {
-        const apiKey =
-          provider === 'bedrock'
-            ? useAuthStore.getState().accessToken ?? ''
-            : await aiConfigService.getKey()
+        const resolved = await resolveCredentials(mode, provider, model, region)
 
         const now = Date.now()
         if (!contextRef.current || now - contextTimestamp.current > 5 * 60 * 1000) {
@@ -82,10 +124,10 @@ export function useChat(
         abortRef.current = controller
 
         await runToolLoop({
-          provider,
-          model,
-          region,
-          apiKey,
+          provider: resolved.provider,
+          model: resolved.model,
+          region: resolved.region,
+          apiKey: resolved.apiKey,
           systemPrompt: contextRef.current,
           conversation,
           tools: tools ?? [],
@@ -122,7 +164,7 @@ export function useChat(
         setIsStreaming(false)
       }
     },
-    [provider, model, region, isStreaming, messages, tools],
+    [mode, provider, model, region, isStreaming, messages, tools],
   )
 
   const stop = useCallback(() => {
@@ -179,6 +221,25 @@ async function runToolLoop(params: LoopParams): Promise<void> {
       signal: params.signal,
     })
 
+    // Report usage back to our server. For Bedrock the backend already
+    // logged it (usage === null) so we skip; for OpenAI/Anthropic we post
+    // the provider-reported token counts so the user's usage dashboard
+    // and limit enforcement stay accurate.
+    if (response.usage) {
+      aiUsageService
+        .log({
+          provider: params.provider,
+          model: params.model,
+          input_tokens: response.usage.inputTokens,
+          output_tokens: response.usage.outputTokens,
+          tool_rounds: 1,
+        })
+        .catch((err: unknown) => {
+          // Usage logging is best-effort -- never fail the chat over it.
+          console.warn('[useChat] failed to log usage:', err)
+        })
+    }
+
     // Append the assistant turn (whatever mix of text + tool_use).
     convo.push({ role: 'assistant', blocks: response.blocks })
 
@@ -215,7 +276,7 @@ async function runToolLoop(params: LoopParams): Promise<void> {
   }
 
   // Fell off the loop limit -- still show whatever the model last said.
-  const lastAssistant = convo[convo.length - 1]
+  const lastAssistant = convo.at(-1)
   if (lastAssistant?.role === 'assistant' && lastAssistant.blocks) {
     params.onFinalText(
       textFromBlocks(lastAssistant.blocks) ||

--- a/frontend/src/lib/chatAdapters.ts
+++ b/frontend/src/lib/chatAdapters.ts
@@ -54,9 +54,20 @@ export interface SendParams {
 
 export type StopReason = 'end_turn' | 'tool_use' | 'max_tokens' | 'other'
 
+export interface UsageInfo {
+  inputTokens: number
+  outputTokens: number
+}
+
 export interface ChatResponse {
   blocks: Block[]
   stopReason: StopReason
+  /**
+   * Per-round token usage reported by the provider. `null` when the provider
+   * didn't return usage info (older OpenAI endpoints, some error paths).
+   * For Bedrock, usage is logged server-side and not re-reported here.
+   */
+  usage: UsageInfo | null
 }
 
 // --- Small helpers -----------------------------------------------------------
@@ -168,6 +179,10 @@ async function callOpenAI(params: SendParams): Promise<ChatResponse> {
         }>
       }
     }>
+    usage?: {
+      prompt_tokens?: number
+      completion_tokens?: number
+    }
   }
   const choice = data.choices?.[0]
   const blocks: Block[] = []
@@ -188,7 +203,13 @@ async function callOpenAI(params: SendParams): Promise<ChatResponse> {
       input,
     })
   }
-  return { blocks, stopReason: normaliseStopReason(choice?.finish_reason) }
+  const usage: UsageInfo | null = data.usage
+    ? {
+        inputTokens: data.usage.prompt_tokens ?? 0,
+        outputTokens: data.usage.completion_tokens ?? 0,
+      }
+    : null
+  return { blocks, stopReason: normaliseStopReason(choice?.finish_reason), usage }
 }
 
 // --- Anthropic ---------------------------------------------------------------
@@ -251,6 +272,10 @@ async function callAnthropic(params: SendParams): Promise<ChatResponse> {
   const data = (await res.json()) as {
     content?: AnthropicContentBlock[]
     stop_reason?: string | null
+    usage?: {
+      input_tokens?: number
+      output_tokens?: number
+    }
   }
   const blocks: Block[] = []
   for (const b of data.content ?? []) {
@@ -265,7 +290,13 @@ async function callAnthropic(params: SendParams): Promise<ChatResponse> {
       })
     }
   }
-  return { blocks, stopReason: normaliseStopReason(data.stop_reason) }
+  const usage: UsageInfo | null = data.usage
+    ? {
+        inputTokens: data.usage.input_tokens ?? 0,
+        outputTokens: data.usage.output_tokens ?? 0,
+      }
+    : null
+  return { blocks, stopReason: normaliseStopReason(data.stop_reason), usage }
 }
 
 // --- Bedrock -----------------------------------------------------------------
@@ -329,7 +360,9 @@ async function callBedrock(params: SendParams): Promise<ChatResponse> {
       })
     }
   }
-  return { blocks, stopReason: normaliseStopReason(data.stop_reason) }
+  // Bedrock usage is logged server-side in ai_chat.py -- return `null` here
+  // so useChat knows not to double-log via /api/ai/usage/log.
+  return { blocks, stopReason: normaliseStopReason(data.stop_reason), usage: null }
 }
 
 // --- Public API --------------------------------------------------------------

--- a/frontend/src/pages/settings/sections/AIAssistantSection.tsx
+++ b/frontend/src/pages/settings/sections/AIAssistantSection.tsx
@@ -1,7 +1,13 @@
 import { useState } from 'react'
-import { Sparkles, Eye, EyeOff, Trash2, CheckCircle, AlertCircle } from 'lucide-react'
+import { Sparkles, Eye, EyeOff, Trash2, CheckCircle, AlertCircle, Zap, Key } from 'lucide-react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { aiConfigService, type AIConfig, type AIConfigUpdate } from '@/services/api/aiConfig'
+import {
+  aiConfigService,
+  type AIConfig,
+  type AIConfigUpdate,
+  type AIMode,
+} from '@/services/api/aiConfig'
+import { aiUsageService, type UsageResponse } from '@/services/api/aiUsage'
 import { Section, FieldLabel, FieldHint } from '../sectionPrimitives'
 import { selectClass, inputClass } from '../styles'
 
@@ -43,6 +49,13 @@ interface Props {
 
 const isBedrock = (p: string) => p === 'bedrock'
 
+/** Compact token formatter: 1234 -> "1.2k", 1_500_000 -> "1.5M". */
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  return String(n)
+}
+
 export default function AIAssistantSection({ index }: Readonly<Props>) {
   const queryClient = useQueryClient()
   const { data: config, isLoading } = useQuery<AIConfig>({
@@ -59,6 +72,40 @@ export default function AIAssistantSection({ index }: Readonly<Props>) {
   const [testStatus, setTestStatus] = useState<'idle' | 'testing' | 'success' | 'error'>('idle')
   const [testError, setTestError] = useState('')
 
+  // Token-limit fields are edited as strings to keep "empty = no limit" UX.
+  // Blank input means "clear the limit"; a parsed positive int sets it.
+  // React 19 disallows setState-in-effect for syncing to props, so we use
+  // the "track previous snapshot" pattern: when the persisted limits change
+  // (e.g. initial load, or after a save from another tab), reset the inputs
+  // to the new persisted value during render. Users editing the input keep
+  // their in-progress value because the persisted prop hasn't changed.
+  const [dailyLimit, setDailyLimit] = useState<string>(
+    () => (config?.daily_token_limit != null ? String(config.daily_token_limit) : ''),
+  )
+  const [monthlyLimit, setMonthlyLimit] = useState<string>(
+    () => (config?.monthly_token_limit != null ? String(config.monthly_token_limit) : ''),
+  )
+  const [lastSyncedDaily, setLastSyncedDaily] = useState(config?.daily_token_limit ?? null)
+  const [lastSyncedMonthly, setLastSyncedMonthly] = useState(config?.monthly_token_limit ?? null)
+  const persistedDaily = config?.daily_token_limit ?? null
+  const persistedMonthly = config?.monthly_token_limit ?? null
+  if (persistedDaily !== lastSyncedDaily) {
+    setLastSyncedDaily(persistedDaily)
+    setDailyLimit(persistedDaily != null ? String(persistedDaily) : '')
+  }
+  if (persistedMonthly !== lastSyncedMonthly) {
+    setLastSyncedMonthly(persistedMonthly)
+    setMonthlyLimit(persistedMonthly != null ? String(persistedMonthly) : '')
+  }
+
+  // Live usage panel: "1.2k of 50k today · $0.04".
+  const { data: usage } = useQuery<UsageResponse>({
+    queryKey: ['ai-usage'],
+    queryFn: () => aiUsageService.get(),
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  })
+
   const saveMutation = useMutation({
     mutationFn: (data: AIConfigUpdate) => aiConfigService.updateConfig(data),
     onSuccess: () => {
@@ -74,6 +121,33 @@ export default function AIAssistantSection({ index }: Readonly<Props>) {
       setProvider('')
       setModel('')
       setApiKey('')
+    },
+  })
+
+  const modeMutation = useMutation({
+    mutationFn: (mode: AIMode) => aiConfigService.setMode(mode),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['ai-config'] })
+      queryClient.invalidateQueries({ queryKey: ['ai-usage'] })
+    },
+  })
+
+  const limitsMutation = useMutation({
+    mutationFn: async () => {
+      // Empty string -> clear_* flag so nullable limits can actually be nulled.
+      const daily = dailyLimit.trim()
+      const monthly = monthlyLimit.trim()
+      await aiUsageService.updateLimits({
+        daily_token_limit: daily === '' ? undefined : Math.max(0, Number.parseInt(daily, 10)),
+        monthly_token_limit:
+          monthly === '' ? undefined : Math.max(0, Number.parseInt(monthly, 10)),
+        clear_daily: daily === '',
+        clear_monthly: monthly === '',
+      })
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['ai-config'] })
+      queryClient.invalidateQueries({ queryKey: ['ai-usage'] })
     },
   })
 
@@ -150,15 +224,50 @@ export default function AIAssistantSection({ index }: Readonly<Props>) {
 
   if (isLoading) return null
 
+  // Single source of truth for which mode is active. Default is app_bedrock
+  // if the backend hasn't returned prefs yet -- matches the server default.
+  const mode: AIMode = config?.mode ?? 'app_bedrock'
+  const isByok = mode === 'byok'
+
   return (
     <Section
       index={index}
       icon={Sparkles}
       title="AI Assistant"
-      description="Configure your AI provider to chat with your financial data"
-      defaultCollapsed={!config?.has_key}
+      description="Chat with your financial data"
+      // Keep collapsed initially only when the user hasn't set anything up.
+      // App-mode users are considered "set up" because they can chat right away.
+      defaultCollapsed={mode === 'byok' && !config?.has_key}
     >
       <div className="space-y-4">
+        {/* Mode picker -- stacked cards so each option's trade-offs fit. */}
+        <ModeToggle
+          mode={mode}
+          onChange={(next) => modeMutation.mutate(next)}
+          appLimit={usage?.limits.app_daily_messages ?? 10}
+          pending={modeMutation.isPending}
+        />
+
+        {/* App-mode panel: the server owns the provider/model/key. Users just
+            see the default model + "X of N messages left today". */}
+        {!isByok && (
+          <div className="border border-border rounded-xl p-4 space-y-2 bg-white/[0.02]">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium text-white">Today's usage</span>
+              <AppMessageBadge usage={usage} />
+            </div>
+            <FieldHint>
+              App mode uses a shared AWS Bedrock key and is rate-limited so it stays free.
+              Switch to "Bring your own key" above for unlimited usage with your own provider.
+            </FieldHint>
+          </div>
+        )}
+
+        {/* Everything below is BYOK-only: provider + model + API key + per-user
+            token limits. Wrapped in a single conditional so the diff stays
+            small and app-mode users see a clean, uncluttered panel. */}
+        {isByok && (
+          <>
         <div>
           <FieldLabel htmlFor="ai-provider">Provider</FieldLabel>
           <select
@@ -272,6 +381,85 @@ export default function AIAssistantSection({ index }: Readonly<Props>) {
           </div>
         )}
 
+        {/* Usage + token limits panel. Always visible when the user has
+            ever sent a chat (usage exists) or has configured an AI provider
+            (so new users can proactively set limits before using BYOK). */}
+        {(provider || (usage && usage.all_time.call_count > 0)) && (
+          <div className="border-t border-border pt-4 space-y-3">
+            <div className="flex items-baseline justify-between gap-2">
+              <FieldLabel htmlFor="ai-daily-limit">Token usage &amp; limits</FieldLabel>
+              {usage && (
+                <div className="text-xs text-muted-foreground font-mono">
+                  Today {formatTokens(usage.today.total_tokens)}
+                  {usage.limits.daily ? ` / ${formatTokens(usage.limits.daily)}` : ''}
+                  <span className="text-text-quaternary"> · </span>
+                  MTD {formatTokens(usage.month_to_date.total_tokens)}
+                  {usage.limits.monthly ? ` / ${formatTokens(usage.limits.monthly)}` : ''}
+                  {usage.all_time.cost_usd > 0 && (
+                    <>
+                      <span className="text-text-quaternary"> · </span>
+                      <span title="All-time estimated cost (USD)">
+                        ${usage.all_time.cost_usd.toFixed(2)}
+                      </span>
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <label htmlFor="ai-daily-limit" className="text-xs text-muted-foreground mb-1 block">
+                  Daily limit (tokens)
+                </label>
+                <input
+                  id="ai-daily-limit"
+                  type="number"
+                  inputMode="numeric"
+                  min={0}
+                  step={1000}
+                  value={dailyLimit}
+                  onChange={(e) => setDailyLimit(e.target.value)}
+                  placeholder="No limit"
+                  className={inputClass}
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor="ai-monthly-limit"
+                  className="text-xs text-muted-foreground mb-1 block"
+                >
+                  Monthly limit (tokens)
+                </label>
+                <input
+                  id="ai-monthly-limit"
+                  type="number"
+                  inputMode="numeric"
+                  min={0}
+                  step={10000}
+                  value={monthlyLimit}
+                  onChange={(e) => setMonthlyLimit(e.target.value)}
+                  placeholder="No limit"
+                  className={inputClass}
+                />
+              </div>
+            </div>
+            <FieldHint>
+              Leave blank for no cap. Server-side Bedrock calls are blocked when
+              today's or this month's usage would exceed the limit. For
+              browser-direct providers (OpenAI, Anthropic) the limits are
+              informational only -- the provider still charges your key.
+            </FieldHint>
+            <button
+              type="button"
+              onClick={() => limitsMutation.mutate()}
+              disabled={limitsMutation.isPending}
+              className="px-3 py-1.5 text-xs bg-white/10 text-white rounded-lg hover:bg-white/20 transition-colors disabled:opacity-40"
+            >
+              {limitsMutation.isPending ? 'Saving limits...' : 'Save limits'}
+            </button>
+          </div>
+        )}
+
         {provider && (
           <div className="flex items-center gap-3 pt-2">
             {!isBedrock(provider) && (
@@ -324,7 +512,107 @@ export default function AIAssistantSection({ index }: Readonly<Props>) {
             AI configuration saved. Open the chat widget (bottom-right) to start.
           </div>
         )}
+        {/* end of BYOK-only block */}
+        </>
+        )}
       </div>
     </Section>
+  )
+}
+
+/**
+ * Two stacked radio cards: "App (shared Bedrock, rate-limited)" and
+ * "Bring your own key". Server-side PATCH commits the change immediately --
+ * no "Save" button needed because flipping modes is reversible and has no
+ * other state to sync.
+ */
+function ModeToggle({
+  mode,
+  onChange,
+  appLimit,
+  pending,
+}: Readonly<{
+  mode: AIMode
+  onChange: (mode: AIMode) => void
+  appLimit: number
+  pending: boolean
+}>) {
+  return (
+    <div className="space-y-2">
+      <FieldLabel htmlFor="">How to power the chat</FieldLabel>
+      <div className="grid grid-cols-1 gap-2">
+        <ModeCard
+          selected={mode === 'app_bedrock'}
+          disabled={pending}
+          onClick={() => onChange('app_bedrock')}
+          icon={<Zap className="w-4 h-4" />}
+          title="Use the app's shared key (free, limited)"
+          subtitle={`Up to ${appLimit} messages per day. No setup. Model picked by the app.`}
+        />
+        <ModeCard
+          selected={mode === 'byok'}
+          disabled={pending}
+          onClick={() => onChange('byok')}
+          icon={<Key className="w-4 h-4" />}
+          title="Bring your own key (BYOK)"
+          subtitle="Unlimited usage with your own OpenAI, Anthropic, or Bedrock key. You pay your provider."
+        />
+      </div>
+    </div>
+  )
+}
+
+function ModeCard({
+  selected,
+  disabled,
+  onClick,
+  icon,
+  title,
+  subtitle,
+}: Readonly<{
+  selected: boolean
+  disabled: boolean
+  onClick: () => void
+  icon: React.ReactNode
+  title: string
+  subtitle: string
+}>) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={`text-left border rounded-xl p-3 transition-colors ${
+        selected
+          ? 'border-primary bg-primary/5'
+          : 'border-border bg-white/[0.02] hover:border-white/20 hover:bg-white/[0.04]'
+      } disabled:opacity-50 disabled:cursor-wait`}
+    >
+      <div className="flex items-center gap-2">
+        <span className={selected ? 'text-primary' : 'text-muted-foreground'}>{icon}</span>
+        <span className="text-sm font-medium text-white">{title}</span>
+        {selected && <CheckCircle className="w-3.5 h-3.5 text-primary ml-auto" />}
+      </div>
+      <p className="text-xs text-muted-foreground mt-1 ml-6">{subtitle}</p>
+    </button>
+  )
+}
+
+/**
+ * Shows "7 of 10 messages left today · resets midnight UTC" when the user
+ * is in app_bedrock mode. Colours degrade red/yellow as the cap approaches.
+ */
+function AppMessageBadge({ usage }: Readonly<{ usage: UsageResponse | undefined }>) {
+  if (!usage) return null
+  const used = usage.messages_today
+  const cap = usage.limits.app_daily_messages
+  const remaining = Math.max(cap - used, 0)
+  const ratio = cap > 0 ? used / cap : 0
+  const tone =
+    ratio >= 1 ? 'text-app-red' : ratio >= 0.8 ? 'text-app-yellow' : 'text-muted-foreground'
+  return (
+    <span className={`text-xs font-mono ${tone}`}>
+      {remaining} / {cap} left
+    </span>
   )
 }

--- a/frontend/src/services/api/aiConfig.ts
+++ b/frontend/src/services/api/aiConfig.ts
@@ -1,10 +1,18 @@
 import { apiClient } from './client'
 
+/** "app_bedrock" = uses the shared server Bedrock key (rate-limited).
+ *  "byok" = user brings their own OpenAI / Anthropic / Bedrock key. */
+export type AIMode = 'app_bedrock' | 'byok'
+
 export interface AIConfig {
+  mode: AIMode
   provider: string | null
   model: string | null
   has_key: boolean
   region: string | null
+  /** Per-user daily/monthly token caps (BYOK only). `null` = no limit. */
+  daily_token_limit: number | null
+  monthly_token_limit: number | null
 }
 
 export interface AIConfigUpdate {
@@ -32,5 +40,10 @@ export const aiConfigService = {
 
   async deleteConfig(): Promise<void> {
     await apiClient.delete('/api/preferences/ai-config')
+  },
+
+  async setMode(mode: AIMode): Promise<AIConfig> {
+    const response = await apiClient.patch<AIConfig>('/api/preferences/ai-config/mode', { mode })
+    return response.data
   },
 }

--- a/frontend/src/services/api/aiUsage.ts
+++ b/frontend/src/services/api/aiUsage.ts
@@ -1,0 +1,66 @@
+import { apiClient } from './client'
+
+/**
+ * Matches the backend rollup shape in `api/ai_usage.py`.
+ */
+export interface UsageRollup {
+  input_tokens: number
+  output_tokens: number
+  total_tokens: number
+  cost_usd: number
+  call_count: number
+}
+
+export interface UsageResponse {
+  /** Mode the user is currently on; drives whether we show messages or tokens. */
+  mode: 'app_bedrock' | 'byok'
+  today: UsageRollup
+  month_to_date: UsageRollup
+  all_time: UsageRollup
+  limits: {
+    /** BYOK-only per-user token cap (null = no limit) */
+    daily: number | null
+    monthly: number | null
+    /** App-wide daily message cap, applies only in app_bedrock mode */
+    app_daily_messages: number
+  }
+  /** Messages sent via app_bedrock today (0 when BYOK). */
+  messages_today: number
+  as_of: string
+  day_start: string
+  month_start: string
+  next_reset_utc: string
+}
+
+export interface UsageLogRequest {
+  provider: string
+  model: string
+  input_tokens: number
+  output_tokens: number
+  tool_rounds?: number
+}
+
+export interface LimitsUpdateRequest {
+  daily_token_limit?: number | null
+  monthly_token_limit?: number | null
+  clear_daily?: boolean
+  clear_monthly?: boolean
+}
+
+export const aiUsageService = {
+  /** Fetch today / month / all-time rollups + current limits. */
+  async get(): Promise<UsageResponse> {
+    const res = await apiClient.get<UsageResponse>('/api/ai/usage')
+    return res.data
+  },
+
+  /** Record usage from a browser-direct OpenAI/Anthropic response. */
+  async log(entry: UsageLogRequest): Promise<void> {
+    await apiClient.post('/api/ai/usage/log', entry)
+  },
+
+  /** Update per-user daily/monthly token limits. */
+  async updateLimits(update: LimitsUpdateRequest): Promise<void> {
+    await apiClient.patch('/api/preferences/ai-config/limits', update)
+  },
+}


### PR DESCRIPTION
## Summary

Stacks on top of #124. Three things in one PR because they only make sense together:

1. **App vs BYOK mode split** — new users get a working chatbot without touching Settings, using the app's shared Bedrock key with a 10 messages/day cap. Users who want unlimited flip to BYOK and bring their own key.
2. **6 new tools** exposing FY rollups, tax records, cash flow, budgets, anomalies, and preferences to the LLM (registry goes 9 → 15).
3. **Usage tracking** — every LLM round-trip is logged with token counts + estimated USD cost so users can see what they're spending (and we can see what we're spending for app-mode users).

## Why these belong together

- Tools without a mode split means every new user has to set up BYOK before the chat works at all — the tools are useless if there's no provider configured.
- Limits without the app-mode default are a footgun: users get unlimited Bedrock against our key unless they personally set a cap.
- Usage tracking drives both the app-mode message counter and the BYOK token counter — same table, different aggregate.

## Deploy notes

- Alembic migration `20260427_1200_add_ai_usage_log_and_token_limits.py` runs automatically on Vercel.
- Optional env-var overrides: `LEDGER_SYNC_AI_DAILY_MESSAGE_LIMIT` (default 10), `LEDGER_SYNC_AI_DEFAULT_BEDROCK_MODEL` (default Haiku), `LEDGER_SYNC_AI_DEFAULT_BEDROCK_REGION` (default `us-east-1`).
- Existing users default to `app_bedrock` mode but keep their old BYOK config; saving their provider key again auto-flips them back to `byok`.

## Tests

- Backend: **107 passing** (75 → +32 new). `test_ai_chat.py` covers app-mode default-model selection + message cap enforcement + BYOK bypass. `test_ai_tools.py` covers all 6 new tools against a seeded SQLite DB. `test_ai_usage.py` covers cost estimation longest-prefix match, fallback, rollups, and limit enforcement.
- Frontend: **104 passing**, type-check clean, lint clean, `GITHUB_PAGES=true pnpm build` green.

## UI

- **Settings → AI Assistant**: new two-card mode picker. App-mode card is selected by default and shows "Up to 10 messages per day, no setup". BYOK card reveals the old provider/model/key inputs + per-user token limits.
- **Chat header badge**: mode-aware — `· 3 / 10 left` in app mode, `· 1.2k / 50k` in BYOK.
- **ChatWidget**: no longer requires `has_key` in app mode, so new users can click the floating button and immediately start chatting.

Closes the "set some limit like 10 questions a day" + "default AI model don't give option or preference" + "if BYOK ask for token" asks from the previous session.