### PR TITLE
docs: README overhaul + sync versions to 2.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,140 +1,199 @@
-# Ledger Sync -- Your Personal Finance Dashboard
+# Ledger Sync — Your Personal Finance Dashboard
 
-**See where every rupee goes.** Import your bank statements, get instant insights, and finally understand your money -- all from a single, self-hosted dashboard you actually own.
+**See where every rupee goes — and ask why.**
+Import bank statements, get instant analytics, then chat with your finances using GPT-4 / Claude. Self-hosted, multi-currency, zero subscriptions.
 
-No subscriptions. No data harvesting. Just a focused set of analytics pages built from your own Excel exports, running on your own infrastructure.
+[![Version](https://img.shields.io/github/package-json/v/Sagargupta16/ledger-sync?filename=frontend%2Fpackage.json&label=version&color=brightgreen)](https://github.com/Sagargupta16/ledger-sync/releases)
+[![CI](https://github.com/Sagargupta16/ledger-sync/actions/workflows/ci.yml/badge.svg)](https://github.com/Sagargupta16/ledger-sync/actions/workflows/ci.yml)
+[![SonarCloud](https://sonarcloud.io/api/project_badges/measure?project=Sagargupta16_ledger-sync&metric=alert_status)](https://sonarcloud.io/dashboard?id=Sagargupta16_ledger-sync)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+![Last commit](https://img.shields.io/github/last-commit/Sagargupta16/ledger-sync)
+[![Stars](https://img.shields.io/github/stars/Sagargupta16/ledger-sync?style=social)](https://github.com/Sagargupta16/ledger-sync)
 
-![Version](https://img.shields.io/badge/version-2.9.0-green.svg)
-![License](https://img.shields.io/badge/license-MIT-blue.svg)
-![Python](https://img.shields.io/badge/python-3.11+-blue.svg)
-![React](https://img.shields.io/badge/react-19-blue.svg)
-![TypeScript](https://img.shields.io/badge/typescript-5.9-blue.svg)
+---
 
-**Live:** [sagargupta.online/ledger-sync](https://sagargupta.online/ledger-sync/) | **Demo:** [Try it now](https://sagargupta.online/ledger-sync/demo) | **API:** [ledger-sync-api.vercel.app](https://ledger-sync-api.vercel.app/docs)
+## Why this exists
+
+Mint shut down. YNAB costs $14.99/mo and doesn't understand Indian bank statements. This is what I built for myself: bring your own data, run it on your own server, no subscription, no ads, no data harvesting. Indian fiscal year, multi-currency, 50/30/20 + tax + FIRE analytics out of the box.
+
+**Just want to try it?** → [Live demo](https://sagargupta.online/ledger-sync/demo) (no signup, sample data)
+
+**Want to use it for real?** → [Sign in to the hosted version](https://sagargupta.online/ledger-sync/) (free, your data stays yours)
+
+**Want to run it yourself?** → [Self-hosting guide](docs/DEPLOYMENT.md) — or one-click:
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FSagargupta16%2Fledger-sync)
 
 ## Features
 
-### AI Finance Chatbot (tool-calling, app or BYOK)
+### AI Finance Chatbot
 
-- **Chat with your financial data** -- floating widget in the bottom-right corner, ask any question about your spending, trends, tax, or goals
-- **Two modes:**
-  - **App mode (default)** -- zero setup, works immediately for every new user. Uses the server's shared Bedrock key, rate-limited to 10 messages/day (configurable via `LEDGER_SYNC_AI_DAILY_MESSAGE_LIMIT`)
-  - **BYOK mode** -- paste your own OpenAI / Anthropic / AWS Bedrock key in Settings for unlimited use; your key is encrypted at rest with AES-256-GCM and per-user daily/monthly token caps are available
-- **Tool calling (not context stuffing)** -- the bot has 15 read-only tools (`search_transactions`, `get_monthly_summary`, `get_net_worth`, `get_fy_summary`, `get_category_spending`, `list_recurring`, `list_goals`, `get_investment_holdings`, and more) and picks what to call based on your question. Works across OpenAI, Anthropic, and Bedrock with a shared tool schema
-- **Latest models** -- OpenAI (O3, O4 Mini, GPT-4.1, GPT-4o), Anthropic (Claude Opus 4.7, Sonnet 4.6, Haiku 4.5), AWS Bedrock (same Claude models)
-- **Usage tracking** -- every round-trip is logged (tokens in/out, estimated USD); today / month-to-date / all-time rollups visible in the chat widget badge
-- **User-scoped** -- every tool is enforced at the FastAPI dependency level with `CurrentUser`; the LLM cannot see another user's data
-- **Hidden in demo mode** -- chat widget only appears when you're logged in
+- Floating chat widget — ask any question about your spending, trends, tax, or goals
+- Tool calling (15 read-only tools) across OpenAI, Anthropic, and AWS Bedrock; the LLM is user-scoped at the FastAPI dependency level
+- App mode (free, rate-limited to 10 messages/day) or BYOK mode (your key, unlimited; encrypted at rest with AES-256-GCM, per-user token caps)
 
 ### Demo Mode
 
-- **Try before you sign up** - Click "Try Demo" on the landing page or visit `/demo` directly
-- Explore the full dashboard with ~500 realistic sample transactions (Indian household model)
-- All 23 pages render with pre-computed analytics data, zero backend calls
-- Floating banner with quick sign-up and exit options
-- Mutations (upload, settings, budgets, goals) are gracefully blocked with toast notifications
+- Try before you sign up — full dashboard with ~500 sample transactions (Indian household model)
+- All 23 pages render with pre-computed analytics, zero backend calls
+- Mutations gracefully blocked with toast notifications
 
 ### Smart Upload & Sync
 
-- Drag-and-drop Excel (.xlsx, .xls) and CSV uploads with beautiful hero UI
-- Client-side parsing via SheetJS -- files never leave your browser, only structured data is sent to the server
-- Browser-native SHA-256 hashing for intelligent duplicate detection
-- Idempotent syncing -- re-upload anytime without duplicates
-- Four-phase upload UX: Parsing (client) -> Processing (server) -> Uploading -> Computing Analytics
-- Real-time toast notifications for upload status
+- Drag-and-drop Excel (.xlsx, .xls) and CSV uploads
+- Client-side parsing via SheetJS — files never leave your browser, only structured data is sent to the server
+- SHA-256 hashing for duplicate detection — re-upload anytime without duplicates
 
 ### Spending Analysis
 
-- **50/30/20 Budget Rule** - Track Needs (50%), Wants (30%), and Savings (20%)
-- Category and subcategory breakdown with treemaps
+- 50/30/20 Budget Rule (Needs / Wants / Savings)
+- Category and subcategory treemaps
 - Year-over-year spending comparisons
 - Recurring transaction detection
 
 ### Investment Portfolio
 
-- **4 Investment Categories**: FD/Bonds, Mutual Funds, PPF/EPF, Stocks
-- Track both inflows (investments) and outflows (redemptions)
-- Net investment calculations per category
+- 4 categories: FD/Bonds, Mutual Funds, PPF/EPF, Stocks
+- Inflows + outflows + net investment per category
 - Asset allocation visualization
 
 ### Cash Flow Visualization
 
-- Interactive Sankey diagrams showing money flow
-- Income to Expenses/Savings breakdown
+- Interactive Sankey diagrams
+- Income → Expenses / Savings breakdown
 - Monthly and yearly views
 
 ### Tax & Retirement Planning
 
-- **India FY tax estimation** -- old vs new regime comparison, slab breakdown, surcharge, cess
-- **Salary-based projections** -- input your CTC structure, RSU grants, and growth assumptions to project multi-year tax liability
-- **FIRE Calculator** -- compute FIRE number, Coast FIRE, years to FIRE, and savings rate from your actual spending data; Lean / **Barista** / Standard / Fat FIRE variants with adjustable SWR, real return, retirement horizon, and part-time-income slider (for soft-landing planning)
-- **Retirement corpus calculator** -- inflation-adjusted corpus, monthly SIP needed, lump-sum alternative, with projection chart
+- **India FY tax estimation** — old vs new regime, slab breakdown, surcharge, cess
+- **Salary projections** — CTC structure + RSU + growth → multi-year tax liability
+- **FIRE Calculator** — Lean / Barista / Standard / Fat variants, adjustable SWR, real return, retirement horizon, part-time-income slider
+- **Retirement corpus** — inflation-adjusted, monthly SIP, lump-sum alternative
 
 ### Analytics & Insights
 
-- Financial Health Score with 8 metrics across 4 pillars (Spend, Save, Borrow, Plan)
-- Income vs Expense trends and forecasting
+- Financial Health Score (8 metrics across 4 pillars: Spend, Save, Borrow, Plan)
+- Income vs expense forecasting
 - Net Worth tracking across all accounts
-- Anomaly detection and review
+- Anomaly detection
 - Budget tracking and goals
 
 ### Multi-Currency Display
 
-- **15 supported currencies** -- USD, EUR, GBP, JPY, CAD, AUD, CHF, SGD, AED, and more
-- Live exchange rates from the European Central Bank (via frankfurter.app), cached 24 hours
-- Quick-switch currency from the sidebar or set a default in Settings
-- All amounts convert instantly across every page -- no reload needed
-- Auto-derives number format, symbol, and symbol position from your currency choice
+- 15 currencies (USD, EUR, GBP, JPY, CAD, AUD, CHF, SGD, AED, …)
+- Live ECB rates via frankfurter.app, cached 24h
+- Quick-switch from sidebar; auto-derives format, symbol, and position
 
 ### Smart Defaults
 
-- **Account classification** - Priority-ordered rules (credit-card > investment > loan > deposit) with word-boundary regex classify accounts by keyword. "HDFC CC" becomes a credit card, "HDFC Bank" a deposit, "HDFC Stocks" an investment. 20+ Indian banks normalized to canonical casing (SBI, HDFC, IDFC First, IndusInd, AU Small Finance, etc.).
-- **Income classification** - Auto-assigns Salary/Freelance to Taxable, Dividends/Interest to Investment Returns, Cashbacks to Non-taxable.
-- **Investment mapping** - User-configurable via Settings > Account Classifications. Default mappings are empty so each user sets their own -- no pre-seeded names from other installs.
+- **Account classification** — priority-ordered (credit-card > investment > loan > deposit) with word-boundary regex; 20+ Indian banks normalized
+- **Income classification** — auto-assigns Salary/Freelance to Taxable, Dividends/Interest to Investment Returns
+- **Investment mappings** — configurable per user; defaults shipped empty (no leaked names)
+
+### Mobile
+
+- Responsive layouts; dedicated mobile tab bar for the most-used pages
+
+## Get Started
+
+### Prerequisites
+
+- Node 20+
+- [pnpm 10](https://pnpm.io/installation)
+- Python 3.11+
+- [uv](https://docs.astral.sh/uv/getting-started/installation/)
+
+### Installation
+
+```bash
+git clone https://github.com/Sagargupta16/ledger-sync.git
+cd ledger-sync
+
+pnpm install              # root deps
+pnpm run setup            # backend + frontend deps in parallel
+pnpm run dev              # both servers
+```
+
+### Access
+
+- Frontend: http://localhost:5173
+- Backend API: http://localhost:8000
+- API Docs: http://localhost:8000/docs
+
+### Configuration
+
+Backend env in `backend/.env`:
+
+```env
+LEDGER_SYNC_DATABASE_URL=sqlite:///./ledger_sync.db    # local dev
+LEDGER_SYNC_ENVIRONMENT=development                     # development | production
+LEDGER_SYNC_FRONTEND_URL=http://localhost:5173          # OAuth redirect base
+# Optional OAuth providers:
+LEDGER_SYNC_GOOGLE_CLIENT_ID=...
+LEDGER_SYNC_GOOGLE_CLIENT_SECRET=...
+LEDGER_SYNC_GITHUB_CLIENT_ID=...
+LEDGER_SYNC_GITHUB_CLIENT_SECRET=...
+```
+
+Frontend env:
+
+```env
+VITE_API_BASE_URL=http://localhost:8000
+```
+
+For OAuth setup (Google + GitHub) and production deployment, see [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
+
+## Usage
+
+1. Sign in with Google or GitHub
+2. Drag a bank-statement Excel file (.xlsx, .xls, or .csv) onto the upload zone
+3. Browse — start with Dashboard, then Cash Flow, Net Worth, and Income Tax Planning
+4. Configure account types, tax preferences, and categories in Settings
+5. Ask the AI chatbot any question about your data
+
+For a tour without signing up, visit `/demo`.
 
 ## Tech Stack
 
-| Layer            | Technology                                                                   |
-| ---------------- | ---------------------------------------------------------------------------- |
+| Layer            | Technology                                                                     |
+| ---------------- | ------------------------------------------------------------------------------ |
 | **Frontend**     | React 19, TypeScript 5.9, Vite 7, Tailwind CSS 4, Recharts 3, Framer Motion 12 |
-| **Auth**         | OAuth 2.0 (Google, GitHub), JWT tokens (PyJWT)                              |
-| **Backend**      | Python 3.11+, FastAPI, SQLAlchemy 2, Alembic                                |
-| **Database**     | SQLite (dev), Neon PostgreSQL 17 (prod)                                      |
-| **State**        | TanStack Query 5, Zustand 5                                                 |
-| **Deployment**   | GitHub Pages (frontend), Vercel (backend), Neon (database)                   |
-| **CI/CD**        | GitHub Actions (lint, type-check, build, deploy)                             |
-| **Package Mgmt** | pnpm 10 (frontend), uv (backend)                                            |
+| **Backend**      | Python 3.11+, FastAPI, SQLAlchemy 2, Alembic                                   |
+| **Database**     | SQLite (dev), Neon PostgreSQL 17 (prod)                                        |
+| **State**        | TanStack Query 5, Zustand 5                                                    |
+| **Deployment**   | GitHub Pages (frontend), Vercel (backend), Neon (database)                     |
+| **CI/CD**        | GitHub Actions (lint, type-check, build, deploy)                               |
+| **Package Mgmt** | pnpm 10 (frontend), uv (backend)                                               |
 
 ## Architecture
 
-### System Overview
-
 <p align="center">
-  <img src="docs/images/system-overview.svg" alt="System Architecture" width="100%"/>
+  <img src="docs/images/system-overview.svg" alt="System architecture" width="100%"/>
 </p>
+
+For detailed architecture docs, see [docs/architecture.md](docs/architecture.md).
+
+<details>
+<summary>More diagrams (Upload Pipeline, Auth Flow, Backend Layers)</summary>
 
 ### Upload & Sync Pipeline
 
 <p align="center">
-  <img src="docs/images/upload-pipeline.svg" alt="Upload Pipeline" width="100%"/>
+  <img src="docs/images/upload-pipeline.svg" alt="Upload pipeline" width="100%"/>
 </p>
 
 ### Authentication Flow
 
 <p align="center">
-  <img src="docs/images/auth-flow.svg" alt="Authentication Flow" width="100%"/>
+  <img src="docs/images/auth-flow.svg" alt="Authentication flow" width="100%"/>
 </p>
 
 ### Backend Layer Architecture
 
 <p align="center">
-  <img src="docs/images/backend-layers.svg" alt="Backend Layers" width="100%"/>
+  <img src="docs/images/backend-layers.svg" alt="Backend layers" width="100%"/>
 </p>
 
-<details>
-<summary>View Mermaid source (for editing)</summary>
-
-Diagrams generated from `.mmd` files in `docs/images/` using:
+Diagrams generated from `.mmd` files in `docs/images/`:
 
 ```bash
 npx -y @mermaid-js/mermaid-cli -i docs/images/<name>.mmd -o docs/images/<name>.svg -b transparent
@@ -142,65 +201,9 @@ npx -y @mermaid-js/mermaid-cli -i docs/images/<name>.mmd -o docs/images/<name>.s
 
 </details>
 
-For detailed architecture docs, see [docs/architecture.md](docs/architecture.md).
-
-## Quick Start
-
-```bash
-# Clone the repository
-git clone https://github.com/Sagargupta16/ledger-sync.git
-cd ledger-sync
-
-# Install root dependencies
-pnpm install
-
-# Setup backend + frontend in parallel
-pnpm run setup
-
-# Start both servers
-pnpm run dev
-```
-
-**Access the app:**
-
-- Frontend: http://localhost:5173
-- Backend API: http://localhost:8000
-- API Docs: http://localhost:8000/docs
-
-## Project Structure
-
-```
-ledger-sync/
-├── backend/                # Python FastAPI backend
-│   ├── src/ledger_sync/    # Main application
-│   │   ├── api/            # REST endpoints
-│   │   ├── core/           # Business logic (reconciler, sync, analytics)
-│   │   ├── db/             # Database models & session
-│   │   ├── ingest/         # Excel/CSV processing (CLI path; web uploads parsed client-side)
-│   │   └── schemas/        # Pydantic request/response models
-│   └── tests/              # pytest tests
-├── frontend/               # React + TypeScript frontend
-│   └── src/
-│       ├── pages/          # 23 page components (split into subdirectories)
-│       │   ├── settings/       # Settings sections (21 files, incl. SalaryStructureSection)
-│       │   ├── goals/          # Goals sub-components (13 files)
-│       │   ├── comparison/     # Comparison sub-components (13 files)
-│       │   └── subscription-tracker/  # Subscription sub-components (3 files)
-│       ├── components/     # UI & analytics components (60+)
-│       ├── hooks/          # React Query hooks & custom hooks
-│       ├── constants/      # Colors, chart tokens, animations, column mappings
-│       ├── store/          # Zustand global stores
-│       ├── services/       # API client (Axios)
-│       ├── lib/            # Utility functions (file parser, formatters, tax/projection calculators)
-│       │   └── demo/          # Demo mode (data generators, cache seeder)
-│       └── types/          # Shared TypeScript types
-├── .github/workflows/      # CI pipeline
-└── CHANGELOG.md            # Version history
-```
-
 ## Pages
 
-Every page focuses on a specific question you'd ask about your money. A one-line summary is below; for the **detailed data catalog** -- what each page shows, where the numbers come from, and what decisions it helps you make -- see **[docs/PAGES.md](docs/PAGES.md)**.
+Every page focuses on a specific question you'd ask about your money. For the **detailed data catalog** — what each page shows, where the numbers come from, and what decisions it helps you make — see **[docs/PAGES.md](docs/PAGES.md)**.
 
 | Page | Answers |
 | --- | --- |
@@ -229,74 +232,43 @@ Every page focuses on a specific question you'd ask about your money. A one-line
 
 ## Deployment
 
-The app is deployed for free using three services:
+Free-tier across three services:
 
 | Service | Platform | Details |
 |---------|----------|---------|
 | Frontend | GitHub Pages | Auto-deploys on push via GitHub Actions |
-| Backend | Vercel (serverless) | FastAPI via Mangum adapter, zero cold starts |
-| Database | Neon PostgreSQL | Free tier, 0.5 GB, Singapore region (Vercel integration) |
+| Backend | Vercel (serverless) | FastAPI via Mangum; ~400 ms median, up to ~20 s after long idle (Neon free-tier branch archival) |
+| Database | Neon PostgreSQL | Free tier, 0.5 GB, Singapore region |
 
-See [Deployment Guide](docs/DEPLOYMENT.md) for full setup instructions.
+See [Deployment Guide](docs/DEPLOYMENT.md) for full setup.
 
-## Authentication
+## Project Structure
 
-Ledger Sync uses **OAuth 2.0** for authentication - no passwords to manage.
-
-- **Google Sign-In** and **GitHub Sign-In** buttons on the login page
-- Backend exchanges OAuth codes for user info, then issues JWT tokens
-- OAuth providers are configurable via environment variables
-- Buttons only appear for providers that are configured
-
-### Setting Up OAuth (Local Dev)
-
-1. Create OAuth apps at [Google Cloud Console](https://console.cloud.google.com/apis/credentials) and/or [GitHub Developer Settings](https://github.com/settings/developers)
-2. Set redirect URIs to `http://localhost:5173/auth/callback/google` and `http://localhost:5173/auth/callback/github`
-3. Add credentials to `backend/.env`:
-
-```env
-LEDGER_SYNC_GOOGLE_CLIENT_ID=your-google-client-id
-LEDGER_SYNC_GOOGLE_CLIENT_SECRET=your-google-secret
-LEDGER_SYNC_GITHUB_CLIENT_ID=your-github-client-id
-LEDGER_SYNC_GITHUB_CLIENT_SECRET=your-github-secret
-LEDGER_SYNC_FRONTEND_URL=http://localhost:5173
+```
+ledger-sync/
+├── backend/      # Python FastAPI backend (api/, core/, db/, ingest/, schemas/)
+├── frontend/     # React + TypeScript frontend (pages/, components/, hooks/, lib/)
+├── docs/         # Architecture, API, calculations, deployment guides
+└── .github/      # CI workflows
 ```
 
-## Configuration
-
-### Backend Environment (`backend/.env`)
-
-```env
-LEDGER_SYNC_DATABASE_URL=sqlite:///./ledger_sync.db    # Local dev (SQLite)
-LEDGER_SYNC_ENVIRONMENT=development                     # development | production
-LEDGER_SYNC_GOOGLE_CLIENT_ID=...                        # OAuth (optional)
-LEDGER_SYNC_GOOGLE_CLIENT_SECRET=...
-LEDGER_SYNC_GITHUB_CLIENT_ID=...
-LEDGER_SYNC_GITHUB_CLIENT_SECRET=...
-LEDGER_SYNC_FRONTEND_URL=http://localhost:5173          # OAuth redirect base URL
-```
-
-### Frontend Environment
-
-```env
-VITE_API_BASE_URL=http://localhost:8000                # Set in GitHub Actions variable for production
-```
+For deeper navigation, browse the [repo](https://github.com/Sagargupta16/ledger-sync) directly.
 
 ## Documentation
 
-- [Changelog](CHANGELOG.md) - Version history with granular release notes
-- [Architecture](docs/architecture.md) - System design and data flow
-- [Calculations & Data Processing](docs/CALCULATIONS.md) - How every metric, chart, and derived number is computed
-- [API Reference](docs/API.md) - REST endpoint documentation
-- [Database Schema](docs/DATABASE.md) - Models and migrations
-- [Development Guide](docs/DEVELOPMENT.md) - Setup and workflow
-- [Testing Guide](docs/TESTING.md) - Test strategies
-- [Deployment Guide](docs/DEPLOYMENT.md) - Production deployment
+- [Changelog](CHANGELOG.md) — version history with release notes
+- [Architecture](docs/architecture.md) — system design and data flow
+- [Calculations & Data Processing](docs/CALCULATIONS.md) — every metric, chart, and derived number
+- [API Reference](docs/API.md) — REST endpoints
+- [Database Schema](docs/DATABASE.md) — models and migrations
+- [Development Guide](docs/DEVELOPMENT.md) — setup and workflow
+- [Testing Guide](docs/TESTING.md) — test strategies
+- [Deployment Guide](docs/DEPLOYMENT.md) — production deployment
 
 ## Contributing
 
-Contributions are welcome! Please read the [Development Guide](docs/DEVELOPMENT.md) first.
+Contributions welcome! Please read the [Development Guide](docs/DEVELOPMENT.md) first.
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) for details.
+MIT — see [LICENSE](LICENSE) for details.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ledger-sync"
-version = "2.0.0"
+version = "2.10.0"
 description = "Personal finance dashboard backend -- Excel import, financial analytics, multi-currency exchange rates"
 authors = [{ name = "Sagar Gupta" }]
 readme = "README.md"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.10.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ledger-sync",
-  "version": "1.0.0",
+  "version": "2.10.0",
   "description": "Personal finance dashboard -- import bank statements, track spending, and view analytics in any currency",
   "scripts": {
     "setup": "concurrently -n \"backend,frontend\" -c \"bgBlue.bold,bgMagenta.bold\" \"pnpm run setup:backend\" \"pnpm run setup:frontend\"",


### PR DESCRIPTION
## Summary

Restructure README around the canonical documentation pattern + fix three pieces of factual drift.

### Fixes

- **Version drift across 4 sources.** README badge said 2.9.0, `package.json` said 2.0.0, `frontend/package.json` said 2.0.0, `backend/pyproject.toml` said 2.0.0, but `CHANGELOG.md` was at 2.10.0 (released 2026-05-13). All four sources are now 2.10.0, and the README badge is now a dynamic shields.io endpoint reading `frontend/package.json` so it can never drift again.
- **'Zero cold starts' claim was false.** Vercel + Neon log analysis (Composio MCP, 17-day window) showed 380 ms median but 15-24 s tail after >24 h idle, due to Neon free-tier branch archival. Replaced with honest latency note in the Deployment table.

### Restructure (canonical pattern)

New section order: Hero -> Why-not-Mint -> Features -> Get Started -> Usage -> Tech Stack -> Architecture -> Pages -> Deployment -> Project Structure -> Documentation -> Contributing -> License.

Lead with what it does, not how it's built. Tech Stack and Architecture used to sit above Features in scan order.

### Adds

- Why-not-Mint paragraph explaining the project's reason for existing (Mint shut down, YNAB doesn't understand Indian bank statements, this is what I built for myself)
- Three CTAs (try-demo / use-hosted / self-host) with a Vercel one-click deploy button
- Prerequisites block in Get Started (Node 20+, pnpm 10, Python 3.11+, uv)
- Usage section with a 5-step minimum-viable walkthrough (sign in -> upload -> browse -> configure -> ask AI)
- Mobile feature line
- CI / SonarCloud / last-commit / stars badges

### Trims

- AI Chatbot section: 8 bullets -> 3. Dense detail was hiding the headline.
- Tech Stack table: dropped the redundant Auth row (covered by Features)
- Architecture section: 1 SVG visible + 3 in `<details>` (was 4 always-visible)
- Project Structure: 30-line tree -> 4-folder summary + link to repo browser. The detailed tree was drift-prone (every page split or folder rename made it stale).
- Standalone Configuration section folded into Get Started -> Configuration

### Net change

| | |
|---|---|
| README.md | -28 lines |
| Total | +155, -183 |

Same content depth available via existing doc links (`docs/architecture.md`, `docs/DEPLOYMENT.md`, `docs/PAGES.md`, etc.). Easier to scan, no more drift hazards.

### Verification

- 3 version files parse and report 2.10.0 (root `package.json`, `frontend/package.json`, `backend/pyproject.toml`)
- README structure has 13 H2 sections in canonical order
- Code blocks copy-pasteable; all file paths link to existing files
- No CI-level changes