### PR TITLE
fix(ci): bootstrap release-please from 2.15.0 baseline

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "release-type": "simple",
   "include-component-in-tag": false,
   "changelog-path": "CHANGELOG.md",
+  "bootstrap-sha": "5bfa19d11b1c350a1bb43c147c45f9ac6d2de30d",
   "packages": {
     ".": {
       "extra-files": [


### PR DESCRIPTION
First release-please run failed parsing pre-conventional-commit history back to the v0.9.0 tag (unexpected-token on old merge commits). Adds bootstrap-sha pinned to the #171 merge so it only parses commits after the 2.15.0 baseline. Auto-ignored once the first release PR merges.