### PR TITLE
feat(a11y): add ariaLabel prop to ChartContainer for screen readers

### DIFF
--- a/frontend/src/components/ui/ChartContainer.tsx
+++ b/frontend/src/components/ui/ChartContainer.tsx
@@ -28,6 +28,15 @@ interface ChartContainerProps {
   minHeight?: number
   aspect?: number
   children: ReactNode
+  /**
+   * Accessible label describing what the chart shows. Recharts renders
+   * SVGs that screen readers can't interpret meaningfully, so chart
+   * authors should pass a one-sentence description here -- e.g.
+   * ``ariaLabel="Net worth over the last 12 months"``. Surfaced as a
+   * ``role="img"`` wrapper so AT users get the gist without trying to
+   * walk every <path>.
+   */
+  ariaLabel?: string
 }
 
 /**
@@ -42,12 +51,13 @@ export default function ChartContainer({
   height = '100%',
   mobileHeight,
   children,
+  ariaLabel,
   ...rest
 }: Readonly<ChartContainerProps>) {
   const isMobile = useIsMobile()
   const resolvedHeight = resolveHeight(isMobile, height, mobileHeight)
 
-  return (
+  const container = (
     <ResponsiveContainer
       width={width}
       height={resolvedHeight}
@@ -57,6 +67,16 @@ export default function ChartContainer({
     >
       {children}
     </ResponsiveContainer>
+  )
+
+  if (!ariaLabel) return container
+
+  // Wrap in a role="img" with the descriptive label so screen readers
+  // announce a single meaningful summary instead of walking every SVG node.
+  return (
+    <div role="img" aria-label={ariaLabel} style={{ width: '100%', height: '100%' }}>
+      {container}
+    </div>
   )
 }
 


### PR DESCRIPTION
Recharts SVGs are unintelligible to screen readers because every path and g gets read individually. Wrapping ChartContainer in a role='img' with a descriptive aria-label lets AT users hear a single one-sentence summary instead. Backwards-compatible: prop is optional. No callsites migrated in this PR -- chart authors opt in incrementally. Audit issue #38. tsc + eslint + build clean.