### PR TITLE
feat(comparison): collapse stacked bars to single overlaid bar per metric

### DIFF
--- a/frontend/src/pages/comparison/components/CategoryDeltaRow.tsx
+++ b/frontend/src/pages/comparison/components/CategoryDeltaRow.tsx
@@ -15,8 +15,21 @@ interface CategoryDeltaRowProps {
   index: number
 }
 
+/**
+ * One row per category in the deltas list.
+ *
+ * Renders both periods overlaid on a single horizontal bar (period A as
+ * the faded ghost layer, period B as the solid layer on top) so the
+ * delta reads in one eye-fixation. When B > A the solid bar extends past
+ * the ghost; when B < A the ghost's tail trails past the solid (the
+ * "we shrank" indicator).
+ *
+ * Uses ``colorB`` for both layers so the row stays metric-coded (income vs
+ * expense) rather than period-coded -- ``colorA`` is unused but kept in the
+ * props signature so callsites don't churn.
+ */
 export function CategoryDeltaRow({
-  delta, labelA, labelB, maxValue, colorA, colorB, invertChange, index,
+  delta, labelA, labelB, maxValue, colorB, invertChange, index,
 }: Readonly<CategoryDeltaRowProps>) {
   const { category, periodA, periodB, change } = delta
   const isPositive = change >= 0
@@ -41,34 +54,39 @@ export function CategoryDeltaRow({
         </span>
       </div>
 
-      {/* Period A bar */}
-      <div className="flex items-center gap-2 mb-1">
-        <span className="text-caption text-text-tertiary w-16 truncate">{labelA}</span>
-        <div className="flex-1 h-3 rounded bg-white/5 overflow-hidden">
+      {/* Single overlaid bar: ghost (A) + solid (B). Period totals
+          flank the bar so the eye gets values + delta from one row. */}
+      <div className="flex items-center gap-2">
+        <span
+          className="text-caption text-text-tertiary tabular-nums w-20 truncate text-right"
+          title={`${labelA}: ${formatCurrency(periodA)}`}
+        >
+          {formatCurrency(periodA)}
+        </span>
+        <div className="relative flex-1 h-3 rounded bg-white/5 overflow-hidden">
           <motion.div
-            className="h-full rounded"
-            style={{ backgroundColor: colorA, opacity: 0.65 }}
+            className="absolute inset-y-0 left-0 rounded"
+            style={{ backgroundColor: colorB, opacity: 0.35 }}
             initial={{ width: 0 }}
             animate={{ width: `${widthA}%` }}
             transition={{ duration: 0.5, ease: 'easeOut', delay: index * 0.03 }}
+            aria-hidden
           />
-        </div>
-        <span className="text-xs text-muted-foreground tabular-nums w-20 text-right">{formatCurrency(periodA)}</span>
-      </div>
-
-      {/* Period B bar */}
-      <div className="flex items-center gap-2">
-        <span className="text-caption text-text-tertiary w-16 truncate">{labelB}</span>
-        <div className="flex-1 h-3 rounded bg-white/5 overflow-hidden">
           <motion.div
-            className="h-full rounded"
+            className="absolute inset-y-0 left-0 rounded"
             style={{ backgroundColor: colorB }}
             initial={{ width: 0 }}
             animate={{ width: `${widthB}%` }}
             transition={{ duration: 0.5, ease: 'easeOut', delay: index * 0.03 + 0.08 }}
+            aria-hidden
           />
         </div>
-        <span className="text-xs font-medium text-white tabular-nums w-20 text-right">{formatCurrency(periodB)}</span>
+        <span
+          className="text-xs font-medium text-white tabular-nums w-20 truncate"
+          title={`${labelB}: ${formatCurrency(periodB)}`}
+        >
+          {formatCurrency(periodB)}
+        </span>
       </div>
     </motion.div>
   )

--- a/frontend/src/pages/comparison/components/OverviewMetricRow.tsx
+++ b/frontend/src/pages/comparison/components/OverviewMetricRow.tsx
@@ -15,6 +15,16 @@ interface OverviewMetricRowProps {
   isPercent?: boolean
 }
 
+/**
+ * One row per metric (Income / Expenses / Savings / Savings Rate).
+ *
+ * Renders the two periods overlaid on a single horizontal bar instead of
+ * stacked one-above-the-other. Period A is the faded ghost layer; period B
+ * is the solid layer on top. When B > A the user sees the change as the
+ * solid bar's extent past where the ghost would end; when B < A the ghost's
+ * tail extends past the solid bar (the "we shrank" trail). Reads in one
+ * eye-fixation instead of two.
+ */
 export function OverviewMetricRow({
   label, valueA, valueB, labelA, labelB,
   color, maxValue, invertChange, isPercent,
@@ -28,7 +38,8 @@ export function OverviewMetricRow({
   const barWidthB = maxValue > 0 ? (Math.abs(valueB) / maxValue) * 100 : 0
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-1.5">
+      {/* Header: metric label + change badge */}
       <div className="flex items-center justify-between">
         <span className="text-sm font-medium text-white">{label}</span>
         <div className={`flex items-center gap-1 text-xs font-medium ${isGood ? 'text-app-green' : 'text-app-red'}`}>
@@ -36,33 +47,39 @@ export function OverviewMetricRow({
           <span>{change > 0 ? '+' : ''}{change.toFixed(1)}{isPercent ? ' pts' : '%'}</span>
         </div>
       </div>
-      {/* Period A bar */}
+      {/* Single overlaid bar: ghost (A) + solid (B). Both anchored at the
+          same left edge so the user reads the delta as the visible gap. */}
       <div className="flex items-center gap-3">
-        <span className="text-xs text-muted-foreground w-24 truncate">{labelA}</span>
-        <div className="flex-1 h-5 rounded-md bg-white/5 overflow-hidden">
+        <span
+          className="text-caption text-text-tertiary tabular-nums w-24 truncate text-right"
+          title={`${labelA}: ${fmtVal(valueA)}`}
+        >
+          {labelA} · {fmtVal(valueA)}
+        </span>
+        <div className="relative flex-1 h-5 rounded-md bg-white/5 overflow-hidden">
           <motion.div
-            className="h-full rounded-md"
-            style={{ backgroundColor: color, opacity: 0.6 }}
+            className="absolute inset-y-0 left-0 rounded-md"
+            style={{ backgroundColor: color, opacity: 0.35 }}
             initial={{ width: 0 }}
             animate={{ width: `${barWidthA}%` }}
-            transition={{ duration: 0.6, ease: 'easeOut' }}
+            transition={{ duration: 0.5, ease: 'easeOut' }}
+            aria-hidden
           />
-        </div>
-        <span className="text-xs font-medium text-foreground tabular-nums w-24 text-right">{fmtVal(valueA)}</span>
-      </div>
-      {/* Period B bar */}
-      <div className="flex items-center gap-3">
-        <span className="text-xs text-muted-foreground w-24 truncate">{labelB}</span>
-        <div className="flex-1 h-5 rounded-md bg-white/5 overflow-hidden">
           <motion.div
-            className="h-full rounded-md"
+            className="absolute inset-y-0 left-0 rounded-md"
             style={{ backgroundColor: color }}
             initial={{ width: 0 }}
             animate={{ width: `${barWidthB}%` }}
             transition={{ duration: 0.6, ease: 'easeOut', delay: 0.1 }}
+            aria-hidden
           />
         </div>
-        <span className="text-xs font-medium text-white tabular-nums w-24 text-right">{fmtVal(valueB)}</span>
+        <span
+          className="text-xs font-medium text-white tabular-nums w-24 truncate"
+          title={`${labelB}: ${fmtVal(valueB)}`}
+        >
+          {labelB} · {fmtVal(valueB)}
+        </span>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

Audit recommendation: instead of period A on one row and period B on a separate row below, overlay them onto a single bar — ghost layer for A (35 % opacity), solid layer for B on top. The user reads the delta as the visible gap in one eye-fixation rather than scanning two rows and mentally subtracting.

## Components updated

### `OverviewMetricRow` (Income / Expenses / Savings / Savings Rate)

Two horizontal bars per metric collapsed into one. Both period values still render, flanking the bar:

\\\
[Income]                                              +5.2%
Apr 24 · ₹100k  [▓▓▓▓▓▓░░░░░░░░░░]  ₹105k · Apr 25
\\\

Header still carries the metric name and change badge so direction reads at a glance.

### `CategoryDeltaRow` (per-category breakdown)

Same collapse. Now uses `colorB` for both layers so the row stays metric-coded (income green vs expense red) rather than period-coded. `colorA` is unused but kept in props so callsites don't churn.

## Visual behaviour

- B > A (growth): solid bar extends past where the ghost ends — the gap *is* the gain.
- B < A (shrinkage): ghost's tail extends past the solid bar — the trailing faded segment *is* the loss.

## Net visual change

Each row is roughly 40 % shorter; the page fits more rows above the fold; gain/loss visualizes as one continuous shape rather than two parallel bars.

## Verification

- `tsc -b --noEmit` clean
- `eslint` clean
- `pnpm run build` clean
- `vitest` 177 tests pass

## Diff

| | |
|---|---|
| Files | 2 |
| Lines | +68, -33 |