### PR TITLE
fix: filter excluded_accounts consistently across all transaction queries

### DIFF
--- a/backend/src/ledger_sync/api/transactions.py
+++ b/backend/src/ledger_sync/api/transactions.py
@@ -13,7 +13,8 @@ from sqlalchemy.orm import Query as SAQuery
 from sqlalchemy.orm import Session
 
 from ledger_sync.api.deps import CurrentUser, DatabaseSession
-from ledger_sync.db.models import Transaction, TransactionType
+from ledger_sync.core.query_helpers import excluded_accounts_for
+from ledger_sync.db.models import Transaction, TransactionType, User
 from ledger_sync.ingest.hash_id import TransactionHasher
 from ledger_sync.schemas.transactions import (
     TransactionCreateRequest,
@@ -173,12 +174,25 @@ def _to_transaction_response(tx: Transaction) -> TransactionResponse:
     )
 
 
-def _base_transaction_query(db: Session, user_id: int) -> SAQuery[Transaction]:
-    """Create base query for non-deleted transactions filtered by user."""
-    return db.query(Transaction).filter(
-        Transaction.user_id == user_id,
+def _base_transaction_query(db: Session, user: User) -> SAQuery[Transaction]:
+    """Create base query for non-deleted, non-excluded transactions for user.
+
+    Honours the user's ``excluded_accounts`` preference via
+    ``excluded_accounts_for`` so the raw transactions endpoints stay
+    consistent with the analytics pipeline.
+    """
+    query = db.query(Transaction).filter(
+        Transaction.user_id == user.id,
         Transaction.is_deleted.is_(False),
     )
+    excluded = excluded_accounts_for(user)
+    if excluded:
+        query = query.filter(
+            Transaction.account.notin_(excluded),
+            Transaction.from_account.is_(None) | Transaction.from_account.notin_(excluded),
+            Transaction.to_account.is_(None) | Transaction.to_account.notin_(excluded),
+        )
+    return query
 
 
 def _apply_date_range(
@@ -226,7 +240,7 @@ async def get_transactions(
 
     """
     # Build query - filter by user and date range
-    query = _base_transaction_query(db, current_user.id)
+    query = _base_transaction_query(db, current_user)
     query = _apply_date_range(query, start_date, end_date)
 
     # Get total count before pagination
@@ -257,7 +271,7 @@ async def get_all_transactions(
     for client-side aggregation. No pagination overhead — one request, one
     response.
     """
-    query = _base_transaction_query(db, current_user.id)
+    query = _base_transaction_query(db, current_user)
     query = _apply_date_range(query, start_date, end_date)
 
     transactions = query.order_by(Transaction.date.desc()).all()
@@ -297,7 +311,7 @@ async def search_transactions(
 
     """
     # Start with base query - filter by user
-    tx_query = _base_transaction_query(db, current_user.id)
+    tx_query = _base_transaction_query(db, current_user)
 
     # Apply all search filters
     tx_query = _apply_search_filters(tx_query, filters)
@@ -327,7 +341,7 @@ async def export_transactions(
     end_date: Annotated[datetime | None, Query(description=END_DATE_DESC)] = None,
 ) -> Response:
     """Export all non-deleted transactions as CSV for the current user."""
-    query = _base_transaction_query(db, current_user.id)
+    query = _base_transaction_query(db, current_user)
     query = _apply_date_range(query, start_date, end_date)
     transactions = query.all()
 

--- a/backend/src/ledger_sync/core/analytics/base.py
+++ b/backend/src/ledger_sync/core/analytics/base.py
@@ -233,14 +233,24 @@ class AnalyticsEngineBase:
     def _user_transaction_query(self) -> Query[Transaction]:
         """Base query for non-deleted transactions, user-scoped and filtered.
 
-        Respects the user's ``excluded_accounts`` preference.
+        Respects the user's ``excluded_accounts`` preference -- drops rows
+        whose ``account``, ``from_account``, or ``to_account`` matches an
+        excluded name. Transfers store ``account = from_account``, so a
+        check on ``account`` alone misses transfers landing in an
+        excluded account (the credit side ends up in net worth).
         """
         query = self.db.query(Transaction).filter(Transaction.is_deleted.is_(False))
         if self.user_id is not None:
             query = query.filter(Transaction.user_id == self.user_id)
         excluded = self.excluded_accounts
         if excluded:
-            query = query.filter(Transaction.account.notin_(excluded))
+            query = query.filter(
+                Transaction.account.notin_(excluded),
+                Transaction.from_account.is_(None)
+                | Transaction.from_account.notin_(excluded),
+                Transaction.to_account.is_(None)
+                | Transaction.to_account.notin_(excluded),
+            )
         return query
 
     # ─── fiscal year helper (shared by summaries and fy_summaries mixins) ──

--- a/backend/src/ledger_sync/core/query_helpers.py
+++ b/backend/src/ledger_sync/core/query_helpers.py
@@ -4,6 +4,7 @@ Centralises duplicated patterns such as income/expense conditional
 aggregation columns and the base filtered-transaction query builder.
 """
 
+import json
 from datetime import UTC, datetime
 from typing import Any
 
@@ -146,6 +147,27 @@ def expense_sum_col(subquery: Subquery, *, label: str = "total_expenses") -> Any
 # ---------------------------------------------------------------------------
 
 
+def excluded_accounts_for(user: User) -> set[str]:
+    """Return the user's ``excluded_accounts`` preference as a set.
+
+    Lazy-loads ``user.preferences``. Returns an empty set when the
+    preference is missing or the JSON is malformed -- the analytics
+    pipeline treats no-preference as "exclude nothing", and the same
+    semantics apply here.
+    """
+    prefs = user.preferences
+    raw = getattr(prefs, "excluded_accounts", None) if prefs else None
+    if not raw:
+        return set()
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        return set()
+    if not isinstance(parsed, list):
+        return set()
+    return {str(a) for a in parsed if a}
+
+
 def build_transaction_query(
     db: Session,
     user: User,
@@ -153,6 +175,7 @@ def build_transaction_query(
     end_date: datetime | None = None,
     *,
     apply_earning_start: bool = False,
+    apply_excluded_accounts: bool = True,
 ) -> Query[Transaction]:
     """Build a filtered ``Transaction`` query for *user*.
 
@@ -161,6 +184,13 @@ def build_transaction_query(
     * ``is_deleted = False`` filter
     * Earning-start-date clamping (**opt-in** via *apply_earning_start=True*)
     * Optional *start_date* / *end_date* range filters
+    * Excluded-accounts filter (**default on**) -- drops rows whose
+      ``account``, ``from_account``, or ``to_account`` matches the
+      user's ``excluded_accounts`` preference. Without this, transfers
+      landing in an excluded account silently leak through (transfers
+      store ``account = from_account``, so a check on ``account`` alone
+      misses the credit side). Pass *apply_excluded_accounts=False* to
+      get the unfiltered set (e.g. for diagnostic admin tooling).
 
     Earning-start is a *view* preference (chart x-axis lower bound),
     not a data-boundary. Most callers want factual totals/balances across
@@ -183,5 +213,16 @@ def build_transaction_query(
         query = query.filter(Transaction.date >= start_date)
     if end_date:
         query = query.filter(Transaction.date <= end_date)
+
+    if apply_excluded_accounts:
+        excluded = excluded_accounts_for(user)
+        if excluded:
+            query = query.filter(
+                Transaction.account.notin_(excluded),
+                Transaction.from_account.is_(None)
+                | Transaction.from_account.notin_(excluded),
+                Transaction.to_account.is_(None)
+                | Transaction.to_account.notin_(excluded),
+            )
 
     return query

--- a/backend/src/ledger_sync/utils/logging.py
+++ b/backend/src/ledger_sync/utils/logging.py
@@ -64,6 +64,14 @@ def setup_logging(log_level: str | None = None) -> logging.Logger:
         # Analytics-specific logger for detailed import/calculation tracking
         analytics_logger = logging.getLogger("ledger_sync.analytics")
         analytics_logger.setLevel(logging.DEBUG)
+        # Clear stale handlers so dev auto-reloads don't duplicate every line.
+        # Without this each module re-import attaches another RotatingFileHandler,
+        # producing N copies of every analytics log line after N reloads.
+        analytics_logger.handlers = []
+        # Don't propagate to the parent ledger_sync logger -- analytics has
+        # its own dedicated file handler and we don't want each line to
+        # also land in ledger_sync.log via the parent's file_handler.
+        analytics_logger.propagate = False
 
         analytics_handler = RotatingFileHandler(
             log_dir / "analytics.log",

--- a/backend/tests/integration/test_analytics_user_scoping.py
+++ b/backend/tests/integration/test_analytics_user_scoping.py
@@ -131,3 +131,82 @@ def test_detect_large_transactions_scopes_by_user(analytics_db: Session) -> None
     anomalies_b: list[dict] = []
     engine_b._detect_large_transactions(anomalies_b)
     assert anomalies_b == []
+
+
+def test_excluded_accounts_filter_drops_transfer_endpoints(analytics_db: Session) -> None:
+    """A transfer landing in an excluded account must not appear in the user query.
+
+    Regression test: previously the filter only checked ``Transaction.account``.
+    For transfers, ``account = from_account``, so a transfer FROM a regular
+    account TO an excluded account passed the filter and silently inflated
+    net worth via ``compute_account_balances``.
+    """
+    from ledger_sync.db.models import UserPreferences
+
+    user = _make_user(analytics_db, "transfer-exclude@example.com")
+    analytics_db.add(
+        UserPreferences(
+            user_id=user.id,
+            excluded_accounts='["Wife Account"]',
+        ),
+    )
+    now = datetime.now(UTC) - timedelta(days=1)
+
+    # Three rows for the same user:
+    #   1. Plain expense from HDFC (kept)
+    #   2. Transfer FROM HDFC TO "Wife Account" (must be dropped)
+    #   3. Transfer FROM "Wife Account" TO HDFC (must be dropped)
+    analytics_db.add_all([
+        Transaction(
+            user_id=user.id,
+            transaction_id="t-keep",
+            date=datetime(2024, 1, 15, tzinfo=UTC),
+            amount=Decimal("100"),
+            currency="INR",
+            type=TransactionType.EXPENSE,
+            account="HDFC",
+            category="Food",
+            source_file="test.xlsx",
+            last_seen_at=now,
+            is_deleted=False,
+        ),
+        Transaction(
+            user_id=user.id,
+            transaction_id="t-out-to-wife",
+            date=datetime(2024, 2, 15, tzinfo=UTC),
+            amount=Decimal("5000"),
+            currency="INR",
+            type=TransactionType.TRANSFER,
+            account="HDFC",
+            from_account="HDFC",
+            to_account="Wife Account",
+            category="Transfer",
+            source_file="test.xlsx",
+            last_seen_at=now,
+            is_deleted=False,
+        ),
+        Transaction(
+            user_id=user.id,
+            transaction_id="t-in-from-wife",
+            date=datetime(2024, 3, 15, tzinfo=UTC),
+            amount=Decimal("3000"),
+            currency="INR",
+            type=TransactionType.TRANSFER,
+            account="Wife Account",
+            from_account="Wife Account",
+            to_account="HDFC",
+            category="Transfer",
+            source_file="test.xlsx",
+            last_seen_at=now,
+            is_deleted=False,
+        ),
+    ])
+    analytics_db.commit()
+
+    engine = AnalyticsEngine(analytics_db, user_id=user.id)
+    rows = engine._user_transaction_query().all()
+
+    assert {tx.transaction_id for tx in rows} == {"t-keep"}, (
+        "Both transfer rows touching 'Wife Account' should be filtered, "
+        f"got {[tx.transaction_id for tx in rows]}"
+    )

--- a/frontend/src/hooks/api/useTransactions.ts
+++ b/frontend/src/hooks/api/useTransactions.ts
@@ -1,68 +1,24 @@
-import { useMemo } from 'react'
-
 import { useQuery } from '@tanstack/react-query'
 
 import { transactionsService, type TransactionFilters } from '@/services/api/transactions'
 
-import { usePreferences } from './usePreferences'
-
-/**
- * Parse excluded_accounts from preferences (may be JSON string or array).
- */
-function parseExcludedAccounts(raw: string[] | string | undefined): Set<string> {
-  if (!raw) return new Set()
-  let arr: string[]
-  if (Array.isArray(raw)) {
-    arr = raw
-  } else {
-    try {
-      const parsed = JSON.parse(raw)
-      arr = Array.isArray(parsed) ? parsed : []
-    } catch {
-      arr = []
-    }
-  }
-  return new Set(arr.map((a) => a.toLowerCase()))
-}
-
 /**
  * Fetch the user's transactions.
  *
- * Filters applied here are *account-level* data filters (excluded accounts).
+ * Account-level data filters (excluded accounts) are applied server-side --
+ * see ``api/transactions.py::_base_transaction_query``.
+ *
  * Earning-start-date is a **view** preference (chart x-axis lower bound) and
  * is intentionally NOT applied here -- consumers that need view-window
  * cropping should apply it at the chart/series level (see
- * `useAnalyticsTimeFilter`).
+ * ``useAnalyticsTimeFilter``).
  */
 export function useTransactions(filters?: TransactionFilters) {
-  const { data: preferences } = usePreferences()
-
-  const query = useQuery({
+  return useQuery({
     queryKey: ['transactions', filters],
     queryFn: () => transactionsService.getTransactions(filters),
     // Transactions only change on upload (which invalidates this key).
     // Keep cached data fresh indefinitely to avoid refetching on navigation.
     staleTime: Infinity,
   })
-
-  // Filter out transactions from excluded accounts before returning
-  const excludedAccounts = useMemo(
-    () => parseExcludedAccounts(preferences?.excluded_accounts),
-    [preferences?.excluded_accounts],
-  )
-
-  const filteredData = useMemo(() => {
-    if (!query.data) return query.data
-    if (excludedAccounts.size === 0) return query.data
-    return query.data.filter((tx) => {
-      const account = tx.account?.toLowerCase()
-      if (account && excludedAccounts.has(account)) return false
-      return true
-    })
-  }, [query.data, excludedAccounts])
-
-  return {
-    ...query,
-    data: filteredData,
-  }
 }

--- a/frontend/src/lib/demo/enterDemoMode.ts
+++ b/frontend/src/lib/demo/enterDemoMode.ts
@@ -11,7 +11,7 @@ import { seedDemoCache } from './seedDemoCache'
 import { generateDemoPreferences } from './generateDerivedData'
 
 export const DEMO_USER = {
-  id: 0,
+  id: -1,
   email: 'demo@ledger-sync.app',
   full_name: 'Demo User',
   is_active: true,

--- a/frontend/src/lib/demo/generateDerivedData.ts
+++ b/frontend/src/lib/demo/generateDerivedData.ts
@@ -121,7 +121,7 @@ export function generateDemoPreferences(): UserPreferences {
   const earningStart = new Date(now.getFullYear() - 2, now.getMonth(), 1).toISOString().slice(0, 10)
 
   return {
-    id: 0,
+    id: -1,
     fiscal_year_start_month: 4,
     essential_categories: ESSENTIAL_CATEGORIES,
     investment_account_mappings: {


### PR DESCRIPTION
## Summary

Three code paths each had separate `excluded_accounts` handling and they disagreed on transfers:

- `core/analytics/base.py::_user_transaction_query` (writes pre-aggregated tables on upload) checked `Transaction.account` only.
- `core/query_helpers.py::build_transaction_query` (used by every on-the-fly `/api/calculations/*` and `/api/analytics/*` endpoint) didn't check at all.
- `api/transactions.py::_base_transaction_query` (raw transactions endpoints) didn't check either; the frontend `useTransactions` hook re-filtered client-side after fetching.

Transfers store `account = from_account`, so a `Transaction.account` check silently leaks the credit side when a transfer **lands in** an excluded account. `compute_account_balances` then attributes the credit to the excluded account and bucketing inflates Net Worth by that amount.

Same problem in three places, three slightly-different rules. Net result: the same dashboard metric could differ depending on which time filter was selected (fast-path vs. fallback), and excluded accounts could still appear on Net Worth, the Sankey, transfer flows, and the Transactions table.

## Fix

- New shared helper `excluded_accounts_for(user)` in `query_helpers`, parses the JSON-encoded preference into a set with safe defaults.
- `build_transaction_query` gains `apply_excluded_accounts=True` flag (default on); calculations/analytics endpoints get correct behaviour for free.
- Analytics base + transactions API both adopt the same three-clause filter (`account`, `from_account`, `to_account`).
- Frontend `useTransactions` reverts to a plain `useQuery` -- backend is now the single source of truth, no client-side re-filter, no race with preferences hydration.
- Regression test in `test_analytics_user_scoping.py` seeds three rows (one expense, two transfers touching the excluded account) and asserts only the expense survives the filter.

## Riding along (cosmetic, same area)

- Demo user `id` and demo preferences `id` flipped from `0` -> `-1`. Auto-increment for real users starts at 1, so 0 wouldn't collide today, but `-1` makes the sentinel impossible to confuse with a real row after any future migration / restore.
- Logging fix: `analytics_logger.handlers` cleared and `propagate = False` set before adding the file handler. Dev auto-reload was attaching a fresh `RotatingFileHandler` on every module re-import, producing N copies of every line in `analytics.log` after N reloads. Production (no auto-reload) was unaffected, but local logs were unreadable.

## Verification

- 113 backend tests pass (was 112 + 1 new regression test)
- `mypy` clean, `ruff` clean
- Frontend `tsc -b`, `eslint`, `vitest` all clean

Existing pre-aggregated tables computed under the old rule will be corrected on the next upload (`run_full_analytics` recomputes them). Users with no excluded accounts see no change either way.