### PR TITLE
fix(recurring): close gaps between frequency bands so float averages resolve

### DIFF
--- a/backend/src/ledger_sync/core/analytics/recurring.py
+++ b/backend/src/ledger_sync/core/analytics/recurring.py
@@ -32,20 +32,26 @@ from ledger_sync.db.models import (
 class RecurringMixin(AnalyticsEngineBase):
     """Mixin: recurring-pattern detection and persistence."""
 
-    # Frequency bands: (min_days, max_days, frequency, confidence_penalty_per_std).
-    # Bands are contiguous (end-of-one = start-of-next - 1) so that a series
-    # with mean gap of e.g. 19 or 78 days still resolves to a frequency
-    # instead of falling into a dead zone. Penalty scales with expected
-    # cadence -- wider cycles tolerate more jitter.
-    _FREQ_BANDS: list[tuple[float, float, RecurrenceFrequency, float]] = [
-        (4, 10, RecurrenceFrequency.WEEKLY, 8),
-        (11, 19, RecurrenceFrequency.BIWEEKLY, 5),
-        (20, 49, RecurrenceFrequency.MONTHLY, 3),
-        (50, 79, RecurrenceFrequency.BIMONTHLY, 2.5),
-        (80, 129, RecurrenceFrequency.QUARTERLY, 2),
-        (130, 269, RecurrenceFrequency.SEMIANNUAL, 1.5),
-        (270, 400, RecurrenceFrequency.YEARLY, 1),
+    # Frequency bands: (min_days, frequency, confidence_penalty_per_std).
+    # Each band starts at min_days and runs up to (but not including) the
+    # next band's min_days, so float averages between integer thresholds
+    # (e.g. avg_diff = 10.5) resolve cleanly instead of falling through
+    # the gap. The final band has an effective upper bound of 400 days
+    # enforced below. Penalty scales with expected cadence -- wider
+    # cycles tolerate more jitter.
+    _FREQ_BANDS: list[tuple[float, RecurrenceFrequency, float]] = [
+        (4, RecurrenceFrequency.WEEKLY, 8),
+        (11, RecurrenceFrequency.BIWEEKLY, 5),
+        (20, RecurrenceFrequency.MONTHLY, 3),
+        (50, RecurrenceFrequency.BIMONTHLY, 2.5),
+        (80, RecurrenceFrequency.QUARTERLY, 2),
+        (130, RecurrenceFrequency.SEMIANNUAL, 1.5),
+        (270, RecurrenceFrequency.YEARLY, 1),
     ]
+    # Cadences longer than this are out of scope for personal finance
+    # recurring detection (annual upper bound = 400 days to allow some
+    # leap-year / late-by-a-week tolerance).
+    _FREQ_MAX_DAYS: float = 400
 
     def _load_confirmed_recurring(self) -> dict[str, RecurringTransaction]:
         """Load user-confirmed recurring patterns keyed by lowercase name."""
@@ -173,11 +179,20 @@ class RecurringMixin(AnalyticsEngineBase):
         confidence: float = 0
         expected_day = None
 
-        for lo, hi, freq, penalty in self._FREQ_BANDS:
-            if lo <= avg_diff <= hi:
-                frequency = freq
-                confidence = max(0, 100 - std_diff * penalty)
-                break
+        # Walk bands in order; each band runs from its min_days up to (but
+        # not including) the next band's min_days. The final band caps at
+        # ``_FREQ_MAX_DAYS`` so absurdly long cadences don't get a label.
+        if avg_diff < self._FREQ_MAX_DAYS:
+            for i, (lo, freq, penalty) in enumerate(self._FREQ_BANDS):
+                next_lo = (
+                    self._FREQ_BANDS[i + 1][0]
+                    if i + 1 < len(self._FREQ_BANDS)
+                    else self._FREQ_MAX_DAYS
+                )
+                if lo <= avg_diff < next_lo:
+                    frequency = freq
+                    confidence = max(0, 100 - std_diff * penalty)
+                    break
 
         # Calculate expected day of month for monthly-ish frequencies
         if frequency in (

--- a/backend/tests/unit/test_recurring_frequency_bands.py
+++ b/backend/tests/unit/test_recurring_frequency_bands.py
@@ -1,0 +1,138 @@
+"""Recurring detection -- frequency-band gap regression tests.
+
+The original ``_FREQ_BANDS`` had closed-closed integer intervals
+``[(4, 10), (11, 19), (20, 49), ...]`` checked with ``lo <= avg_diff <= hi``.
+Because ``avg_diff`` is a float (mean of integer day-gaps), values like
+10.5, 19.5, 49.5 fell through every band and the engine returned
+``frequency = None``, silently dropping legitimate recurring patterns.
+
+These tests pin the new behaviour: half-integer averages resolve to a
+sensible adjacent frequency.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from ledger_sync.core.analytics_engine import AnalyticsEngine
+from ledger_sync.db.base import Base
+from ledger_sync.db.models import RecurrenceFrequency
+
+
+def _engine() -> AnalyticsEngine:
+    """Build an AnalyticsEngine wired to an in-memory SQLite session.
+
+    The engine itself doesn't touch the DB for ``_detect_frequency``,
+    but the constructor wants a session.
+    """
+    sql_engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(sql_engine)
+    session_local = sessionmaker(bind=sql_engine)
+    return AnalyticsEngine(session_local(), user_id=1)
+
+
+def _dates_with_gaps(start: datetime, gaps: list[int]) -> list[datetime]:
+    """Build a date sequence from ``start`` using ``gaps`` (in days).
+
+    e.g. ``_dates_with_gaps(d, [7, 14])`` -> [d, d+7, d+21].
+    """
+    from datetime import timedelta
+
+    out = [start]
+    for gap in gaps:
+        out.append(out[-1] + timedelta(days=gap))
+    return out
+
+
+# ─── Old-bug reproduction cases (should now resolve to a frequency) ─────
+
+
+def test_avg_gap_10_5_resolves_to_weekly() -> None:
+    """7 + 14 -> avg 10.5. Previously: None. Now: WEEKLY."""
+    eng = _engine()
+    dates = _dates_with_gaps(datetime(2026, 1, 1, tzinfo=UTC), [7, 14])
+    freq, conf, _ = eng._detect_frequency(dates)
+    assert freq == RecurrenceFrequency.WEEKLY
+    assert conf > 0
+
+
+def test_avg_gap_19_5_resolves_to_biweekly() -> None:
+    """19 + 20 -> avg 19.5. Previously: None. Now: BIWEEKLY."""
+    eng = _engine()
+    dates = _dates_with_gaps(datetime(2026, 1, 1, tzinfo=UTC), [19, 20])
+    freq, _, _ = eng._detect_frequency(dates)
+    assert freq == RecurrenceFrequency.BIWEEKLY
+
+
+def test_avg_gap_49_5_resolves_to_monthly() -> None:
+    """Monthly bills with one delayed payment: 30 + 31 + 49 -> avg 36.7,
+    fine. But 49 + 50 -> avg 49.5 used to fall through. Now: MONTHLY."""
+    eng = _engine()
+    dates = _dates_with_gaps(datetime(2026, 1, 1, tzinfo=UTC), [49, 50])
+    freq, _, _ = eng._detect_frequency(dates)
+    assert freq == RecurrenceFrequency.MONTHLY
+
+
+def test_avg_gap_79_5_resolves_to_bimonthly() -> None:
+    eng = _engine()
+    dates = _dates_with_gaps(datetime(2026, 1, 1, tzinfo=UTC), [79, 80])
+    freq, _, _ = eng._detect_frequency(dates)
+    assert freq == RecurrenceFrequency.BIMONTHLY
+
+
+def test_avg_gap_129_5_resolves_to_quarterly() -> None:
+    eng = _engine()
+    dates = _dates_with_gaps(datetime(2026, 1, 1, tzinfo=UTC), [129, 130])
+    freq, _, _ = eng._detect_frequency(dates)
+    assert freq == RecurrenceFrequency.QUARTERLY
+
+
+def test_avg_gap_269_5_resolves_to_semiannual() -> None:
+    eng = _engine()
+    dates = _dates_with_gaps(datetime(2026, 1, 1, tzinfo=UTC), [269, 270])
+    freq, _, _ = eng._detect_frequency(dates)
+    assert freq == RecurrenceFrequency.SEMIANNUAL
+
+
+# ─── Sanity: classic cadences still resolve correctly ───────────────────
+
+
+def test_weekly_classic_7_day_cadence() -> None:
+    eng = _engine()
+    dates = _dates_with_gaps(datetime(2026, 1, 1, tzinfo=UTC), [7, 7, 7])
+    freq, conf, _ = eng._detect_frequency(dates)
+    assert freq == RecurrenceFrequency.WEEKLY
+    assert conf == 100  # zero std -> max confidence
+
+
+def test_monthly_classic_30_day_cadence() -> None:
+    eng = _engine()
+    dates = _dates_with_gaps(datetime(2026, 1, 1, tzinfo=UTC), [30, 30, 30])
+    freq, _, _ = eng._detect_frequency(dates)
+    assert freq == RecurrenceFrequency.MONTHLY
+
+
+def test_yearly_classic_365_day_cadence() -> None:
+    eng = _engine()
+    dates = _dates_with_gaps(datetime(2026, 1, 1, tzinfo=UTC), [365, 365, 365])
+    freq, _, _ = eng._detect_frequency(dates)
+    assert freq == RecurrenceFrequency.YEARLY
+
+
+def test_below_minimum_returns_none() -> None:
+    """Sub-weekly gaps (avg < 4) still return None -- not a tracked cadence."""
+    eng = _engine()
+    dates = _dates_with_gaps(datetime(2026, 1, 1, tzinfo=UTC), [1, 2, 1])
+    freq, _, _ = eng._detect_frequency(dates)
+    assert freq is None
+
+
+def test_above_yearly_returns_none() -> None:
+    """Gaps > 400 days are out of scope (not expected for personal finance)."""
+    eng = _engine()
+    dates = _dates_with_gaps(datetime(2026, 1, 1, tzinfo=UTC), [500, 500])
+    freq, _, _ = eng._detect_frequency(dates)
+    assert freq is None


### PR DESCRIPTION
## Bug confirmed

Wrote a failing test before fixing -- `avg_diff = 10.5` (e.g. salary every 7 days + monthly top-up landing some weeks) returned `frequency = None` instead of WEEKLY. The original `_FREQ_BANDS` used closed-closed integer intervals `[(4, 10), (11, 19), (20, 49), ...]` checked with `lo <= avg_diff <= hi`. Because `avg_diff` is a float (mean of integer day-gaps), half-integer values landed in the gap between bands.

Values that fell through every band (legitimate recurring patterns silently dropped):
- 10.5 (between WEEKLY and BIWEEKLY)
- 19.5 (between BIWEEKLY and MONTHLY)
- 49.5 (between MONTHLY and BIMONTHLY)
- 79.5 (between BIMONTHLY and QUARTERLY)
- 129.5 (between QUARTERLY and SEMIANNUAL)
- 269.5 (between SEMIANNUAL and YEARLY)

## Fix

Redefine bands as half-open intervals starting at `min_days`, ending at the next band's `min_days`. Bands now actually tile the real number line. The final band caps at `_FREQ_MAX_DAYS = 400` so absurdly long cadences still don't get a label.

10.5 now resolves to WEEKLY (the lower-adjacent band, since `10.5 < 11`). All previously-broken half-integer cases now resolve to the band starting at the next-lower integer.

## Tests

11 new unit tests in `test_recurring_frequency_bands.py`:
- 6 previously-broken half-integer cases (now resolve correctly)
- 3 classic cadences (7, 30, 365 days) still resolve identically
- below-minimum (avg<4) and above-maximum (avg>400) still return None

124 backend tests pass total. Ruff clean. No frontend changes.