### PR TITLE
feat(charts): add drag-to-zoom Brush to Net Worth chart

### DIFF
--- a/frontend/src/components/analytics/StandardAreaChart.tsx
+++ b/frontend/src/components/analytics/StandardAreaChart.tsx
@@ -12,7 +12,7 @@
  */
 
 import {
-  AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ReferenceLine,
+  AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ReferenceLine, Brush,
 } from 'recharts'
 import { formatCurrency } from '@/lib/formatters'
 import { chartTooltipProps, ChartContainer } from '@/components/ui'
@@ -20,6 +20,7 @@ import {
   GRID_DEFAULTS, xAxisDefaults, yAxisDefaults,
   areaGradient, areaGradientUrl, LEGEND_DEFAULTS, shouldAnimate, ACTIVE_DOT,
 } from '@/components/ui/chartDefaults'
+import { rawColors } from '@/constants/colors'
 import ChartEmptyState from '@/components/shared/ChartEmptyState'
 
 interface AreaConfig {
@@ -56,6 +57,12 @@ interface StandardAreaChartProps {
   readonly xAngle?: number
   readonly referenceLines?: ReferenceLineConfig[]
   readonly stacked?: boolean
+  /**
+   * Show a Recharts ``<Brush>`` below the chart for drag-to-zoom on the
+   * x-axis. Useful for long time-series (>~12 points) where the user wants
+   * to inspect a sub-range without changing the global filter. Default off.
+   */
+  readonly showBrush?: boolean
 }
 
 export default function StandardAreaChart({
@@ -71,6 +78,7 @@ export default function StandardAreaChart({
   xAngle,
   referenceLines,
   stacked = false,
+  showBrush = false,
 }: StandardAreaChartProps) {
   if (data.length === 0) {
     return <ChartEmptyState message={emptyMessage} height={height} />
@@ -141,6 +149,19 @@ export default function StandardAreaChart({
             stackId={stacked ? 'stack' : area.stackId}
           />
         ))}
+        {showBrush && data.length > 4 && (
+          <Brush
+            dataKey={dataKey}
+            height={24}
+            travellerWidth={8}
+            stroke={rawColors.app.blue}
+            fill="rgba(255,255,255,0.04)"
+            tickFormatter={xTickFormatter}
+            // Default to showing the most recent ~quarter of the data so the
+            // chart still reads at full fidelity on first paint.
+            startIndex={Math.max(0, data.length - Math.ceil(data.length / 4))}
+          />
+        )}
       </AreaChart>
     </ChartContainer>
   )

--- a/frontend/src/pages/net-worth/components/NetWorthTrendChart.tsx
+++ b/frontend/src/pages/net-worth/components/NetWorthTrendChart.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'framer-motion'
 import { BarChart3 } from 'lucide-react'
-import { Area, AreaChart, CartesianGrid, Legend, ReferenceLine, Tooltip, XAxis, YAxis } from 'recharts'
+import { Area, AreaChart, Brush, CartesianGrid, Legend, ReferenceLine, Tooltip, XAxis, YAxis } from 'recharts'
 
 import EmptyState from '@/components/shared/EmptyState'
 import {
@@ -245,6 +245,23 @@ export function NetWorthTrendChart(props: Readonly<NetWorthTrendChartProps>) {
                     </>
                   )}
                 </>
+              )}
+              {/* Drag-to-zoom on the x-axis. Default window is the most-recent
+                  third of the data so the chart still reads at full fidelity
+                  on first paint; users can drag either traveller to widen or
+                  narrow the view without touching the global time filter. */}
+              {chartData.length > 6 && (
+                <Brush
+                  dataKey="date"
+                  height={26}
+                  travellerWidth={8}
+                  stroke={rawColors.app.blue}
+                  fill="rgba(255,255,255,0.04)"
+                  tickFormatter={(value: string) =>
+                    new Date(value).toLocaleDateString('en-US', { month: 'short', year: '2-digit' })
+                  }
+                  startIndex={Math.max(0, chartData.length - Math.ceil(chartData.length / 3))}
+                />
               )}
             </AreaChart>
           </ChartContainer>


### PR DESCRIPTION
## Summary

The audit recommended adding Recharts `Brush` below time-series charts so users can inspect a sub-range without changing the global time filter. Highest-value target was Net Worth — by design it accumulates years of data and becomes harder to read as the series grows.

## Changes

### 1. NetWorthTrendChart now has a brush

- Renders a `Brush dataKey='date'` after the chart's main `Area` + projection band + projected line.
- Pre-zoomed to the most-recent third of the data (`startIndex = max(0, n - ceil(n/3))`) so first paint stays at full fidelity instead of squashing the whole multi-year history into 320 px.
- Travellers 8 px wide, stroked in brand blue.
- Bottom-axis ticks formatted as `MMM YY` so the date reads on mobile.
- Only renders when `data.length > 6` — sparse new-user series would just be visual noise.

### 2. `StandardAreaChart` gains an opt-in `showBrush` prop

Default `false`. Lets FIRE Calculator and Instrument Projections charts (both long-horizon projections) flip it on with a single prop change in a follow-up. Brush only renders when `data.length > 4`. Adds the `Brush` import from recharts and `rawColors` for stroke color.

## Skipped (deliberate)

- `TrendsForecastsPage` triple-mini-chart row — each mini chart is too small for a brush to be useful
- `CashFlowForecast` — single-year by design, brush would have nothing to zoom

Worth revisiting per-chart if specific use cases come up.

## Verification

- `tsc -b --noEmit` clean
- `eslint` clean
- `pnpm run build` clean
- `vitest` 177 tests pass

## Diff

| | |
|---|---|
| Files | 2 |
| Lines | +40, -2 |