### PR TITLE
fix: HomePage PWA notch + credit-card classification

### DIFF
--- a/frontend/src/components/analytics/CreditCardHealth.tsx
+++ b/frontend/src/components/analytics/CreditCardHealth.tsx
@@ -2,10 +2,17 @@ import { useMemo } from 'react'
 
 import { motion } from 'framer-motion'
 import { CreditCard, AlertTriangle, CheckCircle } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
 
 import { useAccountBalances } from '@/hooks/api/useAnalytics'
+import { accountClassificationsService } from '@/services/api/accountClassifications'
 import { formatCurrency, formatPercent } from '@/lib/formatters'
 import { usePreferencesStore, selectCreditCardLimits } from '@/store/preferencesStore'
+
+// Backend enum value -- see backend/src/ledger_sync/db/_models/enums.py.
+// The TS type in accountClassifications.ts says 'Credit Card' (singular) but
+// the API actually returns 'Credit Cards'. We match the server string.
+const CREDIT_CARD_TYPE = 'Credit Cards'
 
 interface CreditCardAccount {
   name: string
@@ -19,8 +26,20 @@ interface CreditCardAccount {
 const DEFAULT_CREDIT_LIMIT = 100000
 
 export default function CreditCardHealth() {
-  const { data: balanceData, isLoading } = useAccountBalances()
+  const { data: balanceData, isLoading: isBalanceLoading } = useAccountBalances()
   const creditCardLimits = usePreferencesStore(selectCreditCardLimits)
+
+  // Primary classification source: user-maintained account types from
+  // Settings -> Accounts. Previously this component only looked for the
+  // literal word "credit" in the account name -- cards named "HDFC Millennia"
+  // or "Amazon Pay Card" were silently dropped.
+  const { data: classifications, isLoading: isClassifyLoading } = useQuery({
+    queryKey: ['account-classifications'],
+    queryFn: () => accountClassificationsService.getAllClassifications(),
+    staleTime: Infinity,
+  })
+
+  const isLoading = isBalanceLoading || isClassifyLoading
 
   const creditCards = useMemo((): CreditCardAccount[] => {
     if (!balanceData?.accounts) return []
@@ -28,8 +47,15 @@ export default function CreditCardHealth() {
     const cards: CreditCardAccount[] = []
 
     Object.entries(balanceData.accounts).forEach(([name, data]) => {
-      // Check if it's a credit card account
-      if (name.toLowerCase().includes('credit')) {
+      // Prefer the user's explicit classification. Fall back to the old name
+      // match only when the account hasn't been classified yet -- so users
+      // who haven't visited Settings > Accounts still see their cards.
+      const classifiedType = classifications?.[name]
+      const isClassifiedCreditCard = classifiedType === CREDIT_CARD_TYPE
+      const isNameHintedCreditCard =
+        !classifiedType && name.toLowerCase().includes('credit')
+
+      if (isClassifiedCreditCard || isNameHintedCreditCard) {
         const balance = Math.abs((data as { balance: number; transactions: number }).balance)
         const creditLimit = creditCardLimits[name] || DEFAULT_CREDIT_LIMIT
         const utilization = (balance / creditLimit) * 100
@@ -51,7 +77,7 @@ export default function CreditCardHealth() {
     })
 
     return cards.sort((a, b) => b.utilization - a.utilization)
-  }, [balanceData, creditCardLimits])
+  }, [balanceData, creditCardLimits, classifications])
 
   const totalBalance = creditCards.reduce((sum, c) => sum + c.balance, 0)
   const totalLimit = creditCards.reduce((sum, c) => sum + c.creditLimit, 0)

--- a/frontend/src/pages/home/HomePage.tsx
+++ b/frontend/src/pages/home/HomePage.tsx
@@ -81,9 +81,21 @@ export default function HomePage() {
   }
 
   return (
-    <div className="min-h-screen flex flex-col">
-      {/* Header */}
-      <header className="fixed top-0 left-0 right-0 z-40 backdrop-blur-xl bg-black/50 border-b border-border">
+    <div className="min-h-dvh flex flex-col">
+      {/*
+        PWA standalone mode has no browser chrome, so `fixed top-0` paints the
+        header flush against the device edge -- straight behind the iOS notch.
+        We bake env(safe-area-inset-top) into paddingTop so the logo and auth
+        button sit below the notch. Same horizontal trick for landscape.
+      */}
+      <header
+        className="fixed top-0 left-0 right-0 z-40 backdrop-blur-xl bg-black/50 border-b border-border"
+        style={{
+          paddingTop: 'env(safe-area-inset-top, 0px)',
+          paddingLeft: 'env(safe-area-inset-left, 0px)',
+          paddingRight: 'env(safe-area-inset-right, 0px)',
+        }}
+      >
         <div className="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
           {/* Logo */}
           <Link to="/" className="flex items-center gap-3 group">
@@ -118,8 +130,16 @@ export default function HomePage() {
         </div>
       </header>
 
-      {/* Main Content */}
-      <main className="flex-1 pt-20">
+      {/*
+        Main content sits below the fixed header. The header is ~80px tall
+        PLUS env(safe-area-inset-top) in PWA mode, so we add both here to
+        keep the hero section from sliding under the notch. On regular mobile
+        Safari inset-top is 0, so this degrades cleanly to the original 80px.
+      */}
+      <main
+        className="flex-1"
+        style={{ paddingTop: 'calc(5rem + env(safe-area-inset-top, 0px))' }}
+      >
         {/* Hero Section */}
         <section className="relative overflow-hidden">
           {/* Background Effects */}
@@ -506,8 +526,12 @@ export default function HomePage() {
           </div>
         </section>
 
-        {/* Footer */}
-        <footer className="py-8 border-t border-border">
+        {/* Footer -- safe-area padding so the home-indicator doesn't overlap
+            the tagline on iOS standalone. */}
+        <footer
+          className="py-8 border-t border-border"
+          style={{ paddingBottom: 'calc(2rem + env(safe-area-inset-bottom, 0px))' }}
+        >
           <div className="max-w-6xl mx-auto px-6 text-center">
             <p className="text-sm text-text-tertiary">
               Made with ❤️ for better financial management


### PR DESCRIPTION
## Summary

Two small, independent mobile bugs surfaced from phone testing after PR #127:

**HomePage PWA alignment** — Landing page is outside `AppLayout`, so the safe-area work from #126 didn't reach it. In iOS PWA standalone mode the fixed header painted *behind the notch* and the hero slid up with it, making the top look clipped and the bottom look oversized. Now the header respects `env(safe-area-inset-top/left/right)` and the footer respects `safe-area-inset-bottom` so the tagline clears the home indicator. `h-screen` → `min-h-dvh`.

**CreditCardHealth classification** — The component was matching credit cards by substring-greping `"credit"` in the account name. Cards named `"HDFC Millennia"` or `"Amazon Pay Card"` were silently dropped even though they were classified as `"Credit Cards"` in **Settings → Accounts**. Now queries `/api/account-classifications` and filters on the user-set type; the name match remains as a fallback only when an account has no classification yet (so untouched users don't regress).

## Test plan

- [ ] Install PWA on iPhone → open landing page → logo + hero sit below the notch; footer tagline clears the home bar
- [ ] Open regular mobile Safari → landing page unchanged (inset-top = 0, degrades cleanly)
- [ ] Net Worth page → Credit Card Health card: rename a card in Settings → Accounts to something without "credit" in the name, classify it as "Credit Cards" → card still appears in the widget
- [ ] An unclassified account with "credit" in its name still appears (fallback path)