### PR TITLE
fix(time-range): anchor THIS_MONTH/LAST_N filters on now(), not latest tx

### DIFF
--- a/backend/src/ledger_sync/api/analytics_helpers.py
+++ b/backend/src/ledger_sync/api/analytics_helpers.py
@@ -38,46 +38,69 @@ def _get_time_range_dates(
     user: User,
     time_range: TimeRange,
 ) -> tuple[datetime | None, datetime | None]:
-    """Calculate start/end dates from a TimeRange enum using the DB-level max date.
+    """Calculate start/end dates from a TimeRange enum, anchored on ``now()``.
 
-    Returns (start_date, end_date) or (None, None) for ALL_TIME.
+    "This month", "Last 3 months", etc. are computed relative to the current
+    UTC time, not the user's most recent transaction. This keeps labels
+    honest -- "This Month" always means the current calendar month, even if
+    the user hasn't uploaded data in a while (in which case the chart will
+    legitimately be empty for that range).
+
+    Sliding windows like "Last 3 months" use calendar-aligned month math
+    (subtract N calendar months, snap to the first of the resulting month)
+    rather than fixed 90-day windows, so partial-month overlaps don't show
+    up in monthly breakdowns.
+
+    Returns (start_date, end_date) or (None, None) for ALL_TIME and for the
+    case when the user has no transactions at all (the latter signals "fall
+    through to no filter" so callers don't crash on empty data).
     """
     if time_range == TimeRange.ALL_TIME:
         return None, None
 
-    latest = (
-        db.query(Transaction.date)
+    # We still bail out early when the user has no data so the empty-state
+    # paths upstream (which check ``if not transactions``) don't try to
+    # query a range against an empty table.
+    has_any = (
+        db.query(Transaction.transaction_id)
         .filter(Transaction.user_id == user.id, Transaction.is_deleted.is_(False))
-        .order_by(Transaction.date.desc())
         .first()
     )
-    if not latest:
+    if not has_any:
         return None, None
 
-    latest_date = latest[0]
-    end_date = None
+    now = datetime.now(UTC)
+    end_date: datetime | None = None
 
     if time_range == TimeRange.THIS_MONTH:
-        start_date = latest_date.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        start_date = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
     elif time_range == TimeRange.LAST_MONTH:
-        first_of_month = latest_date.replace(day=1)
-        last_month_end = first_of_month - timedelta(days=1)
+        first_of_month = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        last_month_end = first_of_month - timedelta(microseconds=1)
         start_date = last_month_end.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
         end_date = last_month_end
     elif time_range == TimeRange.LAST_3_MONTHS:
-        start_date = _subtract_months(latest_date, 3)
+        start_date = _subtract_months(
+            now.replace(day=1, hour=0, minute=0, second=0, microsecond=0), 2
+        )
     elif time_range == TimeRange.LAST_6_MONTHS:
-        start_date = _subtract_months(latest_date, 6)
+        start_date = _subtract_months(
+            now.replace(day=1, hour=0, minute=0, second=0, microsecond=0), 5
+        )
     elif time_range == TimeRange.LAST_12_MONTHS:
-        start_date = _subtract_months(latest_date, 12)
+        start_date = _subtract_months(
+            now.replace(day=1, hour=0, minute=0, second=0, microsecond=0), 11
+        )
     elif time_range == TimeRange.THIS_YEAR:
-        start_date = latest_date.replace(month=1, day=1, hour=0, minute=0, second=0, microsecond=0)
+        start_date = now.replace(month=1, day=1, hour=0, minute=0, second=0, microsecond=0)
     elif time_range == TimeRange.LAST_YEAR:
-        year = latest_date.year - 1
+        year = now.year - 1
         start_date = datetime(year, 1, 1, tzinfo=UTC)
         end_date = datetime(year, 12, 31, 23, 59, 59, tzinfo=UTC)
     elif time_range == TimeRange.LAST_DECADE:
-        start_date = _subtract_months(latest_date, 120)
+        start_date = _subtract_months(
+            now.replace(day=1, hour=0, minute=0, second=0, microsecond=0), 119
+        )
     else:
         return None, None
 

--- a/backend/src/ledger_sync/core/time_filter.py
+++ b/backend/src/ledger_sync/core/time_filter.py
@@ -1,9 +1,20 @@
 """Time filtering utilities for transaction data."""
 
+import calendar
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 
 from ledger_sync.db.models import Transaction
+
+
+def _subtract_months(dt: datetime, months: int) -> datetime:
+    """Subtract N calendar months from a datetime, clamping to a valid day."""
+    month = dt.month - months
+    year = dt.year + (month - 1) // 12
+    month = (month - 1) % 12 + 1
+    max_day = calendar.monthrange(year, month)[1]
+    day = min(dt.day, max_day)
+    return dt.replace(year=year, month=month, day=day)
 
 
 class TimeRange(StrEnum):
@@ -28,15 +39,13 @@ class TimeFilter:
         transactions: list[Transaction],
         time_range: TimeRange,
     ) -> list[Transaction]:
-        """Filter transactions by time range.
+        """Filter transactions by time range, anchored on ``now()``.
 
-        Args:
-            transactions: List of transactions to filter
-            time_range: Time range to filter by
-
-        Returns:
-            Filtered list of transactions
-
+        "This month", "Last 3 months", etc. are computed relative to the
+        current UTC time, not the user's most recent transaction. This
+        keeps semantics consistent with the analytics API and means stale
+        data legitimately yields empty filtered results instead of silently
+        showing months-old data under "This Month" labels.
         """
         if time_range == TimeRange.ALL_TIME:
             return transactions
@@ -44,46 +53,51 @@ class TimeFilter:
         if not transactions:
             return []
 
-        # Get the latest transaction date as reference
-        latest_date = max(t.date for t in transactions)
+        now = datetime.now(UTC)
 
         if time_range == TimeRange.THIS_MONTH:
-            start_date = latest_date.replace(day=1)
+            start_date = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
             return [t for t in transactions if t.date >= start_date]
 
         if time_range == TimeRange.LAST_MONTH:
-            # First day of current month
-            first_of_month = latest_date.replace(day=1)
-            # Last day of previous month
-            last_month_end = first_of_month - timedelta(days=1)
-            # First day of previous month
-            last_month_start = last_month_end.replace(day=1)
+            first_of_month = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+            last_month_end = first_of_month - timedelta(microseconds=1)
+            last_month_start = last_month_end.replace(
+                day=1, hour=0, minute=0, second=0, microsecond=0
+            )
             return [t for t in transactions if last_month_start <= t.date <= last_month_end]
 
+        # Sliding ranges -- calendar-aligned: snap to the first of the month
+        # N-1 months ago, so "Last 3 months" = current + 2 prior calendar
+        # months instead of a fixed 90-day window.
+        first_of_now = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
         if time_range == TimeRange.LAST_3_MONTHS:
-            start_date = latest_date - timedelta(days=90)
+            start_date = _subtract_months(first_of_now, 2)
             return [t for t in transactions if t.date >= start_date]
 
         if time_range == TimeRange.LAST_6_MONTHS:
-            start_date = latest_date - timedelta(days=180)
+            start_date = _subtract_months(first_of_now, 5)
             return [t for t in transactions if t.date >= start_date]
 
         if time_range == TimeRange.LAST_12_MONTHS:
-            start_date = latest_date - timedelta(days=365)
+            start_date = _subtract_months(first_of_now, 11)
             return [t for t in transactions if t.date >= start_date]
 
         if time_range == TimeRange.THIS_YEAR:
-            start_date = latest_date.replace(month=1, day=1)
+            start_date = now.replace(
+                month=1, day=1, hour=0, minute=0, second=0, microsecond=0
+            )
             return [t for t in transactions if t.date >= start_date]
 
         if time_range == TimeRange.LAST_YEAR:
-            year = latest_date.year - 1
+            year = now.year - 1
             start_date = datetime(year, 1, 1, tzinfo=UTC)
             end_date = datetime(year, 12, 31, 23, 59, 59, tzinfo=UTC)
             return [t for t in transactions if start_date <= t.date <= end_date]
 
         if time_range == TimeRange.LAST_DECADE:
-            start_date = latest_date - timedelta(days=3650)  # Approx 10 years
+            start_date = _subtract_months(first_of_now, 119)
             return [t for t in transactions if t.date >= start_date]
 
         return transactions

--- a/backend/tests/integration/test_time_range_anchor_now.py
+++ b/backend/tests/integration/test_time_range_anchor_now.py
@@ -1,0 +1,181 @@
+"""Time-range filters anchor on ``now()``, not on the latest transaction.
+
+Covers both implementations:
+- ``ledger_sync.core.time_filter.TimeFilter`` (in-memory list filter)
+- ``ledger_sync.api.analytics_helpers._get_time_range_dates`` (DB query)
+
+The behaviour change matters for users with stale data: clicking
+"This Month" should yield the current calendar month even if their data
+is months old, instead of returning the latest data month under a
+misleading label.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from ledger_sync.api.analytics_helpers import _get_time_range_dates
+from ledger_sync.core.time_filter import TimeFilter, TimeRange
+from ledger_sync.db.base import Base
+from ledger_sync.db.models import Transaction, TransactionType, User
+
+TEST_BCRYPT_HASH = "$2b$12$dummy_hash_for_testing_purposes"  # noqa: S105
+
+
+@pytest.fixture
+def db_session() -> Session:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session_local = sessionmaker(bind=engine)
+    db = session_local()
+    yield db
+    db.close()
+
+
+@pytest.fixture
+def user(db_session: Session) -> User:
+    user = User(
+        email="now-anchor@example.com",
+        hashed_password=TEST_BCRYPT_HASH,
+        full_name="Test",
+        is_active=True,
+        is_verified=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    return user
+
+
+def _make_tx(
+    user_id: int, date: datetime, amount: float, tid: str
+) -> Transaction:
+    return Transaction(
+        user_id=user_id,
+        transaction_id=tid,
+        date=date,
+        amount=Decimal(str(amount)),
+        currency="INR",
+        type=TransactionType.EXPENSE,
+        account="HDFC",
+        category="Test",
+        subcategory=None,
+        note=None,
+        source_file="test.xlsx",
+        last_seen_at=datetime.now(UTC),
+        is_deleted=False,
+    )
+
+
+# ─── core/time_filter.py ────────────────────────────────────────────────
+
+
+def test_in_memory_this_month_uses_now_not_latest_tx() -> None:
+    """A user whose data ends 6 months ago clicks 'This Month' -> empty
+    result, because it's truly not this month."""
+    fake_now = datetime(2026, 5, 15, tzinfo=UTC)
+    txns = [_make_tx(1, datetime(2025, 11, 5, tzinfo=UTC), 100, "old1")]
+
+    with patch("ledger_sync.core.time_filter.datetime") as mock_dt:
+        mock_dt.now.return_value = fake_now
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        result = TimeFilter.filter_by_range(txns, TimeRange.THIS_MONTH)
+
+    assert result == []  # Nov 2025 data, May 2026 "this month" -> empty.
+
+
+def test_in_memory_last_3_months_calendar_aligned() -> None:
+    """'Last 3 months' should snap to the first of (now - 2 months), not a
+    fixed 90-day window."""
+    fake_now = datetime(2026, 5, 15, tzinfo=UTC)
+    # Mar 2026, Apr 2026, May 2026 should be included
+    in_range = [
+        _make_tx(1, datetime(2026, 3, 1, tzinfo=UTC), 100, "mar"),
+        _make_tx(1, datetime(2026, 4, 15, tzinfo=UTC), 100, "apr"),
+        _make_tx(1, datetime(2026, 5, 10, tzinfo=UTC), 100, "may"),
+    ]
+    # Feb 28 should be excluded -- it's just before the calendar start
+    out_of_range = _make_tx(1, datetime(2026, 2, 28, tzinfo=UTC), 100, "feb")
+
+    txns = [*in_range, out_of_range]
+
+    with patch("ledger_sync.core.time_filter.datetime") as mock_dt:
+        mock_dt.now.return_value = fake_now
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        result = TimeFilter.filter_by_range(txns, TimeRange.LAST_3_MONTHS)
+
+    assert {t.transaction_id for t in result} == {"mar", "apr", "may"}
+
+
+def test_in_memory_empty_returns_empty() -> None:
+    assert TimeFilter.filter_by_range([], TimeRange.THIS_MONTH) == []
+
+
+# ─── api/analytics_helpers.py ───────────────────────────────────────────
+
+
+def test_db_this_month_anchors_on_now(db_session: Session, user: User) -> None:
+    """Even when latest tx was months ago, THIS_MONTH range starts at the
+    first of the current calendar month."""
+    db_session.add(_make_tx(user.id, datetime(2025, 11, 5, tzinfo=UTC), 100, "old"))
+    db_session.commit()
+
+    fake_now = datetime(2026, 5, 17, 10, 30, 0, tzinfo=UTC)
+    with patch("ledger_sync.api.analytics_helpers.datetime") as mock_dt:
+        mock_dt.now.return_value = fake_now
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        start, end = _get_time_range_dates(db_session, user, TimeRange.THIS_MONTH)
+
+    assert start == datetime(2026, 5, 1, tzinfo=UTC)
+    assert end is None  # open-ended (covers from start through "now")
+
+
+def test_db_last_3_months_calendar_aligned(db_session: Session, user: User) -> None:
+    db_session.add(_make_tx(user.id, datetime(2025, 11, 5, tzinfo=UTC), 100, "old"))
+    db_session.commit()
+
+    fake_now = datetime(2026, 5, 17, tzinfo=UTC)
+    with patch("ledger_sync.api.analytics_helpers.datetime") as mock_dt:
+        mock_dt.now.return_value = fake_now
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        start, end = _get_time_range_dates(db_session, user, TimeRange.LAST_3_MONTHS)
+
+    # 3 calendar months ending in May = Mar 1, Apr 1, May 1 -> start = Mar 1.
+    assert start == datetime(2026, 3, 1, tzinfo=UTC)
+    assert end is None
+
+
+def test_db_last_year_uses_now_year(db_session: Session, user: User) -> None:
+    """LAST_YEAR is (now.year - 1), regardless of latest transaction year."""
+    db_session.add(_make_tx(user.id, datetime(2023, 6, 1, tzinfo=UTC), 100, "old"))
+    db_session.commit()
+
+    fake_now = datetime(2026, 5, 17, tzinfo=UTC)
+    with patch("ledger_sync.api.analytics_helpers.datetime") as mock_dt:
+        mock_dt.now.return_value = fake_now
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        start, end = _get_time_range_dates(db_session, user, TimeRange.LAST_YEAR)
+
+    assert start == datetime(2025, 1, 1, tzinfo=UTC)
+    assert end == datetime(2025, 12, 31, 23, 59, 59, tzinfo=UTC)
+
+
+def test_db_no_transactions_returns_none(db_session: Session, user: User) -> None:
+    """User with no data still gets (None, None) so callers handle empty
+    state gracefully."""
+    start, end = _get_time_range_dates(db_session, user, TimeRange.THIS_MONTH)
+    assert start is None
+    assert end is None
+
+
+def test_db_all_time_returns_none(db_session: Session, user: User) -> None:
+    db_session.add(_make_tx(user.id, datetime(2025, 1, 1, tzinfo=UTC), 100, "any"))
+    db_session.commit()
+    start, end = _get_time_range_dates(db_session, user, TimeRange.ALL_TIME)
+    assert start is None
+    assert end is None


### PR DESCRIPTION
## Problem

Both backend time-range filters anchored on the user's most recent transaction date. Two issues:

1. **Stale-data drift**: User with data ending Nov 2025 clicks 'This Month' in May 2026 -> gets Nov 2025 transactions under a 'This Month' label. Labels lied to users with one-off uploads, demos, or paused tracking.

2. **Sliding-window quirk**: 'Last 3 months' subtracted a fixed 90/180/365 days from the last tx date, producing partial-month overlaps that don't align with monthly aggregations. Made comparison numbers weird and inconsistent.

## Fix

Anchor on `datetime.now(UTC)` everywhere. 'This Month' is the current calendar month. 'Last 3 Months' snaps to the first of (now - 2 months), giving 3 full calendar months that align with monthly breakdowns.

With truly stale data the chart will now legitimately be empty for ranges that exclude the user's data -- which is correct behaviour. Fixing the empty-state UX (banner suggesting 'All Time' or 'upload more data') is a separate, additive UI task.

## Files touched

- `backend/src/ledger_sync/api/analytics_helpers.py` -- `_get_time_range_dates` for the analytics API endpoints (TimeRange enum query param)
- `backend/src/ledger_sync/core/time_filter.py` -- `TimeFilter.filter_by_range` for in-memory list filtering (consumed elsewhere in the core analytics engine)

## Tests

8 new tests cover:
- 'This Month' returns empty when data is truly stale
- 'Last 3 months' is calendar-aligned and excludes the prior month's tail
- DB-level helper anchors on `now()` for THIS_MONTH / LAST_3_MONTHS / LAST_YEAR
- Empty-data case still returns `(None, None)` so callers don't crash
- `ALL_TIME` is unchanged

121 backend tests pass, ruff clean. No frontend changes.