### PR TITLE
fix(calculations): audit batch -- net-worth opening balance, now-anchored time ranges, recurring band gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-## Unreleased
+## 2.14.0 - 2026-05-17
 
-Calculation correctness audit batch -- three backend fixes uncovered while reviewing every aggregation path for inconsistencies. No frontend changes; no API contract breaks.
+Calculation correctness audit batch -- three backend bugs caught while reviewing every aggregation path. No frontend changes; no API contract breaks.
 
 ### Fixed
 
@@ -18,7 +18,122 @@ Calculation correctness audit batch -- three backend fixes uncovered while revie
 
 ### Tests
 
-- 22 new backend tests across the three fixes (3 + 8 + 11). Backend total 116 -> 135.
+- Backend 116 -> 135 (+22 across the three fixes: 3 for daily-net-worth opening balance, 8 for time-range now-anchor, 11 for recurring band gaps).
+
+### Documentation
+
+- ``docs/CALCULATIONS.md`` recurring-detection algorithm section updated to match the actual current implementation: 7 half-open frequency bands (was a stale 6-band closed-interval description from a much older version), correct confidence formula (``max(0, 100 - std*penalty)`` with per-band penalties), note on why bands are half-open.
+
+---
+
+## 2.13.0 - 2026-05-17
+
+UX consolidation pass (#160). Theme: make every "high-level component" interactive in a way that flows the user through the app -- donut click navigates with a category param, destination page filters end-to-end, treemap auto-drills, subcategory analysis preselects the right category. 14 commits.
+
+### Fixed
+
+- **Dashboard donut click routed to non-existent paths.** Click-to-navigate on income/expense donuts used hardcoded strings instead of ``ROUTES`` constants. Routes 404-ed silently when the canonical route changed. Now uses ``ROUTES.INCOME_ANALYSIS`` / ``ROUTES.SPENDING_ANALYSIS``.
+- **Donut center text was clipping behind the inner ring.** Long currency strings (``Rs 57,27,353``) overflowed past ``innerRadius``. Switched to ``formatCurrencyShort`` and added an adaptive font size that shrinks for longer strings (22px -> 13px across 6-12 chars). Visual polish: ``innerRadius 60%``, ``outerRadius 85%``, ``paddingAngle 3``, ``cornerRadius 4``.
+- **Donut whole-Pie click selected every slice at once.** ``onClick`` was attached to the ``<Pie>`` element and the cursor was ``pointer`` everywhere including the gaps between slices. Each ``<Cell>`` now owns its own ``onClick`` / ``onMouseEnter`` / ``onMouseLeave``. Hover state: active slice brightens 18%, others fade to 40% opacity. Cursor is ``default`` over gaps.
+
+### Added
+
+- **Click-through journey on the dashboard donuts.** Clicking a slice (e.g. "Food & Dining" on the Expense donut) navigates to ``/spending?category=Food%20%26%20Dining``. The destination page reads the URL parameter and applies the filter end-to-end:
+  - New ``FilterBanner`` component appears at the top with a "Clear" button
+  - MetricCards (Total Spending, Monthly Avg, Top Category, Categories) reflect only the filtered category
+  - Pareto Analysis bars + cumulative line filtered
+  - Top Merchants section narrowed to merchants in that category
+  - Expense Breakdown (treemap) auto-expands to show subcategories of the filtered category
+  - Subcategory Deep-Dive opens with the filtered category preselected
+  - Same flow on Income Analysis side (``?category=Salary`` etc.)
+- **MetricCard becomes opt-in clickable.** New ``href`` and ``onClick`` props turn the card into a ``Link`` or ``button`` with a subtle ``y:-2`` hover lift, stronger border, and a top-right ``ArrowUpRight`` indicator that fades in on hover. Default behavior unchanged when neither prop is set, so all 37 existing callsites are zero-regression.
+- **Pareto Analysis chart on Spending Analysis.** Bars sorted by category total, cumulative-percentage line overlaid, 80% reference line marking the Pareto threshold. Helps users see the typical "20% of categories cause 80% of spending" pattern at a glance.
+- **Brush slider on more charts.** Drag-to-zoom across the timeline. New shared ``BRUSH_DEFAULTS`` (height 32, traveller width 10, app-blue stroke) used by Net Worth Trend, Investment Analytics Growth Over Time, and Returns Analysis Monthly P&L combo. Default window is the most-recent third so the chart reads at full fidelity on first paint.
+- **Spending Patterns insight strip.** Below the Cohort Spending bar chart on Spending Analysis. Two pills: "Peak Day/Date/Month" (shows the bucket name + percent above average) and "Quietest". Removes the need to hover to find the takeaway.
+- **Day of Week chart on Year in Review goes radar.** Replaces the flat side-by-side bar chart. Spending and earning overlay each other on a 7-spoke polar grid so weekend-vs-weekday patterns pop visually. Two insight pills below: biggest spending day (with amount) and weekend-vs-weekday delta percent.
+- **Year in Review Monthly Breakdown gains a Net cash-flow line.** ``BarChart`` -> ``ComposedChart`` with a dashed blue line overlaying the Spending and Earning bars. Saving months show as peaks; overspending months as troughs. Subtitle clarifies what the chart shows.
+- **Auto-granularity on time-series category charts.** ``MultiCategoryTimeAnalysis`` and ``EnhancedSubcategoryAnalysis`` were always daily granularity, which is unreadable past ~3 months. Now auto-buckets day -> week -> month based on the actual data span (90-day, 2-year thresholds). New Auto/Daily/Weekly/Monthly selector lets users override. Header shows the active bucket. Shared helpers (``bucketDate``, ``formatBucketLabel``, ``pickGranularity``) live in ``lib/chartPeriodUtils.ts``.
+
+### Changed
+
+- **Comparison Spending Distribution butterfly chart polish.** Capacity 10 -> 15 categories. Inline value labels on both ends (left for periodA, right for periodB) so users see amounts without hovering. Winner-side opacity boost: the bigger-spend side of each row gets full opacity (0.95), the loser dims to 45% so the eye lands on the larger spender.
+- **Holdings Map (Returns Analysis) replaced with horizontal bar chart.** The 2D scatter (transactions vs current value) had weak insight; ranked horizontal bars make winners obvious. Top 12 with overflow footer; top-holding callout in the subtitle.
+- **Asset Allocation chart (Investment Analytics) migrated to ``StandardPieChart``.** Gains the same per-slice hover dimming and centre-value polish as the dashboard donuts. Centre shows total invested; header shows asset-class count.
+
+### Removed
+
+- **Monthly Net Worth Change waterfall chart on /net-worth.** Added clutter without unique insight -- the Net Worth Trend chart immediately above already shows month-over-month direction. The chart, the unused ``monthlyChanges`` memo, and ``MonthlyChangesChart.tsx`` are gone.
+
+### Refactored
+
+- **Two ``SummaryCard`` duplicates merged into ``shared/SummaryCard``.** ``bill-calendar/components/SummaryCard.tsx`` and ``subscription-tracker/components/SummaryCard.tsx`` were 95% identical. Single shared component now consumed by both pages.
+- **``CategorySparkline`` merged into ``Sparkline`` as a compact variant.** ``CategorySparkline.tsx`` was a thin wrapper that dropped axes and added compact dimensions. Now a ``compact`` prop on the canonical ``Sparkline`` component.
+
+### Tests
+
+- Frontend: 177 vitest tests pass throughout (no regressions).
+
+---
+
+## 2.12.0 - 2026-05-17
+
+Audit batch 2 (#159). Ten small UX/a11y/perf fixes consolidated into one PR.
+
+### Added
+
+- **Dashed reference lines for upcoming Net Worth milestones.** 1L, 5L, 10L, 25L, 50L, 1Cr etc. drawn below the Net Worth trend so users see "I'll cross 1Cr around month X" at a glance. Recharts auto-clips outside the y-axis range so all milestones can be rendered without filtering.
+- **Upload CTA on empty states.** Comparison page and Dashboard page empty states now have a clear "Upload Data" action (``EmptyState`` already supported ``actionLabel``/``actionHref``; two visible callsites just hadn't wired them).
+- **12-month trend sparkline per row in CategoryBreakdown.** Pure SVG, no chart-lib overhead. Each category row shows its 12-month trajectory inline.
+- **Drag-to-zoom Brush below Net Worth chart.** Pre-zoomed to the most-recent third of data on first render. ``StandardAreaChart`` gains an opt-in ``showBrush`` prop for future migrations.
+- **Holdings scatter on Returns Analysis.** Activity vs value plot. Pragmatic scope; rigorous CAGR scatter deferred. (Note: subsequently replaced by horizontal bar chart in 2.13.0 -- the scatter axis was confusing in practice.)
+- **``LazySection`` wrapper using IntersectionObserver.** Forward-looking helper for below-the-fold lazy mounting. Deferred consumers will land in future PRs.
+- **``ChartContainer`` ``ariaLabel`` prop.** Wraps in ``role='img'`` so screen readers get a single descriptive summary instead of walking every SVG path. Improves a11y for analytics pages dramatically.
+- **``StaleDataBadge`` component + first consumer in ``InstrumentProjections``.** Tiny amber pill that lights up when a hook lands on compiled-in fallback data (e.g. ``/api/rates/instruments`` is unreachable and the EPF rate comes from the bundled JSON). Users now know when they're seeing fallback values.
+
+### Changed
+
+- **Comparison page: stacked bars collapsed into overlaid bars.** Two-bars-per-metric -> one overlaid bar (faded ghost layer for period A, solid layer for B on top). Reads at a glance instead of forcing the eye to compare two adjacent rectangles.
+
+### Infrastructure
+
+- **GitHub Actions cron** pinging ``/health`` every 30 minutes to keep the Neon free-tier branch unarchived. Eliminates the 20s cold-start the first user of the day was hitting.
+
+---
+
+## 2.11.0 - 2026-05-16
+
+Cleanup + refactor sweep across the codebase. Twelve focused PRs landed in one day.
+
+### Fixed
+
+- **``excluded_accounts`` preference now applied consistently.** Three transaction-query code paths (analytics, calculations, ai_tools) were missing the ``excluded_accounts`` filter so a hidden account could leak into Sankey flows, monthly aggregates, and AI tool responses. Centralized via a shared ``apply_excluded_accounts`` helper on ``build_transaction_query``.
+
+### Added
+
+- **Net Worth projection: 1-stddev confidence band** (#149). Replaced the single dashed projection line (which gave a false impression of certainty) with a band that widens as ``sqrt(time)`` under a geometric Brownian motion model. New ``computeMonthlyGrowthStats`` returns ``{rate, logSigma}`` based on log-return variance over a configurable lookback. New ``projectNetWorthCompoundBand`` paints the band as a Recharts ``<Area>`` with ``[lower, upper]`` tuple values (Recharts paints range areas natively when given a tuple). Median dashed line still renders on top. 7 new unit tests for the math.
+
+### Changed
+
+- **Frontend file-size discipline: every file under 500 LOC** (#141). Big ones split into focused modules. No behaviour change; just easier code review and faster IDE navigation.
+- **``SEMANTIC_COLORS`` is canonical for income/expense/savings** (#146). All previously-hardcoded green/red/blue references in analytics components route through the design tokens.
+- **Status semantic palette wired as Tailwind tokens** (#147). ``bg-app-green``, ``text-app-red``, etc. resolved via the design tokens instead of arbitrary hex strings.
+- **Expense category colors centralized** (#145). ``EXPENSE_CATEGORY_COLORS`` is the single source; consumed by treemaps, donuts, and bar charts.
+- **KPI typography standardized** (#148). MetricCard, KpiCard, StatCard, and SummaryCard all use the same type-scale tokens for value, label, and subtitle.
+
+### Removed
+
+- **In-memory token blacklist** (#139). Was a no-op on Vercel multi-worker deploys (each worker has its own dict, so a "logged-out" token is still valid on every other worker). Logout now just relies on the frontend dropping the token. Real token revocation needs a shared store (Redis) and is a future-PR if SSO ever requires it.
+
+### Documentation
+
+- **README overhaul + version sync** (#142). README badges, examples, and architecture sections reorganized; versions synced to the prevailing 2.10.0 across CHANGELOG, package.json, and pyproject.toml.
+- **Post-2.10.0 cleanup pass** (#144). Doc drift fixes uncovered while reading the 2.10.0 audit notes.
+
+### Internal / tooling (no user impact)
+
+- ``indian-finance-expert`` skill converted to CSV-backed lookups (#143).
+- 8 project-level Claude skills + ``.claude`` config committed (#137).
+- Codebase-atlas skills + task-skills consolidation (#139, mixed with the token-blacklist removal).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## Unreleased
+
+Calculation correctness audit batch -- three backend fixes uncovered while reviewing every aggregation path for inconsistencies. No frontend changes; no API contract breaks.
+
+### Fixed
+
+- **Net Worth API: cumulative series now seeded with pre-window opening balance.** ``GET /api/calculations/daily-net-worth?start_date=...`` previously reset the cumulative ``net_worth`` series to 0 on day one of the window, ignoring all transactions before ``start_date``. A user filtering "Last 6 months" saw their chart begin at zero instead of their actual cumulative cashflow at that point. When ``start_date`` is set we now compute ``opening_balance = SUM(income) - SUM(expense)`` for transactions strictly before it and seed the cumulative series with that value. Transfers excluded (matches existing model). The response also includes ``opening_balance`` so frontends can render a starting-balance annotation.
+- **Time-range filters now anchor on ``now()``, not the user's most recent transaction.** ``THIS_MONTH``, ``LAST_3_MONTHS``, etc. used to anchor on the latest transaction date so a user with stale data saw old months under "This Month" labels. Anchored on ``datetime.now(UTC)`` now: "This Month" = current calendar month, "Last 3 Months" = first day of (now - 2 months) through now (calendar-aligned, no partial-month tails). Stale data legitimately yields empty filtered results -- correct behaviour. Two parallel implementations both fixed: ``api/analytics_helpers._get_time_range_dates`` (DB query) and ``core/time_filter.TimeFilter`` (in-memory list).
+- **Recurring detection: closed gaps between frequency bands.** The 2.10.0 release made ``_FREQ_BANDS`` "contiguous" via integer endpoints ``[(4, 10), (11, 19), (20, 49), ...]`` checked with ``lo <= avg_diff <= hi``. But ``avg_diff`` is a float (mean of integer day-gaps), so half-integer values 10.5, 19.5, 49.5, 79.5, 129.5, 269.5 fell through every band -> ``frequency = None`` -> recurring patterns silently dropped. Real-world example: a salary every 7 days plus a monthly top-up landing some weeks averaged 10.5 days. Bands now redefined as half-open ``[lo, next_lo)`` so they actually tile the real number line. ``_FREQ_MAX_DAYS = 400`` keeps the upper bound on yearly cadence.
+
+### Tests
+
+- 22 new backend tests across the three fixes (3 + 8 + 11). Backend total 116 -> 135.
+
+---
+
 ## 2.10.0 - 2026-05-13
 
 Hardcoded-values audit. Fixes silently-wrong defaults, reduces classifier brittleness, and centralizes policy constants that were scattered across the codebase. Two full rescan passes; every finding either fixed, deliberately skipped with reason, or tracked for a follow-up PR that needs a schema migration.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ledger-sync"
-version = "2.10.0"
+version = "2.14.0"
 description = "Personal finance dashboard backend -- Excel import, financial analytics, multi-currency exchange rates"
 authors = [{ name = "Sagar Gupta" }]
 readme = "README.md"

--- a/backend/src/ledger_sync/api/analytics_helpers.py
+++ b/backend/src/ledger_sync/api/analytics_helpers.py
@@ -38,46 +38,69 @@ def _get_time_range_dates(
     user: User,
     time_range: TimeRange,
 ) -> tuple[datetime | None, datetime | None]:
-    """Calculate start/end dates from a TimeRange enum using the DB-level max date.
+    """Calculate start/end dates from a TimeRange enum, anchored on ``now()``.
 
-    Returns (start_date, end_date) or (None, None) for ALL_TIME.
+    "This month", "Last 3 months", etc. are computed relative to the current
+    UTC time, not the user's most recent transaction. This keeps labels
+    honest -- "This Month" always means the current calendar month, even if
+    the user hasn't uploaded data in a while (in which case the chart will
+    legitimately be empty for that range).
+
+    Sliding windows like "Last 3 months" use calendar-aligned month math
+    (subtract N calendar months, snap to the first of the resulting month)
+    rather than fixed 90-day windows, so partial-month overlaps don't show
+    up in monthly breakdowns.
+
+    Returns (start_date, end_date) or (None, None) for ALL_TIME and for the
+    case when the user has no transactions at all (the latter signals "fall
+    through to no filter" so callers don't crash on empty data).
     """
     if time_range == TimeRange.ALL_TIME:
         return None, None
 
-    latest = (
-        db.query(Transaction.date)
+    # We still bail out early when the user has no data so the empty-state
+    # paths upstream (which check ``if not transactions``) don't try to
+    # query a range against an empty table.
+    has_any = (
+        db.query(Transaction.transaction_id)
         .filter(Transaction.user_id == user.id, Transaction.is_deleted.is_(False))
-        .order_by(Transaction.date.desc())
         .first()
     )
-    if not latest:
+    if not has_any:
         return None, None
 
-    latest_date = latest[0]
-    end_date = None
+    now = datetime.now(UTC)
+    end_date: datetime | None = None
 
     if time_range == TimeRange.THIS_MONTH:
-        start_date = latest_date.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        start_date = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
     elif time_range == TimeRange.LAST_MONTH:
-        first_of_month = latest_date.replace(day=1)
-        last_month_end = first_of_month - timedelta(days=1)
+        first_of_month = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        last_month_end = first_of_month - timedelta(microseconds=1)
         start_date = last_month_end.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
         end_date = last_month_end
     elif time_range == TimeRange.LAST_3_MONTHS:
-        start_date = _subtract_months(latest_date, 3)
+        start_date = _subtract_months(
+            now.replace(day=1, hour=0, minute=0, second=0, microsecond=0), 2
+        )
     elif time_range == TimeRange.LAST_6_MONTHS:
-        start_date = _subtract_months(latest_date, 6)
+        start_date = _subtract_months(
+            now.replace(day=1, hour=0, minute=0, second=0, microsecond=0), 5
+        )
     elif time_range == TimeRange.LAST_12_MONTHS:
-        start_date = _subtract_months(latest_date, 12)
+        start_date = _subtract_months(
+            now.replace(day=1, hour=0, minute=0, second=0, microsecond=0), 11
+        )
     elif time_range == TimeRange.THIS_YEAR:
-        start_date = latest_date.replace(month=1, day=1, hour=0, minute=0, second=0, microsecond=0)
+        start_date = now.replace(month=1, day=1, hour=0, minute=0, second=0, microsecond=0)
     elif time_range == TimeRange.LAST_YEAR:
-        year = latest_date.year - 1
+        year = now.year - 1
         start_date = datetime(year, 1, 1, tzinfo=UTC)
         end_date = datetime(year, 12, 31, 23, 59, 59, tzinfo=UTC)
     elif time_range == TimeRange.LAST_DECADE:
-        start_date = _subtract_months(latest_date, 120)
+        start_date = _subtract_months(
+            now.replace(day=1, hour=0, minute=0, second=0, microsecond=0), 119
+        )
     else:
         return None, None
 

--- a/backend/src/ledger_sync/api/calculations.py
+++ b/backend/src/ledger_sync/api/calculations.py
@@ -401,7 +401,35 @@ def get_daily_net_worth(
     start_date: OptionalStartDate = None,
     end_date: OptionalEndDate = None,
 ) -> dict[str, Any]:
-    """Calculate daily income and expense data for net worth trends."""
+    """Calculate daily income and expense data for net worth trends.
+
+    The cumulative ``net_worth`` series is seeded with the user's
+    pre-window opening balance (``SUM(income) - SUM(expense)`` for
+    transactions strictly before ``start_date``) so a date-filtered
+    chart doesn't reset to zero on day one of the window. With no
+    ``start_date`` the opening balance is zero and the series starts
+    from the first transaction as before.
+
+    Transfers are deliberately excluded from the cashflow model here so
+    movements between user-owned accounts (e.g. SIPs, EMI prepayments)
+    don't double-count or vanish.
+    """
+    # Opening balance = cashflow before the window start. Computed only
+    # when a start_date is supplied; otherwise it's zero and the series
+    # behaves identically to the pre-fix implementation.
+    opening_balance = 0.0
+    if start_date is not None:
+        opening_base = (
+            build_transaction_query(db, current_user, start_date=None, end_date=None)
+            .filter(Transaction.date < start_date)
+            .subquery()
+        )
+        opening_row = db.query(
+            income_sum_col(opening_base, label="income"),
+            expense_sum_col(opening_base, label="expense"),
+        ).one()
+        opening_balance = float(opening_row.income) - float(opening_row.expense)
+
     base = build_transaction_query(db, current_user, start_date, end_date).subquery()
     date_col = fmt_date(base.c.date).label("date_key")
 
@@ -417,7 +445,7 @@ def get_daily_net_worth(
     )
 
     daily_data: dict[str, dict[str, float]] = {}
-    cumulative_net_worth = 0.0
+    cumulative_net_worth = opening_balance
     cumulative_data = []
 
     for row in rows:
@@ -441,6 +469,9 @@ def get_daily_net_worth(
     return {
         "daily_data": daily_data,
         "cumulative_data": cumulative_data,
+        # Surfaced so frontends can render a "starting balance" annotation
+        # or use it to align the chart's y-axis.
+        "opening_balance": opening_balance,
     }
 
 

--- a/backend/src/ledger_sync/core/analytics/recurring.py
+++ b/backend/src/ledger_sync/core/analytics/recurring.py
@@ -32,20 +32,26 @@ from ledger_sync.db.models import (
 class RecurringMixin(AnalyticsEngineBase):
     """Mixin: recurring-pattern detection and persistence."""
 
-    # Frequency bands: (min_days, max_days, frequency, confidence_penalty_per_std).
-    # Bands are contiguous (end-of-one = start-of-next - 1) so that a series
-    # with mean gap of e.g. 19 or 78 days still resolves to a frequency
-    # instead of falling into a dead zone. Penalty scales with expected
-    # cadence -- wider cycles tolerate more jitter.
-    _FREQ_BANDS: list[tuple[float, float, RecurrenceFrequency, float]] = [
-        (4, 10, RecurrenceFrequency.WEEKLY, 8),
-        (11, 19, RecurrenceFrequency.BIWEEKLY, 5),
-        (20, 49, RecurrenceFrequency.MONTHLY, 3),
-        (50, 79, RecurrenceFrequency.BIMONTHLY, 2.5),
-        (80, 129, RecurrenceFrequency.QUARTERLY, 2),
-        (130, 269, RecurrenceFrequency.SEMIANNUAL, 1.5),
-        (270, 400, RecurrenceFrequency.YEARLY, 1),
+    # Frequency bands: (min_days, frequency, confidence_penalty_per_std).
+    # Each band starts at min_days and runs up to (but not including) the
+    # next band's min_days, so float averages between integer thresholds
+    # (e.g. avg_diff = 10.5) resolve cleanly instead of falling through
+    # the gap. The final band has an effective upper bound of 400 days
+    # enforced below. Penalty scales with expected cadence -- wider
+    # cycles tolerate more jitter.
+    _FREQ_BANDS: list[tuple[float, RecurrenceFrequency, float]] = [
+        (4, RecurrenceFrequency.WEEKLY, 8),
+        (11, RecurrenceFrequency.BIWEEKLY, 5),
+        (20, RecurrenceFrequency.MONTHLY, 3),
+        (50, RecurrenceFrequency.BIMONTHLY, 2.5),
+        (80, RecurrenceFrequency.QUARTERLY, 2),
+        (130, RecurrenceFrequency.SEMIANNUAL, 1.5),
+        (270, RecurrenceFrequency.YEARLY, 1),
     ]
+    # Cadences longer than this are out of scope for personal finance
+    # recurring detection (annual upper bound = 400 days to allow some
+    # leap-year / late-by-a-week tolerance).
+    _FREQ_MAX_DAYS: float = 400
 
     def _load_confirmed_recurring(self) -> dict[str, RecurringTransaction]:
         """Load user-confirmed recurring patterns keyed by lowercase name."""
@@ -173,11 +179,20 @@ class RecurringMixin(AnalyticsEngineBase):
         confidence: float = 0
         expected_day = None
 
-        for lo, hi, freq, penalty in self._FREQ_BANDS:
-            if lo <= avg_diff <= hi:
-                frequency = freq
-                confidence = max(0, 100 - std_diff * penalty)
-                break
+        # Walk bands in order; each band runs from its min_days up to (but
+        # not including) the next band's min_days. The final band caps at
+        # ``_FREQ_MAX_DAYS`` so absurdly long cadences don't get a label.
+        if avg_diff < self._FREQ_MAX_DAYS:
+            for i, (lo, freq, penalty) in enumerate(self._FREQ_BANDS):
+                next_lo = (
+                    self._FREQ_BANDS[i + 1][0]
+                    if i + 1 < len(self._FREQ_BANDS)
+                    else self._FREQ_MAX_DAYS
+                )
+                if lo <= avg_diff < next_lo:
+                    frequency = freq
+                    confidence = max(0, 100 - std_diff * penalty)
+                    break
 
         # Calculate expected day of month for monthly-ish frequencies
         if frequency in (

--- a/backend/src/ledger_sync/core/time_filter.py
+++ b/backend/src/ledger_sync/core/time_filter.py
@@ -1,9 +1,20 @@
 """Time filtering utilities for transaction data."""
 
+import calendar
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 
 from ledger_sync.db.models import Transaction
+
+
+def _subtract_months(dt: datetime, months: int) -> datetime:
+    """Subtract N calendar months from a datetime, clamping to a valid day."""
+    month = dt.month - months
+    year = dt.year + (month - 1) // 12
+    month = (month - 1) % 12 + 1
+    max_day = calendar.monthrange(year, month)[1]
+    day = min(dt.day, max_day)
+    return dt.replace(year=year, month=month, day=day)
 
 
 class TimeRange(StrEnum):
@@ -28,15 +39,13 @@ class TimeFilter:
         transactions: list[Transaction],
         time_range: TimeRange,
     ) -> list[Transaction]:
-        """Filter transactions by time range.
+        """Filter transactions by time range, anchored on ``now()``.
 
-        Args:
-            transactions: List of transactions to filter
-            time_range: Time range to filter by
-
-        Returns:
-            Filtered list of transactions
-
+        "This month", "Last 3 months", etc. are computed relative to the
+        current UTC time, not the user's most recent transaction. This
+        keeps semantics consistent with the analytics API and means stale
+        data legitimately yields empty filtered results instead of silently
+        showing months-old data under "This Month" labels.
         """
         if time_range == TimeRange.ALL_TIME:
             return transactions
@@ -44,46 +53,51 @@ class TimeFilter:
         if not transactions:
             return []
 
-        # Get the latest transaction date as reference
-        latest_date = max(t.date for t in transactions)
+        now = datetime.now(UTC)
 
         if time_range == TimeRange.THIS_MONTH:
-            start_date = latest_date.replace(day=1)
+            start_date = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
             return [t for t in transactions if t.date >= start_date]
 
         if time_range == TimeRange.LAST_MONTH:
-            # First day of current month
-            first_of_month = latest_date.replace(day=1)
-            # Last day of previous month
-            last_month_end = first_of_month - timedelta(days=1)
-            # First day of previous month
-            last_month_start = last_month_end.replace(day=1)
+            first_of_month = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+            last_month_end = first_of_month - timedelta(microseconds=1)
+            last_month_start = last_month_end.replace(
+                day=1, hour=0, minute=0, second=0, microsecond=0
+            )
             return [t for t in transactions if last_month_start <= t.date <= last_month_end]
 
+        # Sliding ranges -- calendar-aligned: snap to the first of the month
+        # N-1 months ago, so "Last 3 months" = current + 2 prior calendar
+        # months instead of a fixed 90-day window.
+        first_of_now = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
         if time_range == TimeRange.LAST_3_MONTHS:
-            start_date = latest_date - timedelta(days=90)
+            start_date = _subtract_months(first_of_now, 2)
             return [t for t in transactions if t.date >= start_date]
 
         if time_range == TimeRange.LAST_6_MONTHS:
-            start_date = latest_date - timedelta(days=180)
+            start_date = _subtract_months(first_of_now, 5)
             return [t for t in transactions if t.date >= start_date]
 
         if time_range == TimeRange.LAST_12_MONTHS:
-            start_date = latest_date - timedelta(days=365)
+            start_date = _subtract_months(first_of_now, 11)
             return [t for t in transactions if t.date >= start_date]
 
         if time_range == TimeRange.THIS_YEAR:
-            start_date = latest_date.replace(month=1, day=1)
+            start_date = now.replace(
+                month=1, day=1, hour=0, minute=0, second=0, microsecond=0
+            )
             return [t for t in transactions if t.date >= start_date]
 
         if time_range == TimeRange.LAST_YEAR:
-            year = latest_date.year - 1
+            year = now.year - 1
             start_date = datetime(year, 1, 1, tzinfo=UTC)
             end_date = datetime(year, 12, 31, 23, 59, 59, tzinfo=UTC)
             return [t for t in transactions if start_date <= t.date <= end_date]
 
         if time_range == TimeRange.LAST_DECADE:
-            start_date = latest_date - timedelta(days=3650)  # Approx 10 years
+            start_date = _subtract_months(first_of_now, 119)
             return [t for t in transactions if t.date >= start_date]
 
         return transactions

--- a/backend/tests/integration/test_daily_net_worth_opening_balance.py
+++ b/backend/tests/integration/test_daily_net_worth_opening_balance.py
@@ -1,0 +1,201 @@
+"""Integration tests for /api/calculations/daily-net-worth opening balance.
+
+When the caller supplies a ``start_date``, the cumulative ``net_worth``
+series should be seeded with the user's pre-window cashflow so the chart
+doesn't reset to zero. These tests cover:
+
+1. No start_date -> opening balance is zero (back-compat).
+2. start_date set, transactions exist before it -> opening_balance is
+   their net cashflow and the cumulative series starts from there.
+3. Transfers before start_date are ignored (we only model income+expense
+   here, matching the frontend chart's behaviour).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from ledger_sync.api.deps import get_current_user
+from ledger_sync.api.main import app
+from ledger_sync.db.base import Base
+from ledger_sync.db.models import Transaction, TransactionType, User
+from ledger_sync.db.session import get_session
+
+TEST_BCRYPT_HASH = "$2b$12$dummy_hash_for_testing_purposes"  # noqa: S105
+
+
+@pytest.fixture
+def session() -> Session:
+    # SQLite in-memory with StaticPool so the test thread and the
+    # request thread (FastAPI uses a thread per request) share the
+    # same connection. Without this the FastAPI handler hits a
+    # different in-memory DB and sees no rows.
+    from sqlalchemy.pool import StaticPool
+
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session_local = sessionmaker(bind=engine)
+    db = session_local()
+    yield db
+    db.close()
+
+
+@pytest.fixture
+def user(session: Session) -> User:
+    user = User(
+        email="open-balance@example.com",
+        hashed_password=TEST_BCRYPT_HASH,
+        full_name="Test",
+        is_active=True,
+        is_verified=True,
+    )
+    session.add(user)
+    session.commit()
+    return user
+
+
+@pytest.fixture
+def client(session: Session, user: User) -> TestClient:
+    app.dependency_overrides[get_session] = lambda: session
+    app.dependency_overrides[get_current_user] = lambda: user
+    test_client = TestClient(app)
+    yield test_client
+    app.dependency_overrides.clear()
+
+
+def _add_tx(
+    session: Session,
+    user_id: int,
+    *,
+    date: datetime,
+    amount: float,
+    tx_type: TransactionType,
+    tid: str,
+) -> None:
+    session.add(
+        Transaction(
+            user_id=user_id,
+            transaction_id=tid,
+            date=date,
+            amount=Decimal(str(amount)),
+            currency="INR",
+            type=tx_type,
+            account="HDFC",
+            category="Test",
+            subcategory=None,
+            note=None,
+            source_file="test.xlsx",
+            last_seen_at=datetime.now(UTC),
+            is_deleted=False,
+        )
+    )
+
+
+def test_no_start_date_opens_at_zero(
+    client: TestClient, session: Session, user: User
+) -> None:
+    """Without a start_date the cumulative series starts from zero."""
+    _add_tx(
+        session,
+        user.id,
+        date=datetime(2025, 1, 10, tzinfo=UTC),
+        amount=1000,
+        tx_type=TransactionType.INCOME,
+        tid="t1",
+    )
+    session.commit()
+
+    resp = client.get("/api/calculations/daily-net-worth")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["opening_balance"] == 0.0
+    # First cumulative point is just the 1000 income, no opening offset.
+    assert body["cumulative_data"][0]["net_worth"] == 1000.0
+
+
+def test_start_date_seeds_opening_balance(
+    client: TestClient, session: Session, user: User
+) -> None:
+    """Transactions before start_date contribute to the opening balance."""
+    # Pre-window: 5000 income, 1500 expense -> opening balance 3500
+    _add_tx(
+        session,
+        user.id,
+        date=datetime(2024, 11, 1, tzinfo=UTC),
+        amount=5000,
+        tx_type=TransactionType.INCOME,
+        tid="pre1",
+    )
+    _add_tx(
+        session,
+        user.id,
+        date=datetime(2024, 12, 15, tzinfo=UTC),
+        amount=1500,
+        tx_type=TransactionType.EXPENSE,
+        tid="pre2",
+    )
+    # In-window: 800 income on 2025-01-05
+    _add_tx(
+        session,
+        user.id,
+        date=datetime(2025, 1, 5, tzinfo=UTC),
+        amount=800,
+        tx_type=TransactionType.INCOME,
+        tid="in1",
+    )
+    session.commit()
+
+    resp = client.get(
+        "/api/calculations/daily-net-worth",
+        params={"start_date": "2025-01-01T00:00:00"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["opening_balance"] == pytest.approx(3500.0)
+    # Cumulative starts from opening + first in-window flow
+    assert body["cumulative_data"][0]["net_worth"] == pytest.approx(3500.0 + 800.0)
+
+
+def test_transfers_before_start_date_are_ignored(
+    client: TestClient, session: Session, user: User
+) -> None:
+    """Transfers don't touch the opening balance -- the cashflow model
+    only counts income and expense, matching the frontend chart."""
+    # Pre-window transfer: should be ignored
+    _add_tx(
+        session,
+        user.id,
+        date=datetime(2024, 12, 1, tzinfo=UTC),
+        amount=10_000,
+        tx_type=TransactionType.TRANSFER,
+        tid="pre-xfer",
+    )
+    # Pre-window income: should count
+    _add_tx(
+        session,
+        user.id,
+        date=datetime(2024, 12, 10, tzinfo=UTC),
+        amount=2000,
+        tx_type=TransactionType.INCOME,
+        tid="pre-inc",
+    )
+    session.commit()
+
+    resp = client.get(
+        "/api/calculations/daily-net-worth",
+        params={"start_date": "2025-01-01T00:00:00"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    # Only the 2000 income contributes -- the 10k transfer doesn't.
+    assert body["opening_balance"] == pytest.approx(2000.0)

--- a/backend/tests/integration/test_time_range_anchor_now.py
+++ b/backend/tests/integration/test_time_range_anchor_now.py
@@ -1,0 +1,181 @@
+"""Time-range filters anchor on ``now()``, not on the latest transaction.
+
+Covers both implementations:
+- ``ledger_sync.core.time_filter.TimeFilter`` (in-memory list filter)
+- ``ledger_sync.api.analytics_helpers._get_time_range_dates`` (DB query)
+
+The behaviour change matters for users with stale data: clicking
+"This Month" should yield the current calendar month even if their data
+is months old, instead of returning the latest data month under a
+misleading label.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from ledger_sync.api.analytics_helpers import _get_time_range_dates
+from ledger_sync.core.time_filter import TimeFilter, TimeRange
+from ledger_sync.db.base import Base
+from ledger_sync.db.models import Transaction, TransactionType, User
+
+TEST_BCRYPT_HASH = "$2b$12$dummy_hash_for_testing_purposes"  # noqa: S105
+
+
+@pytest.fixture
+def db_session() -> Session:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session_local = sessionmaker(bind=engine)
+    db = session_local()
+    yield db
+    db.close()
+
+
+@pytest.fixture
+def user(db_session: Session) -> User:
+    user = User(
+        email="now-anchor@example.com",
+        hashed_password=TEST_BCRYPT_HASH,
+        full_name="Test",
+        is_active=True,
+        is_verified=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    return user
+
+
+def _make_tx(
+    user_id: int, date: datetime, amount: float, tid: str
+) -> Transaction:
+    return Transaction(
+        user_id=user_id,
+        transaction_id=tid,
+        date=date,
+        amount=Decimal(str(amount)),
+        currency="INR",
+        type=TransactionType.EXPENSE,
+        account="HDFC",
+        category="Test",
+        subcategory=None,
+        note=None,
+        source_file="test.xlsx",
+        last_seen_at=datetime.now(UTC),
+        is_deleted=False,
+    )
+
+
+# ─── core/time_filter.py ────────────────────────────────────────────────
+
+
+def test_in_memory_this_month_uses_now_not_latest_tx() -> None:
+    """A user whose data ends 6 months ago clicks 'This Month' -> empty
+    result, because it's truly not this month."""
+    fake_now = datetime(2026, 5, 15, tzinfo=UTC)
+    txns = [_make_tx(1, datetime(2025, 11, 5, tzinfo=UTC), 100, "old1")]
+
+    with patch("ledger_sync.core.time_filter.datetime") as mock_dt:
+        mock_dt.now.return_value = fake_now
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        result = TimeFilter.filter_by_range(txns, TimeRange.THIS_MONTH)
+
+    assert result == []  # Nov 2025 data, May 2026 "this month" -> empty.
+
+
+def test_in_memory_last_3_months_calendar_aligned() -> None:
+    """'Last 3 months' should snap to the first of (now - 2 months), not a
+    fixed 90-day window."""
+    fake_now = datetime(2026, 5, 15, tzinfo=UTC)
+    # Mar 2026, Apr 2026, May 2026 should be included
+    in_range = [
+        _make_tx(1, datetime(2026, 3, 1, tzinfo=UTC), 100, "mar"),
+        _make_tx(1, datetime(2026, 4, 15, tzinfo=UTC), 100, "apr"),
+        _make_tx(1, datetime(2026, 5, 10, tzinfo=UTC), 100, "may"),
+    ]
+    # Feb 28 should be excluded -- it's just before the calendar start
+    out_of_range = _make_tx(1, datetime(2026, 2, 28, tzinfo=UTC), 100, "feb")
+
+    txns = [*in_range, out_of_range]
+
+    with patch("ledger_sync.core.time_filter.datetime") as mock_dt:
+        mock_dt.now.return_value = fake_now
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        result = TimeFilter.filter_by_range(txns, TimeRange.LAST_3_MONTHS)
+
+    assert {t.transaction_id for t in result} == {"mar", "apr", "may"}
+
+
+def test_in_memory_empty_returns_empty() -> None:
+    assert TimeFilter.filter_by_range([], TimeRange.THIS_MONTH) == []
+
+
+# ─── api/analytics_helpers.py ───────────────────────────────────────────
+
+
+def test_db_this_month_anchors_on_now(db_session: Session, user: User) -> None:
+    """Even when latest tx was months ago, THIS_MONTH range starts at the
+    first of the current calendar month."""
+    db_session.add(_make_tx(user.id, datetime(2025, 11, 5, tzinfo=UTC), 100, "old"))
+    db_session.commit()
+
+    fake_now = datetime(2026, 5, 17, 10, 30, 0, tzinfo=UTC)
+    with patch("ledger_sync.api.analytics_helpers.datetime") as mock_dt:
+        mock_dt.now.return_value = fake_now
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        start, end = _get_time_range_dates(db_session, user, TimeRange.THIS_MONTH)
+
+    assert start == datetime(2026, 5, 1, tzinfo=UTC)
+    assert end is None  # open-ended (covers from start through "now")
+
+
+def test_db_last_3_months_calendar_aligned(db_session: Session, user: User) -> None:
+    db_session.add(_make_tx(user.id, datetime(2025, 11, 5, tzinfo=UTC), 100, "old"))
+    db_session.commit()
+
+    fake_now = datetime(2026, 5, 17, tzinfo=UTC)
+    with patch("ledger_sync.api.analytics_helpers.datetime") as mock_dt:
+        mock_dt.now.return_value = fake_now
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        start, end = _get_time_range_dates(db_session, user, TimeRange.LAST_3_MONTHS)
+
+    # 3 calendar months ending in May = Mar 1, Apr 1, May 1 -> start = Mar 1.
+    assert start == datetime(2026, 3, 1, tzinfo=UTC)
+    assert end is None
+
+
+def test_db_last_year_uses_now_year(db_session: Session, user: User) -> None:
+    """LAST_YEAR is (now.year - 1), regardless of latest transaction year."""
+    db_session.add(_make_tx(user.id, datetime(2023, 6, 1, tzinfo=UTC), 100, "old"))
+    db_session.commit()
+
+    fake_now = datetime(2026, 5, 17, tzinfo=UTC)
+    with patch("ledger_sync.api.analytics_helpers.datetime") as mock_dt:
+        mock_dt.now.return_value = fake_now
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        start, end = _get_time_range_dates(db_session, user, TimeRange.LAST_YEAR)
+
+    assert start == datetime(2025, 1, 1, tzinfo=UTC)
+    assert end == datetime(2025, 12, 31, 23, 59, 59, tzinfo=UTC)
+
+
+def test_db_no_transactions_returns_none(db_session: Session, user: User) -> None:
+    """User with no data still gets (None, None) so callers handle empty
+    state gracefully."""
+    start, end = _get_time_range_dates(db_session, user, TimeRange.THIS_MONTH)
+    assert start is None
+    assert end is None
+
+
+def test_db_all_time_returns_none(db_session: Session, user: User) -> None:
+    db_session.add(_make_tx(user.id, datetime(2025, 1, 1, tzinfo=UTC), 100, "any"))
+    db_session.commit()
+    start, end = _get_time_range_dates(db_session, user, TimeRange.ALL_TIME)
+    assert start is None
+    assert end is None

--- a/backend/tests/unit/test_recurring_frequency_bands.py
+++ b/backend/tests/unit/test_recurring_frequency_bands.py
@@ -1,0 +1,138 @@
+"""Recurring detection -- frequency-band gap regression tests.
+
+The original ``_FREQ_BANDS`` had closed-closed integer intervals
+``[(4, 10), (11, 19), (20, 49), ...]`` checked with ``lo <= avg_diff <= hi``.
+Because ``avg_diff`` is a float (mean of integer day-gaps), values like
+10.5, 19.5, 49.5 fell through every band and the engine returned
+``frequency = None``, silently dropping legitimate recurring patterns.
+
+These tests pin the new behaviour: half-integer averages resolve to a
+sensible adjacent frequency.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from ledger_sync.core.analytics_engine import AnalyticsEngine
+from ledger_sync.db.base import Base
+from ledger_sync.db.models import RecurrenceFrequency
+
+
+def _engine() -> AnalyticsEngine:
+    """Build an AnalyticsEngine wired to an in-memory SQLite session.
+
+    The engine itself doesn't touch the DB for ``_detect_frequency``,
+    but the constructor wants a session.
+    """
+    sql_engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(sql_engine)
+    session_local = sessionmaker(bind=sql_engine)
+    return AnalyticsEngine(session_local(), user_id=1)
+
+
+def _dates_with_gaps(start: datetime, gaps: list[int]) -> list[datetime]:
+    """Build a date sequence from ``start`` using ``gaps`` (in days).
+
+    e.g. ``_dates_with_gaps(d, [7, 14])`` -> [d, d+7, d+21].
+    """
+    from datetime import timedelta
+
+    out = [start]
+    for gap in gaps:
+        out.append(out[-1] + timedelta(days=gap))
+    return out
+
+
+# ─── Old-bug reproduction cases (should now resolve to a frequency) ─────
+
+
+def test_avg_gap_10_5_resolves_to_weekly() -> None:
+    """7 + 14 -> avg 10.5. Previously: None. Now: WEEKLY."""
+    eng = _engine()
+    dates = _dates_with_gaps(datetime(2026, 1, 1, tzinfo=UTC), [7, 14])
+    freq, conf, _ = eng._detect_frequency(dates)
+    assert freq == RecurrenceFrequency.WEEKLY
+    assert conf > 0
+
+
+def test_avg_gap_19_5_resolves_to_biweekly() -> None:
+    """19 + 20 -> avg 19.5. Previously: None. Now: BIWEEKLY."""
+    eng = _engine()
+    dates = _dates_with_gaps(datetime(2026, 1, 1, tzinfo=UTC), [19, 20])
+    freq, _, _ = eng._detect_frequency(dates)
+    assert freq == RecurrenceFrequency.BIWEEKLY
+
+
+def test_avg_gap_49_5_resolves_to_monthly() -> None:
+    """Monthly bills with one delayed payment: 30 + 31 + 49 -> avg 36.7,
+    fine. But 49 + 50 -> avg 49.5 used to fall through. Now: MONTHLY."""
+    eng = _engine()
+    dates = _dates_with_gaps(datetime(2026, 1, 1, tzinfo=UTC), [49, 50])
+    freq, _, _ = eng._detect_frequency(dates)
+    assert freq == RecurrenceFrequency.MONTHLY
+
+
+def test_avg_gap_79_5_resolves_to_bimonthly() -> None:
+    eng = _engine()
+    dates = _dates_with_gaps(datetime(2026, 1, 1, tzinfo=UTC), [79, 80])
+    freq, _, _ = eng._detect_frequency(dates)
+    assert freq == RecurrenceFrequency.BIMONTHLY
+
+
+def test_avg_gap_129_5_resolves_to_quarterly() -> None:
+    eng = _engine()
+    dates = _dates_with_gaps(datetime(2026, 1, 1, tzinfo=UTC), [129, 130])
+    freq, _, _ = eng._detect_frequency(dates)
+    assert freq == RecurrenceFrequency.QUARTERLY
+
+
+def test_avg_gap_269_5_resolves_to_semiannual() -> None:
+    eng = _engine()
+    dates = _dates_with_gaps(datetime(2026, 1, 1, tzinfo=UTC), [269, 270])
+    freq, _, _ = eng._detect_frequency(dates)
+    assert freq == RecurrenceFrequency.SEMIANNUAL
+
+
+# ─── Sanity: classic cadences still resolve correctly ───────────────────
+
+
+def test_weekly_classic_7_day_cadence() -> None:
+    eng = _engine()
+    dates = _dates_with_gaps(datetime(2026, 1, 1, tzinfo=UTC), [7, 7, 7])
+    freq, conf, _ = eng._detect_frequency(dates)
+    assert freq == RecurrenceFrequency.WEEKLY
+    assert conf == 100  # zero std -> max confidence
+
+
+def test_monthly_classic_30_day_cadence() -> None:
+    eng = _engine()
+    dates = _dates_with_gaps(datetime(2026, 1, 1, tzinfo=UTC), [30, 30, 30])
+    freq, _, _ = eng._detect_frequency(dates)
+    assert freq == RecurrenceFrequency.MONTHLY
+
+
+def test_yearly_classic_365_day_cadence() -> None:
+    eng = _engine()
+    dates = _dates_with_gaps(datetime(2026, 1, 1, tzinfo=UTC), [365, 365, 365])
+    freq, _, _ = eng._detect_frequency(dates)
+    assert freq == RecurrenceFrequency.YEARLY
+
+
+def test_below_minimum_returns_none() -> None:
+    """Sub-weekly gaps (avg < 4) still return None -- not a tracked cadence."""
+    eng = _engine()
+    dates = _dates_with_gaps(datetime(2026, 1, 1, tzinfo=UTC), [1, 2, 1])
+    freq, _, _ = eng._detect_frequency(dates)
+    assert freq is None
+
+
+def test_above_yearly_returns_none() -> None:
+    """Gaps > 400 days are out of scope (not expected for personal finance)."""
+    eng = _engine()
+    dates = _dates_with_gaps(datetime(2026, 1, 1, tzinfo=UTC), [500, 500])
+    freq, _, _ = eng._detect_frequency(dates)
+    assert freq is None

--- a/docs/CALCULATIONS.md
+++ b/docs/CALCULATIONS.md
@@ -640,24 +640,24 @@ Note: this is simplified CAGR, not XIRR. For accurate XIRR-style returns with ir
    - Compute mean amount, amount variance (std dev / mean)
 3. Detect frequency via `_detect_frequency`:
    ```
-   mean_gap in [6, 8]      -> WEEKLY (interval ~7)
-   mean_gap in [13, 15]    -> FORTNIGHTLY
-   mean_gap in [28, 32]    -> MONTHLY
-   mean_gap in [88, 92]    -> QUARTERLY
-   mean_gap in [178, 186]  -> SEMIANNUAL
-   mean_gap in [360, 370]  -> YEARLY
-   else                    -> not recurring
+   # Bands are half-open [lo, next_lo) so float averages between
+   # integer thresholds (e.g. mean_gap = 10.5) resolve cleanly.
+   mean_gap in [4, 11)    -> WEEKLY      (penalty 8)
+   mean_gap in [11, 20)   -> BIWEEKLY    (penalty 5)
+   mean_gap in [20, 50)   -> MONTHLY     (penalty 3)
+   mean_gap in [50, 80)   -> BIMONTHLY   (penalty 2.5)
+   mean_gap in [80, 130)  -> QUARTERLY   (penalty 2)
+   mean_gap in [130, 270) -> SEMIANNUAL  (penalty 1.5)
+   mean_gap in [270, 400) -> YEARLY      (penalty 1)
+   else                   -> not recurring
    ```
 4. **Confidence score** (0-100):
    ```
-   gap_consistency = 1 - (stddev(gaps) / mean(gap))      # penalize irregular intervals
-   amount_consistency = 1 - min(1, amount_variance)       # penalize amount swings
-   count_score = min(1, occurrences / 6)                  # need ~6 to be sure
-   confidence = (gap_consistency * 0.4 + amount_consistency * 0.3 + count_score * 0.3) * 100
+   confidence = max(0, 100 - stddev(gaps) * penalty)
    ```
-5. Only patterns with `confidence >= recurring_min_confidence` (default 50) are saved.
-6. `expected_day = mode(txn.date.day)` for monthly patterns, else None.
-7. `next_expected = last_date + interval_days`.
+   Penalty scales with expected cadence -- wider cycles tolerate more jitter (yearly penalty 1, weekly penalty 8). Only patterns with `confidence >= recurring_min_confidence` (default 50) are saved.
+5. `expected_day = mode(txn.date.day)` for monthly+ patterns, else None.
+6. `next_expected = last_date + interval_days`.
 
 ### User Confirmation
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.10.0",
+  "version": "2.14.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Three calculation correctness fixes from the post-#160 audit, batched into one PR per workflow rule.

## Commits in this PR

### 1. `fix(net-worth-api): seed cumulative series with pre-window opening balance`  (a2e2112)

`GET /api/calculations/daily-net-worth?start_date=...` reset the cumulative `net_worth` series to 0 on day one of the window, ignoring all pre-window transactions. A user filtering 'Last 6 months' would see their chart start at zero instead of their actual cumulative cashflow at that point.

Fix: when `start_date` is set, compute `opening_balance = SUM(income) - SUM(expense)` for transactions strictly before it and seed `cumulative_net_worth` with that value. Transfers excluded (matches existing model). `opening_balance` is also returned in the response so frontends can use it.

3 integration tests cover: no start_date (back-compat), pre-window data seeds opening, transfers ignored.

### 2. `fix(time-range): anchor THIS_MONTH/LAST_N filters on now(), not latest tx`  (9c094b7)

Both backend time-range filters anchored on the user's most recent transaction date. Issues:
- Stale-data drift: 'This Month' returned old data with a misleading current label.
- Sliding-window quirk: 'Last 3 months' = `latest - 90 days` (not calendar-aligned).

Fix: anchor on `datetime.now(UTC)` everywhere. 'This Month' is the current calendar month. 'Last 3 Months' snaps to the first of (now - 2 months), giving 3 full calendar months that align with monthly aggregations.

Touches `api/analytics_helpers.py` and `core/time_filter.py` (two parallel implementations). 8 tests cover both, including the calendar-aligned sliding window.

### 3. `fix(recurring): close gaps between frequency bands so float averages resolve`  (97152a8)

`_FREQ_BANDS` used closed-closed integer intervals checked with `lo <= avg_diff <= hi`. Because `avg_diff` is a float (mean of integer day-gaps), values like 10.5, 19.5, 49.5, 79.5 fell through every band -> `frequency = None` -> recurring patterns silently dropped.

Fix: redefine bands as half-open intervals starting at `min_days`, ending at the next band's `min_days`. Bands now actually tile the real number line.

11 unit tests cover: previously-broken half-integer cases (now resolve correctly), classic cadences (7/30/365 days) still resolve identically, below-min and above-max still return None.

## Verification

- 135 backend tests pass (was 116 on main, +19 new tests across the three fixes)
- Ruff clean
- No frontend changes

## Closes
- Replaces #161, #162, #163 (split-PR mistake; user requested single-PR workflow)