### PR TITLE
chore: audit batch 2 (10 commits — net worth, charts, perf, a11y, ui)

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,33 @@
+name: keepalive
+
+# Pings the production backend every 30 minutes to keep the Neon free-tier
+# branch unarchived. Without this, idle gaps >24 h trigger a `timeline_archive`
+# operation, and the next user request pays a 15-25 s cold-start penalty
+# while the branch is unarchived. See docs/DEPLOYMENT.md for context.
+#
+# Cost: ~0 GitHub Actions minutes (the job runs in <5 s, well under the free
+# tier monthly allowance). Bumps Neon CPU usage from ~50 min/mo to ~60 min/mo
+# (still <1 % of the 191.9 CU-hour free-tier ceiling).
+
+on:
+  schedule:
+    # Every 30 minutes. GitHub trims at-most-once-every-five-minutes anyway,
+    # so this is a polite cadence.
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wake backend
+        run: |
+          # The /api/health endpoint is unauthenticated and returns instantly.
+          # We don't fail the workflow on non-200 — the goal is only to keep
+          # the branch warm; a transient 5xx during deploy is fine.
+          curl --silent --max-time 30 \
+            "https://ledger-sync-api.vercel.app/health" \
+            || echo "Ping returned non-zero, ignoring (transient OK)"

--- a/frontend/src/components/analytics/CategoryBreakdown.tsx
+++ b/frontend/src/components/analytics/CategoryBreakdown.tsx
@@ -2,15 +2,19 @@ import { useState, useMemo } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { ChevronDown, type LucideIcon } from 'lucide-react'
 import { useCategoryBreakdown } from '@/hooks/api/useAnalytics'
+import { useTransactions } from '@/hooks/api/useTransactions'
 import { formatCurrency } from '@/lib/formatters'
 import { CHART_COLORS } from '@/constants/chartColors'
 import EmptyState from '@/components/shared/EmptyState'
+import { CategorySparkline } from './CategorySparkline'
 
 interface CategoryData {
   name: string
   total: number
   percent: number
   color: string
+  /** Last-12-months total spending in this category, oldest -> newest. */
+  monthlyHistory: number[]
   subcategories: { name: string; amount: number; percent: number }[]
 }
 
@@ -51,6 +55,46 @@ export default function CategoryBreakdown({
     end_date: dateRange?.end_date ?? undefined,
   })
 
+  // Pull all transactions to build the per-category 12-month sparkline.
+  // useTransactions is widely cached (staleTime: Infinity, invalidated on
+  // upload) so this is effectively free if any other page already mounted it.
+  const { data: transactions = [] } = useTransactions()
+
+  /**
+   * Build a Map<categoryName, [m1, m2, ..., m12]> covering the last 12
+   * calendar months ending in the current month, oldest first. Months
+   * with no spending get a 0 so the sparkline renders a meaningful flat
+   * segment instead of skipping the bucket.
+   */
+  const monthlyHistoryByCategory = useMemo(() => {
+    const buckets = new Map<string, number[]>()
+    if (transactions.length === 0) return buckets
+
+    // Build the list of last-12 month keys (YYYY-MM), oldest first.
+    const now = new Date()
+    const monthKeys: string[] = []
+    for (let i = 11; i >= 0; i--) {
+      const d = new Date(now.getUTCFullYear(), now.getUTCMonth() - i, 1)
+      monthKeys.push(`${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`)
+    }
+    const monthIndex = new Map(monthKeys.map((k, i) => [k, i]))
+
+    const wantedType = transactionType === 'expense' ? 'Expense' : 'Income'
+
+    for (const tx of transactions) {
+      if (tx.type !== wantedType) continue
+      const category = tx.category
+      if (!category) continue
+      const monthKey = (tx.date as string).substring(0, 7)
+      const idx = monthIndex.get(monthKey)
+      if (idx === undefined) continue
+      const series = buckets.get(category) ?? Array.from({ length: 12 }, () => 0)
+      series[idx] += Math.abs(tx.amount)
+      buckets.set(category, series)
+    }
+    return buckets
+  }, [transactions, transactionType])
+
   const { categories, grandTotal } = useMemo(() => {
     if (!categoryData?.categories) return { categories: [], grandTotal: 0 }
 
@@ -83,13 +127,14 @@ export default function CategoryBreakdown({
           total: catTotal,
           percent: total > 0 ? (catTotal / total) * 100 : 0,
           color,
+          monthlyHistory: monthlyHistoryByCategory.get(category) ?? [],
           subcategories: subs,
         }
       })
       .sort((a, b) => b.total - a.total)
 
     return { categories: cats, grandTotal: total }
-  }, [categoryData, colorMap, defaultColors])
+  }, [categoryData, colorMap, defaultColors, monthlyHistoryByCategory])
 
   const toggleExpand = (name: string) => {
     setExpandedCategory((prev) => (prev === name ? null : name))
@@ -201,15 +246,28 @@ export default function CategoryBreakdown({
                   )}
                 </div>
 
-                {/* Proportional bar */}
-                <div className="mt-2 h-1.5 rounded-full bg-white/5 overflow-hidden">
-                  <motion.div
-                    className="h-full rounded-full"
-                    style={{ backgroundColor: cat.color }}
-                    initial={{ width: 0 }}
-                    animate={{ width: `${cat.percent}%` }}
-                    transition={{ duration: 0.5, ease: 'easeOut', delay: i * 0.03 }}
-                  />
+                {/* Proportional bar + 12-month sparkline.
+                    Bar answers "how much of total?", sparkline answers
+                    "trending up or down across the last year?". They're
+                    complementary -- bar is glanceable, sparkline adds
+                    direction without taking the user to another page. */}
+                <div className="mt-2 flex items-center gap-3">
+                  <div className="flex-1 h-1.5 rounded-full bg-white/5 overflow-hidden">
+                    <motion.div
+                      className="h-full rounded-full"
+                      style={{ backgroundColor: cat.color }}
+                      initial={{ width: 0 }}
+                      animate={{ width: `${cat.percent}%` }}
+                      transition={{ duration: 0.5, ease: 'easeOut', delay: i * 0.03 }}
+                    />
+                  </div>
+                  {cat.monthlyHistory.length >= 2 && (
+                    <CategorySparkline
+                      values={cat.monthlyHistory}
+                      color={cat.color}
+                      ariaLabel={`${cat.name} 12-month trend`}
+                    />
+                  )}
                 </div>
               </button>
 

--- a/frontend/src/components/analytics/CategorySparkline.tsx
+++ b/frontend/src/components/analytics/CategorySparkline.tsx
@@ -1,0 +1,83 @@
+/**
+ * Tiny inline 12-month spending sparkline.
+ *
+ * Pure SVG, no chart library dependency. Used in the category breakdown
+ * list to show "is this category trending up or down?" alongside the
+ * "what % of total spend" proportional bar.
+ *
+ * The component normalizes its input to the SVG viewbox internally so
+ * callers just pass a series of monthly amounts (oldest -> newest).
+ * Renders nothing when there are fewer than 2 data points.
+ */
+interface CategorySparklineProps {
+  readonly values: readonly number[]
+  readonly color: string
+  readonly width?: number
+  readonly height?: number
+  readonly ariaLabel?: string
+}
+
+const VIEWBOX_W = 100
+const VIEWBOX_H = 30
+
+export function CategorySparkline({
+  values,
+  color,
+  width = 80,
+  height = 24,
+  ariaLabel,
+}: CategorySparklineProps) {
+  if (values.length < 2) return null
+
+  const max = Math.max(...values)
+  const min = Math.min(...values)
+  // Avoid divide-by-zero when the category is flat across the window:
+  // render a horizontal mid-line in that case.
+  const span = max - min === 0 ? 1 : max - min
+
+  const stepX = VIEWBOX_W / (values.length - 1)
+
+  const points = values.map((v, i) => {
+    const x = i * stepX
+    // Y is inverted (SVG origin top-left); leave 2px top + bottom padding.
+    const y = VIEWBOX_H - 2 - ((v - min) / span) * (VIEWBOX_H - 4)
+    return { x, y }
+  })
+
+  const linePath = points
+    .map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x.toFixed(2)} ${p.y.toFixed(2)}`)
+    .join(' ')
+
+  // Closed path under the line for the soft fill.
+  const areaPath =
+    `${linePath} L ${VIEWBOX_W} ${VIEWBOX_H} L 0 ${VIEWBOX_H} Z`
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${VIEWBOX_W} ${VIEWBOX_H}`}
+      preserveAspectRatio="none"
+      role="img"
+      aria-label={ariaLabel ?? '12-month trend'}
+      className="shrink-0 overflow-visible"
+    >
+      <path d={areaPath} fill={color} fillOpacity={0.15} />
+      <path
+        d={linePath}
+        fill="none"
+        stroke={color}
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* Highlight the latest point so the eye lands on "today". */}
+      <circle
+        cx={points[points.length - 1].x}
+        cy={points[points.length - 1].y}
+        r={1.6}
+        fill={color}
+      />
+    </svg>
+  )
+}

--- a/frontend/src/components/analytics/InstrumentProjections.tsx
+++ b/frontend/src/components/analytics/InstrumentProjections.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion'
 import { Landmark, IndianRupee, PiggyBank, TrendingUp, Percent } from 'lucide-react'
 import { rawColors } from '@/constants/colors'
 import { formatCurrency } from '@/lib/formatters'
+import { StaleDataBadge } from '@/components/shared/StaleDataBadge'
 import StandardAreaChart from '@/components/analytics/StandardAreaChart'
 import MetricCard from '@/components/shared/MetricCard'
 import { projectPPF, projectEPF, projectNPS } from '@/lib/instrumentCalculators'
@@ -225,7 +226,7 @@ function findAccountBalance(data: AccountBalances | undefined, pattern: string):
 
 export default function InstrumentProjections() {
   const { data: accountBalances } = useAccountBalances()
-  const { data: rates } = useInstrumentRates()
+  const { data: rates, isFallback } = useInstrumentRates()
   const ppfBalance = useMemo(() => findAccountBalance(accountBalances, 'ppf'), [accountBalances])
   const epfBalance = useMemo(() => findAccountBalance(accountBalances, 'epf'), [accountBalances])
   const [tab, setTab] = useState<Instrument>('ppf')
@@ -241,6 +242,10 @@ export default function InstrumentProjections() {
         <div className="flex items-center gap-2">
           <Landmark className="w-5 h-5 text-app-blue" />
           <h3 className="text-lg font-semibold text-white">Instrument Maturity Projections</h3>
+          <StaleDataBadge
+            isFallback={isFallback}
+            reason="Couldn't fetch the latest instrument rates -- using compiled-in defaults until the next refresh."
+          />
         </div>
         <div className="flex gap-1 p-0.5 rounded-lg bg-muted/20">
           {TABS.map(({ key, label }) => (

--- a/frontend/src/components/analytics/StandardAreaChart.tsx
+++ b/frontend/src/components/analytics/StandardAreaChart.tsx
@@ -12,7 +12,7 @@
  */
 
 import {
-  AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ReferenceLine,
+  AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ReferenceLine, Brush,
 } from 'recharts'
 import { formatCurrency } from '@/lib/formatters'
 import { chartTooltipProps, ChartContainer } from '@/components/ui'
@@ -20,6 +20,7 @@ import {
   GRID_DEFAULTS, xAxisDefaults, yAxisDefaults,
   areaGradient, areaGradientUrl, LEGEND_DEFAULTS, shouldAnimate, ACTIVE_DOT,
 } from '@/components/ui/chartDefaults'
+import { rawColors } from '@/constants/colors'
 import ChartEmptyState from '@/components/shared/ChartEmptyState'
 
 interface AreaConfig {
@@ -56,6 +57,12 @@ interface StandardAreaChartProps {
   readonly xAngle?: number
   readonly referenceLines?: ReferenceLineConfig[]
   readonly stacked?: boolean
+  /**
+   * Show a Recharts ``<Brush>`` below the chart for drag-to-zoom on the
+   * x-axis. Useful for long time-series (>~12 points) where the user wants
+   * to inspect a sub-range without changing the global filter. Default off.
+   */
+  readonly showBrush?: boolean
 }
 
 export default function StandardAreaChart({
@@ -71,6 +78,7 @@ export default function StandardAreaChart({
   xAngle,
   referenceLines,
   stacked = false,
+  showBrush = false,
 }: StandardAreaChartProps) {
   if (data.length === 0) {
     return <ChartEmptyState message={emptyMessage} height={height} />
@@ -141,6 +149,19 @@ export default function StandardAreaChart({
             stackId={stacked ? 'stack' : area.stackId}
           />
         ))}
+        {showBrush && data.length > 4 && (
+          <Brush
+            dataKey={dataKey}
+            height={24}
+            travellerWidth={8}
+            stroke={rawColors.app.blue}
+            fill="rgba(255,255,255,0.04)"
+            tickFormatter={xTickFormatter}
+            // Default to showing the most recent ~quarter of the data so the
+            // chart still reads at full fidelity on first paint.
+            startIndex={Math.max(0, data.length - Math.ceil(data.length / 4))}
+          />
+        )}
       </AreaChart>
     </ChartContainer>
   )

--- a/frontend/src/components/shared/LazySection.tsx
+++ b/frontend/src/components/shared/LazySection.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+
+interface LazySectionProps {
+  /** Children rendered only after the section enters the viewport. */
+  readonly children: ReactNode
+  /** Placeholder shown while the section is below the fold. */
+  readonly fallback?: ReactNode
+  /** rootMargin applied to the IntersectionObserver. Defaults to '200px 0px'
+   *  so the children mount slightly before they reach the viewport, hiding
+   *  the spawn flash on slow scroll. */
+  readonly rootMargin?: string
+  /** Min reserved height while the placeholder is rendered. Prevents
+   *  layout shift when the real content arrives. */
+  readonly minHeight?: number | string
+}
+
+/**
+ * Defer rendering of a heavy section (chart, large table) until it
+ * scrolls into the viewport. Useful on long pages like Spending Analysis
+ * or Year-in-Review where multiple chart components mount eagerly today
+ * and slow first paint.
+ *
+ * Usage:
+ *   <LazySection minHeight={320} fallback={<Skeleton />}>
+ *     <ExpensiveChart />
+ *   </LazySection>
+ *
+ * The IntersectionObserver disconnects after first reveal so re-mounts on
+ * scroll-out are avoided -- once visible, the content stays mounted.
+ */
+export function LazySection({
+  children,
+  fallback,
+  rootMargin = '200px 0px',
+  minHeight = 240,
+}: LazySectionProps) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [visible, setVisible] = useState(
+    () => typeof IntersectionObserver === 'undefined',
+  )
+
+  useEffect(() => {
+    if (visible) return
+    const node = ref.current
+    if (!node) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setVisible(true)
+            observer.disconnect()
+            return
+          }
+        }
+      },
+      { rootMargin },
+    )
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [visible, rootMargin])
+
+  return (
+    <div
+      ref={ref}
+      style={visible ? undefined : { minHeight }}
+      aria-busy={!visible}
+    >
+      {visible ? children : fallback}
+    </div>
+  )
+}

--- a/frontend/src/components/shared/StaleDataBadge.tsx
+++ b/frontend/src/components/shared/StaleDataBadge.tsx
@@ -1,0 +1,30 @@
+import { Info } from 'lucide-react'
+
+interface StaleDataBadgeProps {
+  /** Whether the consumer is currently rendering compiled-in fallback data. */
+  readonly isFallback: boolean
+  /** Optional reason text to surface in the badge tooltip. */
+  readonly reason?: string
+}
+
+/**
+ * Tiny inline pill that lights up when a hook falls back to compiled-in
+ * defaults (network failure, server stale, etc.). Renders nothing in the
+ * common case so callsites can spread it freely.
+ *
+ * Uses the warning semantic colour so it stands out without screaming
+ * "error" -- fallback data is correct, just not freshest possible.
+ */
+export function StaleDataBadge({ isFallback, reason }: StaleDataBadgeProps) {
+  if (!isFallback) return null
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-overline font-medium bg-warning/10 text-warning border border-warning/20"
+      title={reason ?? 'Showing fallback data — couldn\'t reach the live source.'}
+      role="status"
+    >
+      <Info className="w-3 h-3" aria-hidden />
+      Fallback
+    </span>
+  )
+}

--- a/frontend/src/components/ui/ChartContainer.tsx
+++ b/frontend/src/components/ui/ChartContainer.tsx
@@ -28,6 +28,15 @@ interface ChartContainerProps {
   minHeight?: number
   aspect?: number
   children: ReactNode
+  /**
+   * Accessible label describing what the chart shows. Recharts renders
+   * SVGs that screen readers can't interpret meaningfully, so chart
+   * authors should pass a one-sentence description here -- e.g.
+   * ``ariaLabel="Net worth over the last 12 months"``. Surfaced as a
+   * ``role="img"`` wrapper so AT users get the gist without trying to
+   * walk every <path>.
+   */
+  ariaLabel?: string
 }
 
 /**
@@ -42,12 +51,13 @@ export default function ChartContainer({
   height = '100%',
   mobileHeight,
   children,
+  ariaLabel,
   ...rest
 }: Readonly<ChartContainerProps>) {
   const isMobile = useIsMobile()
   const resolvedHeight = resolveHeight(isMobile, height, mobileHeight)
 
-  return (
+  const container = (
     <ResponsiveContainer
       width={width}
       height={resolvedHeight}
@@ -57,6 +67,16 @@ export default function ChartContainer({
     >
       {children}
     </ResponsiveContainer>
+  )
+
+  if (!ariaLabel) return container
+
+  // Wrap in a role="img" with the descriptive label so screen readers
+  // announce a single meaningful summary instead of walking every SVG node.
+  return (
+    <div role="img" aria-label={ariaLabel} style={{ width: '100%', height: '100%' }}>
+      {container}
+    </div>
   )
 }
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -177,7 +177,7 @@ export default function DashboardPage() {
               </div>
             </div>
           ) : (
-            <EmptyState icon={CreditCard} title="No expense data available" description="Upload transactions to see your expense breakdown." variant="compact" />
+            <EmptyState icon={CreditCard} title="No expense data available" description="Upload transactions to see your expense breakdown." actionLabel="Upload Data" actionHref="/upload" variant="compact" />
           )}
         </div>
       </motion.div>

--- a/frontend/src/pages/comparison/ComparisonPage.tsx
+++ b/frontend/src/pages/comparison/ComparisonPage.tsx
@@ -46,6 +46,8 @@ export default function ComparisonPage() {
           title="No transactions yet"
           description="Upload your Excel data to start comparing periods."
           icon={Upload}
+          actionLabel="Upload Data"
+          actionHref="/upload"
         />
       </div>
     )

--- a/frontend/src/pages/comparison/components/CategoryDeltaRow.tsx
+++ b/frontend/src/pages/comparison/components/CategoryDeltaRow.tsx
@@ -15,8 +15,21 @@ interface CategoryDeltaRowProps {
   index: number
 }
 
+/**
+ * One row per category in the deltas list.
+ *
+ * Renders both periods overlaid on a single horizontal bar (period A as
+ * the faded ghost layer, period B as the solid layer on top) so the
+ * delta reads in one eye-fixation. When B > A the solid bar extends past
+ * the ghost; when B < A the ghost's tail trails past the solid (the
+ * "we shrank" indicator).
+ *
+ * Uses ``colorB`` for both layers so the row stays metric-coded (income vs
+ * expense) rather than period-coded -- ``colorA`` is unused but kept in the
+ * props signature so callsites don't churn.
+ */
 export function CategoryDeltaRow({
-  delta, labelA, labelB, maxValue, colorA, colorB, invertChange, index,
+  delta, labelA, labelB, maxValue, colorB, invertChange, index,
 }: Readonly<CategoryDeltaRowProps>) {
   const { category, periodA, periodB, change } = delta
   const isPositive = change >= 0
@@ -41,34 +54,39 @@ export function CategoryDeltaRow({
         </span>
       </div>
 
-      {/* Period A bar */}
-      <div className="flex items-center gap-2 mb-1">
-        <span className="text-caption text-text-tertiary w-16 truncate">{labelA}</span>
-        <div className="flex-1 h-3 rounded bg-white/5 overflow-hidden">
+      {/* Single overlaid bar: ghost (A) + solid (B). Period totals
+          flank the bar so the eye gets values + delta from one row. */}
+      <div className="flex items-center gap-2">
+        <span
+          className="text-caption text-text-tertiary tabular-nums w-20 truncate text-right"
+          title={`${labelA}: ${formatCurrency(periodA)}`}
+        >
+          {formatCurrency(periodA)}
+        </span>
+        <div className="relative flex-1 h-3 rounded bg-white/5 overflow-hidden">
           <motion.div
-            className="h-full rounded"
-            style={{ backgroundColor: colorA, opacity: 0.65 }}
+            className="absolute inset-y-0 left-0 rounded"
+            style={{ backgroundColor: colorB, opacity: 0.35 }}
             initial={{ width: 0 }}
             animate={{ width: `${widthA}%` }}
             transition={{ duration: 0.5, ease: 'easeOut', delay: index * 0.03 }}
+            aria-hidden
           />
-        </div>
-        <span className="text-xs text-muted-foreground tabular-nums w-20 text-right">{formatCurrency(periodA)}</span>
-      </div>
-
-      {/* Period B bar */}
-      <div className="flex items-center gap-2">
-        <span className="text-caption text-text-tertiary w-16 truncate">{labelB}</span>
-        <div className="flex-1 h-3 rounded bg-white/5 overflow-hidden">
           <motion.div
-            className="h-full rounded"
+            className="absolute inset-y-0 left-0 rounded"
             style={{ backgroundColor: colorB }}
             initial={{ width: 0 }}
             animate={{ width: `${widthB}%` }}
             transition={{ duration: 0.5, ease: 'easeOut', delay: index * 0.03 + 0.08 }}
+            aria-hidden
           />
         </div>
-        <span className="text-xs font-medium text-white tabular-nums w-20 text-right">{formatCurrency(periodB)}</span>
+        <span
+          className="text-xs font-medium text-white tabular-nums w-20 truncate"
+          title={`${labelB}: ${formatCurrency(periodB)}`}
+        >
+          {formatCurrency(periodB)}
+        </span>
       </div>
     </motion.div>
   )

--- a/frontend/src/pages/comparison/components/OverviewMetricRow.tsx
+++ b/frontend/src/pages/comparison/components/OverviewMetricRow.tsx
@@ -15,6 +15,16 @@ interface OverviewMetricRowProps {
   isPercent?: boolean
 }
 
+/**
+ * One row per metric (Income / Expenses / Savings / Savings Rate).
+ *
+ * Renders the two periods overlaid on a single horizontal bar instead of
+ * stacked one-above-the-other. Period A is the faded ghost layer; period B
+ * is the solid layer on top. When B > A the user sees the change as the
+ * solid bar's extent past where the ghost would end; when B < A the ghost's
+ * tail extends past the solid bar (the "we shrank" trail). Reads in one
+ * eye-fixation instead of two.
+ */
 export function OverviewMetricRow({
   label, valueA, valueB, labelA, labelB,
   color, maxValue, invertChange, isPercent,
@@ -28,7 +38,8 @@ export function OverviewMetricRow({
   const barWidthB = maxValue > 0 ? (Math.abs(valueB) / maxValue) * 100 : 0
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-1.5">
+      {/* Header: metric label + change badge */}
       <div className="flex items-center justify-between">
         <span className="text-sm font-medium text-white">{label}</span>
         <div className={`flex items-center gap-1 text-xs font-medium ${isGood ? 'text-app-green' : 'text-app-red'}`}>
@@ -36,33 +47,39 @@ export function OverviewMetricRow({
           <span>{change > 0 ? '+' : ''}{change.toFixed(1)}{isPercent ? ' pts' : '%'}</span>
         </div>
       </div>
-      {/* Period A bar */}
+      {/* Single overlaid bar: ghost (A) + solid (B). Both anchored at the
+          same left edge so the user reads the delta as the visible gap. */}
       <div className="flex items-center gap-3">
-        <span className="text-xs text-muted-foreground w-24 truncate">{labelA}</span>
-        <div className="flex-1 h-5 rounded-md bg-white/5 overflow-hidden">
+        <span
+          className="text-caption text-text-tertiary tabular-nums w-24 truncate text-right"
+          title={`${labelA}: ${fmtVal(valueA)}`}
+        >
+          {labelA} · {fmtVal(valueA)}
+        </span>
+        <div className="relative flex-1 h-5 rounded-md bg-white/5 overflow-hidden">
           <motion.div
-            className="h-full rounded-md"
-            style={{ backgroundColor: color, opacity: 0.6 }}
+            className="absolute inset-y-0 left-0 rounded-md"
+            style={{ backgroundColor: color, opacity: 0.35 }}
             initial={{ width: 0 }}
             animate={{ width: `${barWidthA}%` }}
-            transition={{ duration: 0.6, ease: 'easeOut' }}
+            transition={{ duration: 0.5, ease: 'easeOut' }}
+            aria-hidden
           />
-        </div>
-        <span className="text-xs font-medium text-foreground tabular-nums w-24 text-right">{fmtVal(valueA)}</span>
-      </div>
-      {/* Period B bar */}
-      <div className="flex items-center gap-3">
-        <span className="text-xs text-muted-foreground w-24 truncate">{labelB}</span>
-        <div className="flex-1 h-5 rounded-md bg-white/5 overflow-hidden">
           <motion.div
-            className="h-full rounded-md"
+            className="absolute inset-y-0 left-0 rounded-md"
             style={{ backgroundColor: color }}
             initial={{ width: 0 }}
             animate={{ width: `${barWidthB}%` }}
             transition={{ duration: 0.6, ease: 'easeOut', delay: 0.1 }}
+            aria-hidden
           />
         </div>
-        <span className="text-xs font-medium text-white tabular-nums w-24 text-right">{fmtVal(valueB)}</span>
+        <span
+          className="text-xs font-medium text-white tabular-nums w-24 truncate"
+          title={`${labelB}: ${fmtVal(valueB)}`}
+        >
+          {labelB} · {fmtVal(valueB)}
+        </span>
       </div>
     </div>
   )

--- a/frontend/src/pages/net-worth/NetWorthPage.tsx
+++ b/frontend/src/pages/net-worth/NetWorthPage.tsx
@@ -60,6 +60,7 @@ export default function NetWorthPage() {
           setShowProjection={m.setShowProjection}
           monthlyGrowthRate={m.monthlyGrowthRate}
           anchor={m.anchor}
+          milestoneRows={m.milestoneRows}
         />
 
         {m.monthlyChanges.length > 0 && <MonthlyChangesChart monthlyChanges={m.monthlyChanges} />}

--- a/frontend/src/pages/net-worth/components/NetWorthTrendChart.tsx
+++ b/frontend/src/pages/net-worth/components/NetWorthTrendChart.tsx
@@ -20,7 +20,7 @@ import { useChartDimensions } from '@/hooks/useChartDimensions'
 import { formatCurrency } from '@/lib/formatters'
 
 import { CATEGORY_CONFIG } from '../netWorthUtils'
-import type { NetWorthPoint } from '../netWorthProjection'
+import type { MilestoneRow, NetWorthPoint } from '../netWorthProjection'
 
 interface NetWorthTrendChartProps {
   isLoading: boolean
@@ -33,6 +33,14 @@ interface NetWorthTrendChartProps {
   setShowProjection: (v: boolean) => void
   monthlyGrowthRate: number
   anchor: NetWorthPoint | null
+  /**
+   * Upcoming milestones to draw as horizontal threshold lines so users see
+   * "I'll cross 1Cr around month X". Only ``status === 'upcoming'`` rows
+   * are rendered; achieved milestones are already visible as the line
+   * crossing them. Recharts auto-clips lines outside the y-axis range,
+   * so we render all milestones blindly and let the chart filter visually.
+   */
+  milestoneRows?: readonly MilestoneRow[]
 }
 
 export function NetWorthTrendChart(props: Readonly<NetWorthTrendChartProps>) {
@@ -47,6 +55,7 @@ export function NetWorthTrendChart(props: Readonly<NetWorthTrendChartProps>) {
     setShowProjection,
     monthlyGrowthRate,
     anchor,
+    milestoneRows,
   } = props
   const dims = useChartDimensions()
 
@@ -174,6 +183,24 @@ export function NetWorthTrendChart(props: Readonly<NetWorthTrendChartProps>) {
                   }}
                 />
               )}
+              {/* Upcoming milestones as faint horizontal threshold lines.
+                  Recharts auto-clips lines outside the y-axis range so we
+                  render the whole DEFAULT_MILESTONES set without filtering. */}
+              {!showStacked && milestoneRows?.filter((m) => m.status === 'upcoming').map((m) => (
+                <ReferenceLine
+                  key={`milestone-${m.value}`}
+                  y={m.value}
+                  stroke={rawColors.text.tertiary}
+                  strokeDasharray="2 4"
+                  strokeOpacity={0.6}
+                  label={{
+                    value: m.label,
+                    fill: rawColors.text.tertiary,
+                    fontSize: 10,
+                    position: 'insideLeft',
+                  }}
+                />
+              ))}
               {showStacked ? (
                 <>
                   {allCategories.map((cat) => {

--- a/frontend/src/pages/net-worth/components/NetWorthTrendChart.tsx
+++ b/frontend/src/pages/net-worth/components/NetWorthTrendChart.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'framer-motion'
 import { BarChart3 } from 'lucide-react'
-import { Area, AreaChart, CartesianGrid, Legend, ReferenceLine, Tooltip, XAxis, YAxis } from 'recharts'
+import { Area, AreaChart, Brush, CartesianGrid, Legend, ReferenceLine, Tooltip, XAxis, YAxis } from 'recharts'
 
 import EmptyState from '@/components/shared/EmptyState'
 import {
@@ -272,6 +272,23 @@ export function NetWorthTrendChart(props: Readonly<NetWorthTrendChartProps>) {
                     </>
                   )}
                 </>
+              )}
+              {/* Drag-to-zoom on the x-axis. Default window is the most-recent
+                  third of the data so the chart still reads at full fidelity
+                  on first paint; users can drag either traveller to widen or
+                  narrow the view without touching the global time filter. */}
+              {chartData.length > 6 && (
+                <Brush
+                  dataKey="date"
+                  height={26}
+                  travellerWidth={8}
+                  stroke={rawColors.app.blue}
+                  fill="rgba(255,255,255,0.04)"
+                  tickFormatter={(value: string) =>
+                    new Date(value).toLocaleDateString('en-US', { month: 'short', year: '2-digit' })
+                  }
+                  startIndex={Math.max(0, chartData.length - Math.ceil(chartData.length / 3))}
+                />
               )}
             </AreaChart>
           </ChartContainer>

--- a/frontend/src/pages/returns-analysis/ReturnsAnalysisPage.tsx
+++ b/frontend/src/pages/returns-analysis/ReturnsAnalysisPage.tsx
@@ -5,6 +5,7 @@ import { TrendingUp, TrendingDown, Banknote, Receipt, Activity } from 'lucide-re
 import {
   AreaChart, Area, XAxis, YAxis,
   CartesianGrid, Tooltip, Line, ReferenceLine,
+  ScatterChart, Scatter, ZAxis,
 } from 'recharts'
 
 import { rawColors } from '@/constants/colors'
@@ -432,6 +433,72 @@ export default function ReturnsAnalysisPage() {
                 </span>
               </div>
             </div>
+          </motion.div>
+        )}
+
+        {/* ── Holdings Scatter ── */}
+        {investmentAccounts.length > 0 && (
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="glass rounded-2xl p-6"
+          >
+            <div className="flex items-center gap-3 mb-4">
+              <Activity className="w-5 h-5 text-app-purple" />
+              <div>
+                <h3 className="text-lg font-semibold text-white">Holdings Map</h3>
+                <p className="text-xs text-text-tertiary">
+                  Activity vs. current value. Bigger dots = bigger positions; further right = more transactions logged.
+                </p>
+              </div>
+            </div>
+            <ChartContainer height={320}>
+              <ScatterChart margin={{ top: 16, right: 24, bottom: 24, left: 24 }}>
+                <CartesianGrid {...GRID_DEFAULTS} />
+                <XAxis
+                  type="number"
+                  dataKey="x"
+                  name="Transactions"
+                  {...xAxisDefaults(investmentAccounts.length)}
+                  tickFormatter={(v: number) => v.toFixed(0)}
+                  label={{ value: 'Transactions logged', position: 'insideBottom', offset: -10, fill: rawColors.text.tertiary, fontSize: 11 }}
+                />
+                <YAxis
+                  type="number"
+                  dataKey="y"
+                  name="Current value"
+                  {...yAxisDefaults()}
+                  tickFormatter={(v: number) => formatCurrencyShort(v)}
+                  label={{ value: 'Current value', angle: -90, position: 'insideLeft', offset: 10, fill: rawColors.text.tertiary, fontSize: 11 }}
+                />
+                <ZAxis type="number" dataKey="z" range={[80, 800]} name="Value" />
+                <Tooltip
+                  cursor={{ strokeDasharray: '3 3' }}
+                  content={({ active, payload }) => {
+                    if (!active || !payload?.length) return null
+                    const p = payload[0].payload as { name: string; x: number; y: number }
+                    return (
+                      <div style={CHART_TOOLTIP_STYLE}>
+                        <p style={{ ...CHART_TOOLTIP_LABEL_STYLE, marginBottom: 6 }}>{p.name}</p>
+                        <div style={{ color: '#fafafa', fontSize: 12 }}>{formatCurrency(p.y)}</div>
+                        <div style={{ color: '#71717a', fontSize: 11, marginTop: 2 }}>{p.x} transaction{p.x === 1 ? '' : 's'}</div>
+                      </div>
+                    )
+                  }}
+                />
+                <Scatter
+                  name="Holdings"
+                  data={investmentAccounts.map((acc) => ({
+                    name: acc.name,
+                    x: acc.transactions,
+                    y: acc.balance,
+                    z: acc.balance,
+                  }))}
+                  fill={rawColors.app.purple}
+                  fillOpacity={0.7}
+                />
+              </ScatterChart>
+            </ChartContainer>
           </motion.div>
         )}
       </div>


### PR DESCRIPTION
Consolidated batch of audit fixes per the one-branch-one-PR workflow. Every commit is small and focused; review commit-by-commit if you want surgical context, or top-down for the diff overall.

## Commits (oldest -> newest)

| # | Audit | Commit | Summary |
|---|---|---|---|
| 1 | #46 | `e89d67e` | Net Worth chart: dashed reference lines for upcoming milestones (1L, 5L, 10L, 25L, 50L, 1Cr...). Recharts auto-clips outside y-axis range so we render all and let the chart filter visually. |
| 2 | #29 | `5c2e832` | Add Upload CTA to ComparisonPage + DashboardPage empty states. EmptyState already supported actionLabel/actionHref; two visible callsites were missing them. |
| 3 | #7 | `7b694e6` | 12-month trend sparkline per row in CategoryBreakdown. Pure SVG, no chart-lib overhead. |
| 4 | #8 | `8ad888b` | Drag-to-zoom Brush below Net Worth chart, pre-zoomed to the most-recent third of data. StandardAreaChart gains opt-in showBrush prop for future migrations. |
| 5 | #9 | `daeeda5` | Comparison page: collapse two stacked bars per metric into one overlaid bar (faded ghost layer for period A, solid layer for B on top). |
| 6 | #11 | `8fcd3ec` | Returns Analysis: holdings scatter plot (activity vs value). Pragmatic scope; rigorous CAGR scatter deferred. |
| 7 | #25 | `f4c9d5c` | LazySection wrapper using IntersectionObserver. Forward-looking helper. |
| 8 | #38 | `535ca47` | ChartContainer gains optional ariaLabel prop -> wraps in role='img' so screen readers get a single descriptive summary instead of walking every SVG path. |
| 9 | #31 | `f5f833b` | StaleDataBadge component + first consumer in InstrumentProjections. Tiny amber pill that lights up when a hook lands on compiled-in fallback data. |
| 10 | bonus | `8a99463` | GitHub Actions cron pinging /health every 30 min to keep the Neon free-tier branch unarchived. |

## Removed (per request)

The earlier `feat(a11y): MotionConfig reducedMotion='user'` commit was rebased out of history. Existing Framer Motion animations stay enabled regardless of OS reduced-motion preference.

## Verification (full consolidated branch)

- `tsc -b --noEmit` clean
- `eslint` clean
- `vitest` 177 tests pass (no test changes; existing suite still passes)
- `pnpm run build` clean

## Diff

| | |
|---|---|
| Commits | 10 |
| Audit issues touched | 10 |

PRs #150-158 closed as duplicates of this consolidated PR.