### PR TITLE
feat(analytics): add 12-month trend sparkline to category breakdown rows

### DIFF
--- a/frontend/src/components/analytics/CategoryBreakdown.tsx
+++ b/frontend/src/components/analytics/CategoryBreakdown.tsx
@@ -2,15 +2,19 @@ import { useState, useMemo } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { ChevronDown, type LucideIcon } from 'lucide-react'
 import { useCategoryBreakdown } from '@/hooks/api/useAnalytics'
+import { useTransactions } from '@/hooks/api/useTransactions'
 import { formatCurrency } from '@/lib/formatters'
 import { CHART_COLORS } from '@/constants/chartColors'
 import EmptyState from '@/components/shared/EmptyState'
+import { CategorySparkline } from './CategorySparkline'
 
 interface CategoryData {
   name: string
   total: number
   percent: number
   color: string
+  /** Last-12-months total spending in this category, oldest -> newest. */
+  monthlyHistory: number[]
   subcategories: { name: string; amount: number; percent: number }[]
 }
 
@@ -51,6 +55,46 @@ export default function CategoryBreakdown({
     end_date: dateRange?.end_date ?? undefined,
   })
 
+  // Pull all transactions to build the per-category 12-month sparkline.
+  // useTransactions is widely cached (staleTime: Infinity, invalidated on
+  // upload) so this is effectively free if any other page already mounted it.
+  const { data: transactions = [] } = useTransactions()
+
+  /**
+   * Build a Map<categoryName, [m1, m2, ..., m12]> covering the last 12
+   * calendar months ending in the current month, oldest first. Months
+   * with no spending get a 0 so the sparkline renders a meaningful flat
+   * segment instead of skipping the bucket.
+   */
+  const monthlyHistoryByCategory = useMemo(() => {
+    const buckets = new Map<string, number[]>()
+    if (transactions.length === 0) return buckets
+
+    // Build the list of last-12 month keys (YYYY-MM), oldest first.
+    const now = new Date()
+    const monthKeys: string[] = []
+    for (let i = 11; i >= 0; i--) {
+      const d = new Date(now.getUTCFullYear(), now.getUTCMonth() - i, 1)
+      monthKeys.push(`${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`)
+    }
+    const monthIndex = new Map(monthKeys.map((k, i) => [k, i]))
+
+    const wantedType = transactionType === 'expense' ? 'Expense' : 'Income'
+
+    for (const tx of transactions) {
+      if (tx.type !== wantedType) continue
+      const category = tx.category
+      if (!category) continue
+      const monthKey = (tx.date as string).substring(0, 7)
+      const idx = monthIndex.get(monthKey)
+      if (idx === undefined) continue
+      const series = buckets.get(category) ?? Array.from({ length: 12 }, () => 0)
+      series[idx] += Math.abs(tx.amount)
+      buckets.set(category, series)
+    }
+    return buckets
+  }, [transactions, transactionType])
+
   const { categories, grandTotal } = useMemo(() => {
     if (!categoryData?.categories) return { categories: [], grandTotal: 0 }
 
@@ -83,13 +127,14 @@ export default function CategoryBreakdown({
           total: catTotal,
           percent: total > 0 ? (catTotal / total) * 100 : 0,
           color,
+          monthlyHistory: monthlyHistoryByCategory.get(category) ?? [],
           subcategories: subs,
         }
       })
       .sort((a, b) => b.total - a.total)
 
     return { categories: cats, grandTotal: total }
-  }, [categoryData, colorMap, defaultColors])
+  }, [categoryData, colorMap, defaultColors, monthlyHistoryByCategory])
 
   const toggleExpand = (name: string) => {
     setExpandedCategory((prev) => (prev === name ? null : name))
@@ -201,15 +246,28 @@ export default function CategoryBreakdown({
                   )}
                 </div>
 
-                {/* Proportional bar */}
-                <div className="mt-2 h-1.5 rounded-full bg-white/5 overflow-hidden">
-                  <motion.div
-                    className="h-full rounded-full"
-                    style={{ backgroundColor: cat.color }}
-                    initial={{ width: 0 }}
-                    animate={{ width: `${cat.percent}%` }}
-                    transition={{ duration: 0.5, ease: 'easeOut', delay: i * 0.03 }}
-                  />
+                {/* Proportional bar + 12-month sparkline.
+                    Bar answers "how much of total?", sparkline answers
+                    "trending up or down across the last year?". They're
+                    complementary -- bar is glanceable, sparkline adds
+                    direction without taking the user to another page. */}
+                <div className="mt-2 flex items-center gap-3">
+                  <div className="flex-1 h-1.5 rounded-full bg-white/5 overflow-hidden">
+                    <motion.div
+                      className="h-full rounded-full"
+                      style={{ backgroundColor: cat.color }}
+                      initial={{ width: 0 }}
+                      animate={{ width: `${cat.percent}%` }}
+                      transition={{ duration: 0.5, ease: 'easeOut', delay: i * 0.03 }}
+                    />
+                  </div>
+                  {cat.monthlyHistory.length >= 2 && (
+                    <CategorySparkline
+                      values={cat.monthlyHistory}
+                      color={cat.color}
+                      ariaLabel={`${cat.name} 12-month trend`}
+                    />
+                  )}
                 </div>
               </button>
 

--- a/frontend/src/components/analytics/CategorySparkline.tsx
+++ b/frontend/src/components/analytics/CategorySparkline.tsx
@@ -1,0 +1,83 @@
+/**
+ * Tiny inline 12-month spending sparkline.
+ *
+ * Pure SVG, no chart library dependency. Used in the category breakdown
+ * list to show "is this category trending up or down?" alongside the
+ * "what % of total spend" proportional bar.
+ *
+ * The component normalizes its input to the SVG viewbox internally so
+ * callers just pass a series of monthly amounts (oldest -> newest).
+ * Renders nothing when there are fewer than 2 data points.
+ */
+interface CategorySparklineProps {
+  readonly values: readonly number[]
+  readonly color: string
+  readonly width?: number
+  readonly height?: number
+  readonly ariaLabel?: string
+}
+
+const VIEWBOX_W = 100
+const VIEWBOX_H = 30
+
+export function CategorySparkline({
+  values,
+  color,
+  width = 80,
+  height = 24,
+  ariaLabel,
+}: CategorySparklineProps) {
+  if (values.length < 2) return null
+
+  const max = Math.max(...values)
+  const min = Math.min(...values)
+  // Avoid divide-by-zero when the category is flat across the window:
+  // render a horizontal mid-line in that case.
+  const span = max - min === 0 ? 1 : max - min
+
+  const stepX = VIEWBOX_W / (values.length - 1)
+
+  const points = values.map((v, i) => {
+    const x = i * stepX
+    // Y is inverted (SVG origin top-left); leave 2px top + bottom padding.
+    const y = VIEWBOX_H - 2 - ((v - min) / span) * (VIEWBOX_H - 4)
+    return { x, y }
+  })
+
+  const linePath = points
+    .map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x.toFixed(2)} ${p.y.toFixed(2)}`)
+    .join(' ')
+
+  // Closed path under the line for the soft fill.
+  const areaPath =
+    `${linePath} L ${VIEWBOX_W} ${VIEWBOX_H} L 0 ${VIEWBOX_H} Z`
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${VIEWBOX_W} ${VIEWBOX_H}`}
+      preserveAspectRatio="none"
+      role="img"
+      aria-label={ariaLabel ?? '12-month trend'}
+      className="shrink-0 overflow-visible"
+    >
+      <path d={areaPath} fill={color} fillOpacity={0.15} />
+      <path
+        d={linePath}
+        fill="none"
+        stroke={color}
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* Highlight the latest point so the eye lands on "today". */}
+      <circle
+        cx={points[points.length - 1].x}
+        cy={points[points.length - 1].y}
+        r={1.6}
+        fill={color}
+      />
+    </svg>
+  )
+}


### PR DESCRIPTION
## Summary

The audit asked for a hover sparkline on the spending treemap. Investigation revealed that what's called `ExpenseTreemap` is actually a `CategoryBreakdown` list with a stacked overview bar — not a real Recharts `<Treemap>`. The audit's intent applies the same way: each category row needed a quick visual answer to *'is this trending up or down?'* that didn't require navigating to another page.

## Implementation

### New component: `CategorySparkline`

Pure SVG (no chart-library overhead), 80×24 px, with:
- Soft area fill + line stroke + dot on the latest point so the eye lands on 'today'
- Internal viewbox normalisation (callers pass raw monthly amounts, oldest first)
- Renders nothing when fewer than 2 data points exist

### `CategoryBreakdown` wiring

- Pulls raw transactions via `useTransactions` (already widely cached, `staleTime: Infinity`, invalidated only on upload — effectively free if any other page already mounted it).
- Builds `Map<categoryName, [m1..m12]>` covering the last 12 calendar months. Months with no spending get `0` so the line draws across the full window instead of skipping buckets.
- The existing proportional 'percent of total' bar and the new sparkline sit side-by-side in each row: bar at `flex-1`, sparkline at fixed 80 px. The bar still answers 'how much?' at a glance; the sparkline adds direction.

## Scope decision: sunburst skipped

The audit's secondary suggestion was a sunburst toggle for category → subcategory hierarchies. That's genuinely several days of work (new D3/VisX component, accessibility plumbing, performance tuning for hierarchies). Worth its own PR if it lands at all — calling it out so future-me doesn't think it was forgotten.

## Verification

- `tsc -b --noEmit` clean
- `eslint` clean
- `pnpm run build` clean  
- `vitest` 177 tests pass

## Diff

| | |
|---|---|
| Files | 2 |
| Lines | +151, -10 |