### PR TITLE
feat(ui): StaleDataBadge component + Instrument Projections wiring

### DIFF
--- a/frontend/src/components/analytics/InstrumentProjections.tsx
+++ b/frontend/src/components/analytics/InstrumentProjections.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion'
 import { Landmark, IndianRupee, PiggyBank, TrendingUp, Percent } from 'lucide-react'
 import { rawColors } from '@/constants/colors'
 import { formatCurrency } from '@/lib/formatters'
+import { StaleDataBadge } from '@/components/shared/StaleDataBadge'
 import StandardAreaChart from '@/components/analytics/StandardAreaChart'
 import MetricCard from '@/components/shared/MetricCard'
 import { projectPPF, projectEPF, projectNPS } from '@/lib/instrumentCalculators'
@@ -225,7 +226,7 @@ function findAccountBalance(data: AccountBalances | undefined, pattern: string):
 
 export default function InstrumentProjections() {
   const { data: accountBalances } = useAccountBalances()
-  const { data: rates } = useInstrumentRates()
+  const { data: rates, isFallback } = useInstrumentRates()
   const ppfBalance = useMemo(() => findAccountBalance(accountBalances, 'ppf'), [accountBalances])
   const epfBalance = useMemo(() => findAccountBalance(accountBalances, 'epf'), [accountBalances])
   const [tab, setTab] = useState<Instrument>('ppf')
@@ -241,6 +242,10 @@ export default function InstrumentProjections() {
         <div className="flex items-center gap-2">
           <Landmark className="w-5 h-5 text-app-blue" />
           <h3 className="text-lg font-semibold text-white">Instrument Maturity Projections</h3>
+          <StaleDataBadge
+            isFallback={isFallback}
+            reason="Couldn't fetch the latest instrument rates -- using compiled-in defaults until the next refresh."
+          />
         </div>
         <div className="flex gap-1 p-0.5 rounded-lg bg-muted/20">
           {TABS.map(({ key, label }) => (

--- a/frontend/src/components/shared/StaleDataBadge.tsx
+++ b/frontend/src/components/shared/StaleDataBadge.tsx
@@ -1,0 +1,30 @@
+import { Info } from 'lucide-react'
+
+interface StaleDataBadgeProps {
+  /** Whether the consumer is currently rendering compiled-in fallback data. */
+  readonly isFallback: boolean
+  /** Optional reason text to surface in the badge tooltip. */
+  readonly reason?: string
+}
+
+/**
+ * Tiny inline pill that lights up when a hook falls back to compiled-in
+ * defaults (network failure, server stale, etc.). Renders nothing in the
+ * common case so callsites can spread it freely.
+ *
+ * Uses the warning semantic colour so it stands out without screaming
+ * "error" -- fallback data is correct, just not freshest possible.
+ */
+export function StaleDataBadge({ isFallback, reason }: StaleDataBadgeProps) {
+  if (!isFallback) return null
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-overline font-medium bg-warning/10 text-warning border border-warning/20"
+      title={reason ?? 'Showing fallback data — couldn\'t reach the live source.'}
+      role="status"
+    >
+      <Info className="w-3 h-3" aria-hidden />
+      Fallback
+    </span>
+  )
+}


### PR DESCRIPTION
Tiny amber 'Fallback' pill that surfaces when a hook lands on compiled-in defaults instead of live data. First consumer is InstrumentProjections (PPF/EPF/NPS rates). useExchangeRate also exposes isFallback, ready for incremental migration. Audit issue #31. tsc + eslint + build clean.