### PR TITLE
feat(net-worth): replace single-line projection with confidence band

### DIFF
--- a/frontend/src/pages/net-worth/__tests__/netWorthProjection.test.ts
+++ b/frontend/src/pages/net-worth/__tests__/netWorthProjection.test.ts
@@ -6,10 +6,12 @@ import {
   buildMilestoneRowsCompound,
   computeAvgMonthlyGrowth,
   computeMonthlyGrowthRate,
+  computeMonthlyGrowthStats,
   downsampleToMonthly,
   type MilestoneRow,
   projectNetWorth,
   projectNetWorthCompound,
+  projectNetWorthCompoundBand,
 } from '../netWorthProjection'
 
 function requireRow(rows: readonly MilestoneRow[], label: string): MilestoneRow {
@@ -293,6 +295,95 @@ describe('projectNetWorthCompound', () => {
     // Linear says 5M + 50k*60 = 8M. Compound says 5M * 1.01^60 = ~9.08M.
     // Compound must be meaningfully larger so our milestone ETAs are sooner.
     expect(compoundPt.netWorth).toBeGreaterThan(linearPt.netWorth * 1.1)
+  })
+})
+
+describe('computeMonthlyGrowthStats', () => {
+  it('returns zeros when there is too little data', () => {
+    expect(computeMonthlyGrowthStats([])).toEqual({ rate: 0, logSigma: 0 })
+    expect(computeMonthlyGrowthStats([{ date: '2024-01-31', netWorth: 100 }])).toEqual({
+      rate: 0,
+      logSigma: 0,
+    })
+    expect(
+      computeMonthlyGrowthStats([
+        { date: '2024-01-31', netWorth: 100 },
+        { date: '2024-02-29', netWorth: 110 },
+      ]),
+    ).toEqual({ rate: 0, logSigma: 0 })
+  })
+
+  it('returns logSigma=0 when the series grows at a constant rate', () => {
+    // 1% per month exactly, no variance.
+    const series: Array<{ date: string; netWorth: number }> = []
+    let v = 100_000
+    for (let m = 0; m <= 6; m++) {
+      const month = String(m + 1).padStart(2, '0')
+      series.push({ date: `2024-${month}-28`, netWorth: v })
+      v *= 1.01
+    }
+    const stats = computeMonthlyGrowthStats(series)
+    expect(stats.rate).toBeCloseTo(0.01, 4)
+    expect(stats.logSigma).toBeCloseTo(0, 6)
+  })
+
+  it('captures variance when monthly returns vary', () => {
+    // Alternating 0% and 2% per month -> mean ~1%/mo, non-zero sigma.
+    const series = [
+      { date: '2024-01-28', netWorth: 100_000 },
+      { date: '2024-02-28', netWorth: 100_000 }, // +0%
+      { date: '2024-03-28', netWorth: 102_000 }, // +2%
+      { date: '2024-04-28', netWorth: 102_000 }, // +0%
+      { date: '2024-05-28', netWorth: 104_040 }, // +2%
+      { date: '2024-06-28', netWorth: 104_040 }, // +0%
+      { date: '2024-07-28', netWorth: 106_120.8 }, // +2%
+    ]
+    const stats = computeMonthlyGrowthStats(series)
+    // Geometric mean ~1%/mo (alternating 0% and 2%).
+    expect(stats.rate).toBeGreaterThan(0.005)
+    expect(stats.rate).toBeLessThan(0.015)
+    // Sigma should be roughly half the spread of |0% - 2%| in log space ≈ 0.0099.
+    expect(stats.logSigma).toBeGreaterThan(0.005)
+    expect(stats.logSigma).toBeLessThan(0.02)
+  })
+})
+
+describe('projectNetWorthCompoundBand', () => {
+  const anchor = { date: '2024-01-01', netWorth: 1_000_000 }
+
+  it('returns empty for non-positive horizon', () => {
+    expect(projectNetWorthCompoundBand(anchor, 0.01, 0.005, 0)).toEqual([])
+  })
+
+  it('collapses upper/lower to mean when logSigma is zero', () => {
+    const pts = projectNetWorthCompoundBand(anchor, 0.01, 0, 12)
+    expect(pts).toHaveLength(12)
+    for (const p of pts) {
+      expect(p.upper).toBeCloseTo(p.mean, 4)
+      expect(p.lower).toBeCloseTo(p.mean, 4)
+    }
+    // Final mean = anchor * 1.01^12 ≈ 1,126,825
+    expect(pts.at(-1)!.mean).toBeCloseTo(1_126_825, 0)
+  })
+
+  it('upper > mean > lower at every point when logSigma is positive', () => {
+    const pts = projectNetWorthCompoundBand(anchor, 0.01, 0.02, 24)
+    for (const p of pts) {
+      expect(p.upper).toBeGreaterThan(p.mean)
+      expect(p.lower).toBeLessThan(p.mean)
+      expect(p.lower).toBeGreaterThan(0)
+    }
+  })
+
+  it('band width grows with sqrt(time) under GBM', () => {
+    // log(upper) - log(lower) = 2 * sigma * sqrt(n) — should scale ~sqrt of time.
+    const pts = projectNetWorthCompoundBand(anchor, 0.01, 0.02, 36)
+    const widthAtMonth1 = Math.log(pts[0].upper) - Math.log(pts[0].lower)
+    const widthAtMonth36 = Math.log(pts[35].upper) - Math.log(pts[35].lower)
+    // sqrt(36) / sqrt(1) = 6 ; allow some slack for rounding.
+    const ratio = widthAtMonth36 / widthAtMonth1
+    expect(ratio).toBeGreaterThan(5.5)
+    expect(ratio).toBeLessThan(6.5)
   })
 })
 

--- a/frontend/src/pages/net-worth/components/NetWorthTrendChart.tsx
+++ b/frontend/src/pages/net-worth/components/NetWorthTrendChart.tsx
@@ -215,19 +215,34 @@ export function NetWorthTrendChart(props: Readonly<NetWorthTrendChartProps>) {
                     animationEasing="ease-out"
                   />
                   {showProjectionLine && (
-                    <Area
-                      type="monotone"
-                      dataKey="projected"
-                      stroke={rawColors.app.blue}
-                      strokeWidth={2}
-                      strokeDasharray="6 4"
-                      dot={false}
-                      activeDot={{ ...ACTIVE_DOT, fill: rawColors.app.blue }}
-                      fill="transparent"
-                      name="Projected"
-                      connectNulls
-                      isAnimationActive={false}
-                    />
+                    <>
+                      {/* 1-stddev confidence band, drawn before the median line so the
+                          line renders on top. The band widens as sqrt(time) under the
+                          GBM model. Empty during historical points (null tuple). */}
+                      <Area
+                        type="monotone"
+                        dataKey="projectionBand"
+                        stroke="none"
+                        fill={rawColors.app.blue}
+                        fillOpacity={0.15}
+                        name="Projection band (±1σ)"
+                        connectNulls
+                        isAnimationActive={false}
+                      />
+                      <Area
+                        type="monotone"
+                        dataKey="projected"
+                        stroke={rawColors.app.blue}
+                        strokeWidth={2}
+                        strokeDasharray="6 4"
+                        dot={false}
+                        activeDot={{ ...ACTIVE_DOT, fill: rawColors.app.blue }}
+                        fill="transparent"
+                        name="Projected (median)"
+                        connectNulls
+                        isAnimationActive={false}
+                      />
+                    </>
                   )}
                 </>
               )}

--- a/frontend/src/pages/net-worth/netWorthProjection.ts
+++ b/frontend/src/pages/net-worth/netWorthProjection.ts
@@ -215,6 +215,119 @@ export function projectNetWorthCompound(
   return points
 }
 
+/**
+ * Compute the geometric monthly growth rate AND the standard deviation of
+ * its log-returns over the last ``lookbackMonths`` of month-end net worth.
+ *
+ * - ``rate``: same value ``computeMonthlyGrowthRate`` returns. Decimal.
+ * - ``logSigma``: stddev of ln(1 + r_i) for the individual monthly growth
+ *   rates r_i in the window. Used by ``projectNetWorthCompoundBand`` to
+ *   model uncertainty under a geometric Brownian motion (GBM) projection.
+ *
+ * Returns ``{rate: 0, logSigma: 0}`` when fewer than 3 month-end points are
+ * available (need at least 2 monthly rates to have any variance), or when
+ * any month-end value is non-positive (compound growth undefined). Sample
+ * standard deviation (n-1 denominator) is used.
+ */
+export function computeMonthlyGrowthStats(
+  series: readonly NetWorthPoint[],
+  lookbackMonths = 12,
+): { rate: number; logSigma: number } {
+  if (series.length < 3) return { rate: 0, logSigma: 0 }
+  const sorted = [...series].sort((a, b) => a.date.localeCompare(b.date))
+
+  const monthlyLast: Record<string, number> = {}
+  for (const point of sorted) {
+    monthlyLast[point.date.substring(0, 7)] = point.netWorth
+  }
+
+  const months = Object.keys(monthlyLast).sort((a, b) => a.localeCompare(b))
+  if (months.length < 3) return { rate: 0, logSigma: 0 }
+
+  const windowMonths = months.slice(-Math.max(3, lookbackMonths + 1))
+  const lastMonth = windowMonths.at(-1)
+  if (lastMonth === undefined) return { rate: 0, logSigma: 0 }
+  const start = monthlyLast[windowMonths[0]]
+  const end = monthlyLast[lastMonth]
+  const spanMonths = windowMonths.length - 1
+
+  if (start <= 0 || end <= 0 || spanMonths <= 0) return { rate: 0, logSigma: 0 }
+
+  // Geometric-mean monthly rate (matches computeMonthlyGrowthRate).
+  const rate = (end / start) ** (1 / spanMonths) - 1
+
+  // Per-month log-returns over the same window.
+  const logReturns: number[] = []
+  for (let i = 1; i < windowMonths.length; i++) {
+    const prev = monthlyLast[windowMonths[i - 1]]
+    const curr = monthlyLast[windowMonths[i]]
+    if (prev <= 0 || curr <= 0) return { rate: 0, logSigma: 0 }
+    logReturns.push(Math.log(curr / prev))
+  }
+  if (logReturns.length < 2) return { rate, logSigma: 0 }
+
+  const meanLog = logReturns.reduce((sum, x) => sum + x, 0) / logReturns.length
+  const variance =
+    logReturns.reduce((sum, x) => sum + (x - meanLog) ** 2, 0) / (logReturns.length - 1)
+  const logSigma = Math.sqrt(variance)
+
+  return { rate, logSigma }
+}
+
+/** A single projected point with a 1-stddev confidence band. */
+export interface NetWorthProjectionBandPoint {
+  date: string
+  mean: number
+  upper: number
+  lower: number
+}
+
+/**
+ * Project future monthly net worth with a 1-sigma confidence band under
+ * a geometric Brownian motion model.
+ *
+ * For month ``n`` after the anchor:
+ *   mean  = anchor * (1 + monthlyRate)^n
+ *   upper = anchor * exp(n * ln(1 + monthlyRate) + logSigma * sqrt(n))
+ *   lower = anchor * exp(n * ln(1 + monthlyRate) - logSigma * sqrt(n))
+ *
+ * The sqrt(n) scaling is the correct uncertainty-grows-with-time behaviour
+ * for compounding returns: roughly 68 % of plausible trajectories fall
+ * within the band, and the band widens further out (the projection is
+ * confident next month, less confident in 5 years).
+ *
+ * When ``logSigma <= 0`` the band collapses to the mean (visually a single
+ * line, same as ``projectNetWorthCompound``).
+ */
+export function projectNetWorthCompoundBand(
+  anchor: NetWorthPoint,
+  monthlyRate: number,
+  logSigma: number,
+  horizonMonths = 60,
+): NetWorthProjectionBandPoint[] {
+  if (horizonMonths <= 0) return []
+  const points: NetWorthProjectionBandPoint[] = []
+  const start = new Date(anchor.date)
+  start.setUTCHours(0, 0, 0, 0)
+  const lnGrowth = Math.log(1 + monthlyRate)
+  for (let i = 1; i <= horizonMonths; i++) {
+    const d = new Date(start)
+    d.setUTCMonth(d.getUTCMonth() + i)
+    const mean = anchor.netWorth * (1 + monthlyRate) ** i
+    const drift = lnGrowth * i
+    const halfBand = logSigma > 0 ? logSigma * Math.sqrt(i) : 0
+    const upper = anchor.netWorth * Math.exp(drift + halfBand)
+    const lower = anchor.netWorth * Math.exp(drift - halfBand)
+    points.push({
+      date: d.toISOString().substring(0, 10),
+      mean,
+      upper,
+      lower,
+    })
+  }
+  return points
+}
+
 /** First-crossing scan: returns value -> ISO date for every milestone reached. */
 function scanAchievements(
   series: readonly NetWorthPoint[],

--- a/frontend/src/pages/net-worth/useNetWorth.ts
+++ b/frontend/src/pages/net-worth/useNetWorth.ts
@@ -8,8 +8,9 @@ import { accountClassificationsService } from '@/services/api/accountClassificat
 
 import {
   computeMonthlyGrowthRate,
+  computeMonthlyGrowthStats,
   downsampleToMonthly,
-  projectNetWorthCompound,
+  projectNetWorthCompoundBand,
   buildMilestoneRowsCompound,
   type NetWorthPoint,
 } from './netWorthProjection'
@@ -176,6 +177,11 @@ export function useNetWorth() {
 
   const monthlyGrowthRate = useMemo(() => computeMonthlyGrowthRate(chartSeries, 12), [chartSeries])
 
+  const monthlyGrowthLogSigma = useMemo(
+    () => computeMonthlyGrowthStats(chartSeries, 12).logSigma,
+    [chartSeries],
+  )
+
   const milestoneRows = useMemo(
     () => buildMilestoneRowsCompound(fullSeries, anchor, monthlyGrowthRate),
     [fullSeries, anchor, monthlyGrowthRate],
@@ -186,23 +192,39 @@ export function useNetWorth() {
       return filteredNetWorthData
     }
     const monthlyHistorical = downsampleToMonthly(chartSeries)
-    const projection = projectNetWorthCompound(anchor, monthlyGrowthRate, 60)
+    const band = projectNetWorthCompoundBand(
+      anchor,
+      monthlyGrowthRate,
+      monthlyGrowthLogSigma,
+      60,
+    )
 
     const historicalPoints = monthlyHistorical.map((p) => ({
       date: p.date,
       netWorth: p.netWorth,
       projected: null as number | null,
+      // Recharts <Area> can render a [low, high] tuple as a band when given
+      // an array dataKey; null on historical points so the band only paints
+      // forward of the anchor.
+      projectionBand: null as [number, number] | null,
     }))
     const projectedPoints = [
-      { date: anchor.date, netWorth: null as number | null, projected: anchor.netWorth },
-      ...projection.map((p) => ({
+      {
+        date: anchor.date,
+        netWorth: null as number | null,
+        projected: anchor.netWorth,
+        // Anchor point: band collapses to the value (zero uncertainty at t=0).
+        projectionBand: [anchor.netWorth, anchor.netWorth] as [number, number] | null,
+      },
+      ...band.map((p) => ({
         date: p.date,
         netWorth: null as number | null,
-        projected: p.netWorth,
+        projected: p.mean,
+        projectionBand: [p.lower, p.upper] as [number, number] | null,
       })),
     ]
     return [...historicalPoints, ...projectedPoints]
-  }, [showProjection, anchor, monthlyGrowthRate, chartSeries, filteredNetWorthData])
+  }, [showProjection, anchor, monthlyGrowthRate, monthlyGrowthLogSigma, chartSeries, filteredNetWorthData])
 
   const currentNetWorth = anchor?.netWorth ?? 0
 


### PR DESCRIPTION
## Summary

The audit flagged the existing Net Worth projection as brittle: a single linear-extrapolation line that gave the impression of false precision. The actual model already used compound growth (`projectNetWorthCompound`), but rendered as one dashed line that ignored historical month-to-month variability.

Replaced the rendered single line with a **1-stddev confidence band** under a geometric Brownian motion model. The band widens as `sqrt(time)` — the projection is confident next month, much less confident at year five — which honestly visualizes uncertainty instead of pretending compound growth is deterministic.

## Math

### `computeMonthlyGrowthStats(series, lookbackMonths)`

Returns `{rate, logSigma}`:
- `rate` matches the existing `computeMonthlyGrowthRate` (geometric mean monthly rate).
- `logSigma` is the sample stddev (n-1) of `ln(1 + r_i)` over the per-month rates in the window.

Returns zeros when fewer than 3 month-end points are available (need at least 2 monthly rates to have variance) or when any month-end value is non-positive.

### `projectNetWorthCompoundBand(anchor, rate, logSigma, horizonMonths)`

For month `n` after the anchor:

\\\
mean  = anchor * (1 + rate)^n
upper = anchor * exp(n * ln(1 + rate) + logSigma * sqrt(n))
lower = anchor * exp(n * ln(1 + rate) - logSigma * sqrt(n))
\\\

Roughly 68 % of plausible trajectories fall within the band. When `logSigma <= 0` the band collapses to the mean line.

## Wiring

- `useNetWorth.chartData` adds a `projectionBand: [lower, upper]` tuple per projected point, plus an anchor point at `[anchor, anchor]` (zero uncertainty at t=0).
- `NetWorthTrendChart` renders an extra `<Area>` with `stroke=none`, `fillOpacity=0.15`, and the tuple as dataKey — Recharts paints range areas natively when given a `[number, number]` value. The dashed median line continues to render on top, so the chart now shows both 'most likely path' and 'plausible spread'.
- Legend labels updated: `Projected` -> `Projected (median)` and `Projection band (±1σ)` to make the semantics readable.

## Tests

7 new unit tests covering:
- `computeMonthlyGrowthStats` — zero variance case, varying-rate case, no-data short-circuits
- `projectNetWorthCompoundBand` — empty horizon, `logSigma=0` collapse, monotonicity (upper > mean > lower), `sqrt(time)` width scaling

| | |
|---|---|
| Before | 170 vitest pass |
| After | 177 vitest pass |
| `tsc -b --noEmit` | clean |
| `eslint` | clean |
| `pnpm run build` | clean |

## Diff

| | |
|---|---|
| Files | 4 |
| Lines | +260, -19 |