### PR TITLE
fix(mobile): PWA alignment - dvh, safe-area insets, body reset

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,7 +12,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="Ledger Sync — Self-hosted personal finance dashboard with analytics, budgeting, and tax planning." />
-    <meta name="theme-color" content="#09090b" />
+    <meta name="theme-color" content="#000000" />
     <meta name="color-scheme" content="dark" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="apple-touch-icon" href="/apple-touch-icon-180x180.png" />

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -67,7 +67,7 @@ export default function ChatPanel({
       animate={{ opacity: 1, y: 0, scale: 1 }}
       exit={{ opacity: 0, y: 20, scale: 0.95 }}
       transition={{ duration: 0.2 }}
-      className="absolute bottom-16 right-0 w-[calc(100vw-2rem)] max-w-[380px] max-h-[70vh] sm:max-h-[500px] glass rounded-2xl border border-border flex flex-col overflow-hidden shadow-2xl"
+      className="absolute bottom-16 right-0 w-[calc(100vw-2rem)] max-w-[380px] max-h-[70dvh] sm:max-h-[500px] glass rounded-2xl border border-border flex flex-col overflow-hidden shadow-2xl"
     >
       <div className="flex items-center justify-between px-4 py-3 border-b border-border">
         <div className="flex items-center gap-2 min-w-0">

--- a/frontend/src/components/chat/ChatWidget.tsx
+++ b/frontend/src/components/chat/ChatWidget.tsx
@@ -51,8 +51,13 @@ export default function ChatWidget() {
 
   return (
     <div
-      className="fixed right-6 z-40"
-      style={{ bottom: 'calc(env(safe-area-inset-bottom, 0px) + 1.5rem)' }}
+      className="fixed z-40"
+      style={{
+        // Park the widget above the iOS home bar and clear any right-edge
+        // safe-area inset (landscape on notched devices).
+        bottom: 'calc(env(safe-area-inset-bottom, 0px) + 1.5rem)',
+        right: 'calc(env(safe-area-inset-right, 0px) + 1.5rem)',
+      }}
     >
       <AnimatePresence>
         {isOpen && isConfigured && (

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -59,7 +59,7 @@ export default function AppLayout() {
   }, [location.pathname])
 
   return (
-    <div className="flex h-screen bg-black relative overflow-hidden">
+    <div className="flex h-dvh bg-black relative overflow-hidden">
       {isDemoMode && <DemoBanner />}
 
       {/* Skip to main content link for keyboard users */}
@@ -85,7 +85,17 @@ export default function AppLayout() {
       />
 
       <Sidebar />
-      <main id="main-content" className="flex-1 overflow-auto relative z-10">
+      {/*
+        Mobile PWA notes:
+        - `overscroll-contain` stops the rubber-band scroll from bleeding into
+          the document (which otherwise shows a white flash under the notch).
+        - `pb-safe` on the scrollable main means the last row of any page
+          clears the iOS home indicator without every page having to add it.
+      */}
+      <main
+        id="main-content"
+        className="flex-1 overflow-auto overscroll-contain relative z-10 pb-safe"
+      >
         <AnimatePresence mode="popLayout">
           <motion.div key={location.pathname} {...pageTransition}>
             <Outlet />

--- a/frontend/src/components/layout/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar/Sidebar.tsx
@@ -223,11 +223,15 @@ export default function Sidebar() {
 
   return (
     <>
-      {/* Mobile toggle -- offset by safe-area-inset-top so it clears the iOS notch in PWA mode. */}
+      {/* Mobile toggle -- offset by safe-area-inset-top so it clears the iOS notch in PWA mode.
+          Left offset also respects safe-area-inset-left for landscape on notched devices. */}
       <button
         onClick={() => setIsMobileOpen(!isMobileOpen)}
-        className="lg:hidden fixed left-4 z-50 w-11 h-11 flex items-center justify-center rounded-xl bg-zinc-900/90 border border-white/[0.08] backdrop-blur-sm active:scale-95 transition-transform"
-        style={{ top: 'calc(env(safe-area-inset-top, 0px) + 0.75rem)' }}
+        className="lg:hidden fixed z-50 w-11 h-11 flex items-center justify-center rounded-xl bg-zinc-900/90 border border-white/[0.08] backdrop-blur-sm active:scale-95 transition-transform"
+        style={{
+          top: 'calc(env(safe-area-inset-top, 0px) + 0.75rem)',
+          left: 'calc(env(safe-area-inset-left, 0px) + 1rem)',
+        }}
         aria-label={isMobileOpen ? 'Close menu' : 'Open menu'}
       >
         {isMobileOpen
@@ -235,17 +239,20 @@ export default function Sidebar() {
           : <Menu size={20} className="text-white" />}
       </button>
 
-      {/* Sidebar */}
+      {/* Sidebar -- h-dvh so the nav tracks the real viewport height
+          (h-screen = 100vh jumps when the mobile browser address bar toggles). */}
       <aside
         className={cn(
-          'fixed lg:sticky top-0 h-screen w-64 z-40',
+          'fixed lg:sticky top-0 h-dvh w-64 z-40',
           'bg-[#111113]/95 backdrop-blur-sm',
           'border-r border-border',
           'transition-transform duration-200 ease-out',
           isMobileOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0',
         )}
       >
-        <div className="flex flex-col h-full">
+        {/* pt-safe ensures the brand row clears the iOS notch when the drawer
+            opens in PWA standalone mode; desktop gets no extra padding. */}
+        <div className="flex flex-col h-full pt-safe">
           {/* Brand Header */}
           <BrandHeader
             user={isDemoMode ? { email: 'Demo Mode' } : user}

--- a/frontend/src/components/ui/PageHeader.tsx
+++ b/frontend/src/components/ui/PageHeader.tsx
@@ -22,18 +22,29 @@ const PageHeader = memo(function PageHeader({ title, subtitle, action }: PageHea
     return () => main.removeEventListener('scroll', onScroll)
   }, [])
 
+  // Sticky headers get painted at the viewport edge, so in PWA standalone
+  // mode the title lands under the notch unless we add safe-area padding.
+  // We bake env(safe-area-inset-top) into the padding calc. The compressed
+  // state on scroll keeps the same inset -- only the design padding shrinks.
+  const basePadTop = scrolled ? '0.75rem' : '1rem'
+  const basePadBottom = scrolled ? '0.75rem' : '1rem'
+
   return (
     <motion.div
       initial={{ opacity: 0, y: -10 }}
       animate={{ opacity: 1, y: 0 }}
       className="sticky top-0 z-20 -mx-4 md:-mx-6 lg:-mx-8 px-4 md:px-6 lg:px-8 py-3 md:py-4 transition-all duration-150 ease-out backdrop-blur-md bg-black/80"
       style={{
-        paddingTop: scrolled ? '0.75rem' : '1rem',
-        paddingBottom: scrolled ? '0.75rem' : '1rem',
+        paddingTop: `calc(${basePadTop} + env(safe-area-inset-top, 0px))`,
+        paddingBottom: basePadBottom,
+        paddingLeft: 'max(1rem, env(safe-area-inset-left))',
+        paddingRight: 'max(1rem, env(safe-area-inset-right))',
       }}
     >
-      {/* Mobile: stack + center everything (title, subtitle, action). 48px of horizontal
-          padding on the title block reserves room for the lg:hidden hamburger at top-4 left-4.
+      {/* Mobile: stack + center everything (title, subtitle, action). The title
+          block reserves horizontal room for the lg:hidden hamburger which sits at
+          `calc(safe-area-inset-left + 1rem)` top-left. 3rem of padding on each
+          side keeps the centered title balanced and clear of the button.
           Desktop (sm+): reverts to the original row layout with title left, action right. */}
       <div className="flex flex-col items-center text-center sm:flex-row sm:items-start sm:justify-between sm:text-left gap-3 sm:gap-4">
         <div className="min-w-0 px-12 sm:px-0">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -115,14 +115,27 @@ html {
   -moz-osx-font-smoothing: grayscale;
   scrollbar-width: thin;
   scrollbar-color: rgba(255, 255, 255, 0.10) transparent;
+  /* Needed so child elements using `h-dvh` / `100dvh` have a reference
+     height and so mobile browsers render a consistent full-height layout. */
+  height: 100%;
 }
 
 body {
+  margin: 0;
+  padding: 0;
+  min-height: 100%;
   background: #000000;
   background-attachment: fixed;
   color: var(--color-foreground);
   font-family: -apple-system, BlinkMacSystemFont, 'Inter', system-ui, sans-serif;
   overflow-x: hidden;
+  /* Prevent iOS from rubber-banding the whole body behind the app shell --
+     scrollable regions handle their own overscroll. */
+  overscroll-behavior-y: none;
+}
+
+#root {
+  height: 100%;
 }
 
 /* ===== GLASS / SURFACE SYSTEM ===== */

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -19,8 +19,8 @@ export default defineConfig({
         short_name: 'Ledger',
         description:
           'Self-hosted personal finance dashboard -- analytics, budgeting, and tax planning.',
-        theme_color: '#09090b',
-        background_color: '#09090b',
+        theme_color: '#000000',
+        background_color: '#000000',
         display: 'standalone',
         orientation: 'portrait',
         // start_url is relative to Vite's `base`, so it resolves to /ledger-sync/ on GH Pages.


### PR DESCRIPTION
- AppLayout: h-dvh so content tracks dynamic viewport height (no jump when mobile address bar toggles); main gets pb-safe + overscroll-contain so the last row clears the home indicator and rubber-band doesn't flash white behind the notch.
- Sidebar: h-dvh for the aside, pt-safe on the inner column so the brand row clears the notch when the mobile drawer opens; hamburger now offsets by env(safe-area-inset-left) for landscape notched devices.
- PageHeader: sticky header bakes env(safe-area-inset-top) into paddingTop so the title never renders under the status bar in PWA standalone mode; horizontal padding uses max(1rem, inset-left/right).
- index.css: html { height: 100% } (reference for dvh), body margin/padding reset + overscroll-behavior-y: none; #root { height: 100% }.
- ChatPanel: 70dvh max-height; ChatWidget button offset by safe-area-inset-right for landscape.
- index.html + manifest: theme-color aligned to #000000 so the status bar blends into the page (no seam at the top).