### PR TITLE
refactor(frontend): wire status semantic palette as Tailwind tokens

### DIFF
--- a/frontend/src/components/shared/ErrorState.tsx
+++ b/frontend/src/components/shared/ErrorState.tsx
@@ -48,14 +48,14 @@ export default function ErrorState({
       <motion.div
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
-        className="flex items-center gap-3 px-4 py-3 bg-red-500/10 border border-red-500/20 rounded-lg"
+        className="flex items-center gap-3 px-4 py-3 bg-error/10 border border-error/20 rounded-lg"
       >
-        <AlertCircle className="w-5 h-5 text-red-400 shrink-0" />
-        <p className="text-sm text-red-400 flex-1">{displayMessage}</p>
+        <AlertCircle className="w-5 h-5 text-error shrink-0" />
+        <p className="text-sm text-error flex-1">{displayMessage}</p>
         {onRetry && (
           <button
             onClick={onRetry}
-            className="shrink-0 text-sm text-red-400 hover:text-red-300 underline underline-offset-2 transition-colors duration-150"
+            className="shrink-0 text-sm text-error hover:opacity-80 underline underline-offset-2 transition-opacity duration-150"
             aria-label="Retry"
           >
             Retry
@@ -75,11 +75,11 @@ export default function ErrorState({
     >
       {/* Icon */}
       <div
-        className={`rounded-xl bg-red-500/10 border border-red-500/20 flex items-center justify-center mb-4 ${
+        className={`rounded-xl bg-error/10 border border-error/20 flex items-center justify-center mb-4 ${
           isCompact ? 'w-12 h-12' : 'w-16 h-16'
         }`}
       >
-        <Icon className={`text-red-400 ${isCompact ? 'w-6 h-6' : 'w-8 h-8'}`} />
+        <Icon className={`text-error ${isCompact ? 'w-6 h-6' : 'w-8 h-8'}`} />
       </div>
 
       {/* Title */}
@@ -104,7 +104,7 @@ export default function ErrorState({
       {onRetry && (
         <button
           onClick={onRetry}
-          className={`mt-4 inline-flex items-center gap-2 px-4 py-2 bg-red-500/10 text-red-400 rounded-lg hover:bg-red-500/20 transition-colors duration-150 ${
+          className={`mt-4 inline-flex items-center gap-2 px-4 py-2 bg-error/10 text-error rounded-lg hover:bg-error/20 transition-colors duration-150 ${
             isCompact ? 'text-xs' : 'text-sm'
           }`}
           aria-label="Retry loading"
@@ -118,7 +118,7 @@ export default function ErrorState({
 
   if (isCard) {
     return (
-      <div className="glass rounded-2xl border border-red-500/20">
+      <div className="glass rounded-2xl border border-error/20">
         {content}
       </div>
     )

--- a/frontend/src/constants/chartColors.ts
+++ b/frontend/src/constants/chartColors.ts
@@ -117,6 +117,40 @@ export function getSemanticBadgeClass(type: string): string {
   return 'bg-white/10 text-text-secondary border-white/10'
 }
 
+/**
+ * Status semantics. Use these instead of hand-rolled red/green/orange/blue
+ * Tailwind classes for "this thing succeeded / failed / is risky / is
+ * informational." Maps to the ``--color-success / -warning / -error / -info``
+ * CSS custom properties declared in ``index.css`` so a future palette swap
+ * touches one file, not dozens.
+ *
+ * Tailwind v4 auto-generates ``text-success``, ``bg-warning``, ``border-error``
+ * etc. utilities from those tokens. Prefer those classes directly when you
+ * just need a single utility; use the helpers below when you need the full
+ * "background + text + border" trio for a badge / inline alert / pill.
+ */
+export type Status = 'success' | 'warning' | 'error' | 'info'
+
+/** Tailwind text class for a status semantics. */
+export function getStatusTextClass(status: Status): string {
+  if (status === 'success') return 'text-success'
+  if (status === 'warning') return 'text-warning'
+  if (status === 'error') return 'text-error'
+  return 'text-info'
+}
+
+/**
+ * Tailwind badge classes (background + text + border) for inline status
+ * indicators. Background uses /10 alpha, border /20, matching the existing
+ * convention from ``getSemanticBadgeClass``.
+ */
+export function getStatusBadgeClass(status: Status): string {
+  if (status === 'success') return 'bg-success/10 text-success border-success/20'
+  if (status === 'warning') return 'bg-warning/10 text-warning border-warning/20'
+  if (status === 'error') return 'bg-error/10 text-error border-error/20'
+  return 'bg-info/10 text-info border-info/20'
+}
+
 // Chart axis and grid colors
 export const CHART_AXIS_COLOR = '#9ca3af'
 export const CHART_GRID_COLOR = '#2a2a2e'


### PR DESCRIPTION
## Summary

The design tokens for `success` / `warning` / `error` / `info` already existed:

- `index.css` declares `--color-success` / `--color-warning` / `--color-error` / `--color-info` (all aliased to `--color-app-green` / -orange / -red / -blue)
- `colors.ts` exposes them as `colors.semantic.{success,warning,error,info}`

But **zero components used them**. `ErrorState.tsx` even bypassed the app palette and hardcoded raw Tailwind colors (`red-500/10`, `text-red-400`, `text-red-300`).

## Fix

- **Migrated `ErrorState.tsx` to use `text-error` / `bg-error/10` / `border-error/20`** across all 4 variants (default, compact, card, inline). Tailwind v4 auto-generates these utilities from the CSS variables, so a future palette swap is a one-line change in `index.css` instead of grep-and-replacing every component.
- **Verified the build emits the new utilities** -- `pnpm run build` clean, no missing-class warnings.
- **Added two helpers in `chartColors.ts`** so future status renderings have an obvious place to land:
  - `getStatusTextClass(status)` -> right `text-*` class for `'success' | 'warning' | 'error' | 'info'`
  - `getStatusBadgeClass(status)` -> background + text + border combination for inline alerts / pills

## Why scope is small

Semantic tokens are aliased to app palette colors, so existing `text-app-red` usages render the same as `text-error` today. The migration is forward-looking -- if the design system later wants 'error' visually distinct from 'expense' (both currently `app-red`), that change is now possible without touching every component.

Other status callsites (`ErrorBoundary`, sonner toast styling, scattered `text-app-orange` warnings) are left for incremental migration -- the helpers and tokens are now in place to support it.

## Verification

- `tsc -b --noEmit` clean
- `eslint` clean  
- `pnpm run build` clean (Tailwind emits the new utilities)
- `vitest` 170 tests pass

## Diff

| | |
|---|---|
| Files | 2 |
| Lines | +42, -8 |