### PR TITLE
feat(a11y): respect prefers-reduced-motion via Framer MotionConfig

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense, useEffect, useRef, useState } from 'react'
 import { BrowserRouter, Routes, Route, Link } from 'react-router-dom'
+import { MotionConfig } from 'framer-motion'
 
 import { QueryClientProvider } from '@tanstack/react-query'
 import { Toaster } from 'sonner'
@@ -194,10 +195,11 @@ const TOASTER_OPTIONS = {
 function App() {
   return (
     <ErrorBoundary>
-      <QueryClientProvider client={queryClient}>
-        <AuthInitializer>
-          <PreferencesProvider>
-            <BrowserRouter basename={import.meta.env.BASE_URL}>
+      <MotionConfig reducedMotion="user">
+        <QueryClientProvider client={queryClient}>
+          <AuthInitializer>
+            <PreferencesProvider>
+              <BrowserRouter basename={import.meta.env.BASE_URL}>
               <ChunkErrorBoundary>
               <Suspense fallback={<PageLoader />}>
                 <Routes>
@@ -254,6 +256,7 @@ function App() {
           </PreferencesProvider>
         </AuthInitializer>
       </QueryClientProvider>
+      </MotionConfig>
     </ErrorBoundary>
   )
 }


### PR DESCRIPTION
Wraps the app tree in MotionConfig reducedMotion='user' so every Framer Motion component automatically skips animations when the user has Reduced Motion set in their OS. One-line behavioral change. tsc clean, eslint clean, build clean. Issue 37 of the audit.