### PR TITLE
fix: resolve 24 verified audit findings (security, correctness, robustness)

### DIFF
--- a/backend/src/ledger_sync/api/ai_chat.py
+++ b/backend/src/ledger_sync/api/ai_chat.py
@@ -35,8 +35,6 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
-from slowapi import Limiter
-from slowapi.util import get_remote_address
 from sqlalchemy import select
 
 from ledger_sync.api.ai_usage import (
@@ -45,6 +43,7 @@ from ledger_sync.api.ai_usage import (
     record_usage,
 )
 from ledger_sync.api.deps import CurrentUser, DatabaseSession
+from ledger_sync.api.rate_limit import limiter
 from ledger_sync.config.settings import settings
 from ledger_sync.db.models import UserPreferences
 
@@ -53,7 +52,6 @@ router = APIRouter(prefix="/api/ai", tags=["ai"])
 # Rate-limit the Bedrock proxy. App-mode usage is additionally capped per
 # user per day via ai_daily_message_limit; this IP-keyed limit catches
 # abusive clients that rotate users or bypass the in-app UI.
-limiter = Limiter(key_func=get_remote_address)
 
 
 class ContentBlock(BaseModel):
@@ -246,13 +244,13 @@ def bedrock_chat_proxy(
             ),
         )
 
-    # Gate by mode:
-    #   app_bedrock -> count messages, enforce app-wide daily cap
-    #   byok        -> the user owns the bill; only their optional per-user
-    #                  token caps apply.
-    if prefs.ai_mode == "app_bedrock":
-        check_app_message_limit(session, current_user.id)
-    else:
+    # This proxy ALWAYS signs with the server's Bedrock credential (there is
+    # no per-user AWS key path), so every call through it — app_bedrock OR
+    # byok+bedrock — spends the shared server token. Enforce the app-wide daily
+    # message cap regardless of mode so a user cannot bypass cost control by
+    # flipping to byok. BYOK's optional per-user token caps still apply on top.
+    check_app_message_limit(session, current_user.id)
+    if prefs.ai_mode != "app_bedrock":
         check_token_limits(session, current_user.id)
 
     import boto3

--- a/backend/src/ledger_sync/api/ai_tools_impl/analytics_tools.py
+++ b/backend/src/ledger_sync/api/ai_tools_impl/analytics_tools.py
@@ -18,6 +18,7 @@ from ledger_sync.db.models import (
 )
 
 from .registry import (
+    LIST_ENTITIES_MAX_LIMIT,
     ToolSpec,
     register,
     to_decimal,
@@ -279,6 +280,7 @@ def _exec_list_budgets(user: User, db: Session, _args: dict[str, Any]) -> Any:
             select(Budget)
             .where(Budget.user_id == user.id, Budget.is_active.is_(True))
             .order_by(Budget.current_month_pct.desc())
+            .limit(LIST_ENTITIES_MAX_LIMIT)
         )
         .scalars()
         .all()
@@ -298,6 +300,7 @@ def _exec_list_budgets(user: User, db: Session, _args: dict[str, Any]) -> Any:
             for b in rows
         ],
         "count": len(rows),
+        "truncated": len(rows) >= LIST_ENTITIES_MAX_LIMIT,
     }
 
 

--- a/backend/src/ledger_sync/api/ai_tools_impl/categories_summary.py
+++ b/backend/src/ledger_sync/api/ai_tools_impl/categories_summary.py
@@ -21,6 +21,7 @@ from ledger_sync.db.models import (
 from .registry import (
     LIST_CATEGORIES_DEFAULT_LIMIT,
     LIST_CATEGORIES_MAX_LIMIT,
+    LIST_ENTITIES_MAX_LIMIT,
     LIST_RECENT_MONTHS_DEFAULT_LIMIT,
     LIST_RECENT_MONTHS_MAX_LIMIT,
     ToolSpec,
@@ -226,7 +227,7 @@ def _exec_list_recurring(user: User, db: Session, args: dict[str, Any]) -> Any:
     stmt = select(RecurringTransaction).where(RecurringTransaction.user_id == user.id)
     if active_only:
         stmt = stmt.where(RecurringTransaction.is_active.is_(True))
-    stmt = stmt.order_by(RecurringTransaction.expected_amount.desc())
+    stmt = stmt.order_by(RecurringTransaction.expected_amount.desc()).limit(LIST_ENTITIES_MAX_LIMIT)
     rows = db.execute(stmt).scalars().all()
     return {
         "recurring": [
@@ -244,6 +245,7 @@ def _exec_list_recurring(user: User, db: Session, args: dict[str, Any]) -> Any:
             for r in rows
         ],
         "count": len(rows),
+        "truncated": len(rows) >= LIST_ENTITIES_MAX_LIMIT,
     }
 
 
@@ -263,7 +265,15 @@ register(
 
 
 def _exec_list_goals(user: User, db: Session, _args: dict[str, Any]) -> Any:
-    rows = db.execute(select(FinancialGoal).where(FinancialGoal.user_id == user.id)).scalars().all()
+    rows = (
+        db.execute(
+            select(FinancialGoal)
+            .where(FinancialGoal.user_id == user.id)
+            .limit(LIST_ENTITIES_MAX_LIMIT)
+        )
+        .scalars()
+        .all()
+    )
     return {
         "goals": [
             {
@@ -278,6 +288,7 @@ def _exec_list_goals(user: User, db: Session, _args: dict[str, Any]) -> Any:
             for g in rows
         ],
         "count": len(rows),
+        "truncated": len(rows) >= LIST_ENTITIES_MAX_LIMIT,
     }
 
 

--- a/backend/src/ledger_sync/api/ai_tools_impl/registry.py
+++ b/backend/src/ledger_sync/api/ai_tools_impl/registry.py
@@ -30,6 +30,11 @@ LIST_CATEGORIES_MAX_LIMIT = 50
 LIST_RECENT_MONTHS_DEFAULT_LIMIT = 6
 LIST_RECENT_MONTHS_MAX_LIMIT = 24
 
+# Cap for curated/grouped lists (recurring, goals, budgets). These tables are
+# small by nature, but the cap enforces the tool invariant that no tool can
+# dump an unbounded row count into the LLM prompt.
+LIST_ENTITIES_MAX_LIMIT = 100
+
 # --- Tool registry -----------------------------------------------------------
 
 ToolExecutor = Callable[[User, Session, dict[str, Any]], Any]

--- a/backend/src/ledger_sync/api/ai_tools_impl/transactions.py
+++ b/backend/src/ledger_sync/api/ai_tools_impl/transactions.py
@@ -188,23 +188,16 @@ def _exec_search_transactions(user: User, db: Session, args: dict[str, Any]) -> 
     if max_amount is not None:
         stmt = stmt.where(Transaction.amount <= Decimal(str(max_amount)))
 
+    # `stmt` now carries every filter (query/category/account/type/amount).
     stmt = apply_date_range(stmt, start, end)
-    stmt = stmt.order_by(Transaction.date.desc()).limit(limit)
 
-    rows = db.execute(stmt).scalars().all()
-
+    # Count from the SAME filtered statement so the total reflects the actual
+    # query, not just user+date-range. Strip ordering before counting.
     total = db.execute(
-        select(func.count()).select_from(
-            apply_date_range(
-                select(Transaction).where(
-                    Transaction.user_id == user.id,
-                    Transaction.is_deleted.is_(False),
-                ),
-                start,
-                end,
-            ).subquery()
-        )
+        select(func.count()).select_from(stmt.order_by(None).subquery())
     ).scalar_one()
+
+    rows = db.execute(stmt.order_by(Transaction.date.desc()).limit(limit)).scalars().all()
 
     return {
         "transactions": [
@@ -220,7 +213,7 @@ def _exec_search_transactions(user: User, db: Session, args: dict[str, Any]) -> 
             for t in rows
         ],
         "returned": len(rows),
-        "total_matching_date_range": int(total),
+        "total_matching_filters": total,
         "truncated": len(rows) >= limit,
     }
 

--- a/backend/src/ledger_sync/api/auth.py
+++ b/backend/src/ledger_sync/api/auth.py
@@ -9,10 +9,9 @@ Rate-limited refresh to prevent abuse (CWE-307).
 from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, Query, Request
-from slowapi import Limiter
-from slowapi.util import get_remote_address
 
 from ledger_sync.api.deps import CurrentUser, DatabaseSession
+from ledger_sync.api.rate_limit import limiter
 from ledger_sync.schemas.auth import (
     MessageResponse,
     RefreshTokenRequest,
@@ -23,9 +22,6 @@ from ledger_sync.schemas.auth import (
 from ledger_sync.services.auth_service import AuthService
 
 router = APIRouter(prefix="/api/auth", tags=["authentication"])
-
-# Rate limiter — keyed by client IP address
-limiter = Limiter(key_func=get_remote_address)
 
 
 # =============================================================================

--- a/backend/src/ledger_sync/api/main.py
+++ b/backend/src/ledger_sync/api/main.py
@@ -29,6 +29,7 @@ from ledger_sync.api.exchange_rates import router as exchange_rates_router
 from ledger_sync.api.meta import router as meta_router
 from ledger_sync.api.oauth import router as oauth_router
 from ledger_sync.api.preferences import router as preferences_router
+from ledger_sync.api.rate_limit import limiter
 from ledger_sync.api.rates import router as rates_router
 from ledger_sync.api.reports import router as reports_router
 from ledger_sync.api.stock_price import router as stock_price_router
@@ -95,6 +96,11 @@ app = FastAPI(
 )
 
 # ─── Rate Limiting ───────────────────────────────────────────────────────────
+
+# Attach the shared limiter to app state so _rate_limit_exceeded_handler can
+# inject Retry-After / rate-limit headers. Without this, a tripped limit raises
+# AttributeError inside the handler and surfaces as a generic 500 instead of 429.
+app.state.limiter = limiter
 
 # Register slowapi rate-limit exceeded handler (returns 429 Too Many Requests)
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # type: ignore[arg-type]

--- a/backend/src/ledger_sync/api/oauth.py
+++ b/backend/src/ledger_sync/api/oauth.py
@@ -8,18 +8,19 @@ Handles the server-side of the OAuth authorization code flow:
    then creates/links a local user and returns JWT tokens.
 """
 
+import base64
+import hashlib
+import hmac
 import logging
 import secrets
-import threading
 import time
 from typing import Any
 
 import httpx
 from fastapi import APIRouter, HTTPException, Request, status
-from slowapi import Limiter
-from slowapi.util import get_remote_address
 
 from ledger_sync.api.deps import DatabaseSession, HttpClient
+from ledger_sync.api.rate_limit import limiter
 from ledger_sync.config.settings import settings
 from ledger_sync.schemas.auth import OAuthCallbackRequest, OAuthProviderConfig, Token
 from ledger_sync.services.auth_service import AuthService
@@ -27,8 +28,6 @@ from ledger_sync.services.auth_service import AuthService
 logger = logging.getLogger("ledger_sync.oauth")
 
 router = APIRouter(prefix="/api/auth/oauth", tags=["oauth"])
-
-limiter = Limiter(key_func=get_remote_address)
 
 # ─── Provider Configurations ──────────────────────────────────────────────────
 
@@ -44,41 +43,62 @@ _GITHUB_SCOPES = "read:user user:email"
 
 _GOOGLE_AUTHORIZE_URL = "https://accounts.google.com/o/oauth2/v2/auth"
 
-# ─── CSRF State Token Store ──────────────────────────────────────────────────
-# Short-lived in-memory store for OAuth state tokens (10 min TTL).
+# ─── CSRF State Token (stateless, HMAC-signed) ───────────────────────────────
+# State tokens are self-contained and HMAC-signed with the server secret, so
+# they survive across serverless instances (no shared in-memory store to lose
+# on cold start) while remaining unforgeable. Format: "<nonce>.<expiry>.<sig>".
 
 _STATE_TTL = 600  # 10 minutes
-_state_store: dict[str, float] = {}  # state_token -> expiry_timestamp
-_state_lock = threading.Lock()
+
+
+def _state_secret() -> bytes:
+    """Key used to sign state tokens (the server's JWT secret)."""
+    return settings.jwt_secret_key.encode()
+
+
+def _sign_state(payload: str) -> str:
+    """Return the base64url HMAC-SHA256 of a state payload."""
+    digest = hmac.new(_state_secret(), payload.encode(), hashlib.sha256).digest()
+    return base64.urlsafe_b64encode(digest).decode().rstrip("=")
 
 
 def _generate_state() -> str:
-    """Generate a random state token and store it with a TTL."""
-    token = secrets.token_urlsafe(32)
-    now = time.monotonic()
-    with _state_lock:
-        # Clean up expired tokens while we're here
-        expired = [k for k, exp in _state_store.items() if now > exp]
-        for k in expired:
-            del _state_store[k]
-        _state_store[token] = now + _STATE_TTL
-    return token
+    """Generate a signed, self-expiring state token."""
+    nonce = secrets.token_urlsafe(16)
+    expiry = str(int(time.time()) + _STATE_TTL)
+    payload = f"{nonce}.{expiry}"
+    return f"{payload}.{_sign_state(payload)}"
 
 
 def _validate_state(state: str | None) -> None:
-    """Validate and consume a state token. Raises 400 if invalid or expired."""
+    """Validate a signed state token. Raises 400 if invalid or expired."""
     if not state:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Missing OAuth state parameter",
         )
-    now = time.monotonic()
-    with _state_lock:
-        expiry = _state_store.pop(state, None)
-    if expiry is None or now > expiry:
+    try:
+        nonce, expiry_str, sig = state.split(".")
+    except ValueError:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invalid or expired OAuth state parameter",
+            detail="Invalid OAuth state parameter",
+        ) from None
+
+    payload = f"{nonce}.{expiry_str}"
+    if not hmac.compare_digest(sig, _sign_state(payload)):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid OAuth state parameter",
+        )
+    try:
+        expired = int(time.time()) > int(expiry_str)
+    except ValueError:
+        expired = True
+    if expired:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Expired OAuth state parameter",
         )
 
 
@@ -213,6 +233,13 @@ async def google_callback(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Could not retrieve email from Google",
+        )
+    # Only trust the email as an identity claim if Google verified it.
+    # An unverified email must not be allowed to match/link an account.
+    if not user_info.get("verified_email", False):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Google email is not verified",
         )
 
     auth_service = AuthService(session)

--- a/backend/src/ledger_sync/api/rate_limit.py
+++ b/backend/src/ledger_sync/api/rate_limit.py
@@ -1,0 +1,14 @@
+"""Shared rate limiter.
+
+A single Limiter instance is shared across all routers and attached to
+``app.state.limiter`` in main.py. slowapi's ``_rate_limit_exceeded_handler``
+reads ``request.app.state.limiter`` to inject Retry-After / rate-limit headers;
+if no limiter is attached it raises AttributeError and the 429 surfaces as a
+generic 500. Sharing one instance keeps the decorator config and the handler
+in sync.
+"""
+
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+limiter = Limiter(key_func=get_remote_address)

--- a/backend/src/ledger_sync/api/upload.py
+++ b/backend/src/ledger_sync/api/upload.py
@@ -10,10 +10,10 @@ stay in sync with the raw transactions. The explicit POST
 
 import anyio
 from fastapi import APIRouter, HTTPException, Request
-from slowapi import Limiter
-from slowapi.util import get_remote_address
+from sqlalchemy.exc import OperationalError
 
 from ledger_sync.api.deps import CurrentUser, DatabaseSession
+from ledger_sync.api.rate_limit import limiter
 from ledger_sync.core.analytics import AnalyticsEngine
 from ledger_sync.core.sync_engine import SyncEngine
 from ledger_sync.ingest.normalizer import NormalizationError
@@ -27,7 +27,6 @@ router = APIRouter(prefix="", tags=["upload"])
 # come close to this; it exists to cap an abusive client that might try to
 # replay / brute force uploads. Keyed by remote address, not user, so an
 # unauthenticated flood is also throttled.
-limiter = Limiter(key_func=get_remote_address)
 
 
 @router.post(
@@ -95,14 +94,18 @@ async def upload_transactions(
             await anyio.to_thread.run_sync(
                 lambda: analytics.run_full_analytics(source_file=payload.file_name),
             )
-        except (OSError, RuntimeError, ValueError) as exc:
+        except (OSError, RuntimeError, ValueError, OperationalError) as exc:
             # Don't fail the upload if the post-upload refresh blows up -- the
             # raw data is safely persisted; the user can re-run /refresh.
+            # OperationalError covers a Postgres statement timeout on a large
+            # recompute (Neon free tier), which must NOT fail an upload whose
+            # transactions are already committed.
             logger.warning(
                 "Post-upload analytics refresh failed for user_id=%s: %s",
                 current_user.id,
                 exc,
             )
+            db.rollback()
 
         return UploadResponse(
             success=True,

--- a/backend/src/ledger_sync/core/analytics/fy_summaries.py
+++ b/backend/src/ledger_sync/core/analytics/fy_summaries.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections import defaultdict
 from datetime import UTC, datetime
 from decimal import Decimal
@@ -11,6 +12,10 @@ from sqlalchemy import delete
 
 from ledger_sync.core.analytics.base import AnalyticsEngineBase
 from ledger_sync.db.models import FYSummary, Transaction, TransactionType
+
+# Match "tax"/"taxes" as a whole word so notes like "Taxi" or "Syntax" don't
+# get counted as tax paid.
+_TAX_NOTE_RE = re.compile(r"\btax(es)?\b", re.IGNORECASE)
 
 
 class FYSummariesMixin(AnalyticsEngineBase):
@@ -176,7 +181,7 @@ class FYSummariesMixin(AnalyticsEngineBase):
 
         elif txn.type == TransactionType.EXPENSE:
             data["total_expenses"] += amount
-            if "tax" in (txn.note or "").lower() or txn.category == "Taxes":
+            if txn.category == "Taxes" or _TAX_NOTE_RE.search(txn.note or ""):
                 data["tax_paid"] += amount
 
         elif txn.type == TransactionType.TRANSFER:

--- a/backend/src/ledger_sync/core/analytics/net_worth.py
+++ b/backend/src/ledger_sync/core/analytics/net_worth.py
@@ -92,7 +92,10 @@ class NetWorthMixin(AnalyticsEngineBase):
         if prev_snapshot:
             net_worth_change = net_worth - prev_snapshot.net_worth
             if prev_snapshot.net_worth is not None and prev_snapshot.net_worth != 0:
-                net_worth_change_pct = float(net_worth_change / prev_snapshot.net_worth * 100)
+                # Divide by abs() so the sign reflects the direction of change,
+                # not the sign of the (possibly negative) base. Matches the
+                # yoy_savings convention in fy_summaries.py.
+                net_worth_change_pct = float(net_worth_change / abs(prev_snapshot.net_worth) * 100)
         return net_worth_change, net_worth_change_pct
 
     def _upsert_net_worth_snapshot(

--- a/backend/src/ledger_sync/core/calculator.py
+++ b/backend/src/ledger_sync/core/calculator.py
@@ -184,7 +184,10 @@ def calculate_spending_velocity(
         return {"recent_daily": 0.0, "historical_daily": 0.0, "velocity_ratio": 0.0}
 
     today = max(t.date for t in expenses)
-    recent_cutoff = today - timedelta(days=recent_days)
+    # -1 so the inclusive window (t.date >= cutoff) spans exactly recent_days
+    # calendar days, matching the divisor below and the historical branch's
+    # inclusive +1 span convention.
+    recent_cutoff = today - timedelta(days=recent_days - 1)
 
     recent_expenses = [t for t in expenses if t.date >= recent_cutoff]
     historical_expenses = [t for t in expenses if t.date < recent_cutoff]

--- a/backend/src/ledger_sync/core/report_generator_html.py
+++ b/backend/src/ledger_sync/core/report_generator_html.py
@@ -5,10 +5,16 @@ Extracted from report_generator.py to keep both modules under 500 LOC.
 
 from __future__ import annotations
 
+import html
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ledger_sync.core.report_generator import MonthlyReportData
+
+
+def _esc(value: object) -> str:
+    """HTML-escape a dynamic (user-derived) value before interpolation."""
+    return html.escape(str(value))
 
 
 def _format_currency(amount: float) -> str:
@@ -40,10 +46,11 @@ def generate_html_report(data: MonthlyReportData) -> str:
     # --- Build expense categories rows ---
     expense_rows = ""
     for i, cat in enumerate(data.top_expense_categories, 1):
+        cat_name = _esc(cat["category"])
         expense_rows += f"""
             <tr>
                 <td style="padding: 8px 12px; border-bottom: 1px solid #e5e7eb;">{i}</td>
-                <td style="padding:8px 12px;border-bottom:1px solid #e5e7eb;">{cat["category"]}</td>
+                <td style="padding:8px 12px;border-bottom:1px solid #e5e7eb;">{cat_name}</td>
                 <td style="padding: 8px 12px; border-bottom: 1px solid #e5e7eb; text-align: right;">
                     {_format_currency(cat["amount"])}
                 </td>
@@ -63,10 +70,11 @@ def generate_html_report(data: MonthlyReportData) -> str:
     # --- Build income sources rows ---
     income_rows = ""
     for i, src in enumerate(data.top_income_sources, 1):
+        src_name = _esc(src["category"])
         income_rows += f"""
             <tr>
                 <td style="padding: 8px 12px; border-bottom: 1px solid #e5e7eb;">{i}</td>
-                <td style="padding:8px 12px;border-bottom:1px solid #e5e7eb;">{src["category"]}</td>
+                <td style="padding:8px 12px;border-bottom:1px solid #e5e7eb;">{src_name}</td>
                 <td style="padding: 8px 12px; border-bottom: 1px solid #e5e7eb; text-align: right;">
                     {_format_currency(src["amount"])}
                 </td>

--- a/backend/src/ledger_sync/db/_models/user.py
+++ b/backend/src/ledger_sync/db/_models/user.py
@@ -3,7 +3,17 @@
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Boolean, DateTime, Float, ForeignKey, Index, Integer, String, Text
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ledger_sync.db._models._constants import CASCADE_ALL_DELETE_ORPHAN, USER_FK
@@ -28,6 +38,15 @@ class User(Base):
     """
 
     __tablename__ = "users"
+
+    # A provider identity (provider, provider_id) must map to at most one user.
+    # NULLs (legacy/email accounts with no provider) are distinct, so they
+    # never collide under this constraint.
+    __table_args__ = (
+        UniqueConstraint(
+            "auth_provider", "auth_provider_id", name="uq_users_auth_provider_identity"
+        ),
+    )
 
     id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
     email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)

--- a/backend/src/ledger_sync/db/migrations/versions/20260624_1200_add_auth_provider_unique_constraint.py
+++ b/backend/src/ledger_sync/db/migrations/versions/20260624_1200_add_auth_provider_unique_constraint.py
@@ -1,0 +1,42 @@
+"""add unique constraint on (auth_provider, auth_provider_id)
+
+Identity for OAuth users must be keyed on the provider identity, not email,
+to prevent cross-provider account linking. NULLs (legacy/email accounts with
+no provider) are distinct under a unique constraint in both SQLite and
+Postgres, so they never collide.
+
+Revision ID: f7a8b9c0d1e2
+Revises: 9cbf967f67a6
+Create Date: 2026-06-24 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f7a8b9c0d1e2"
+down_revision: str | None = "9cbf967f67a6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Production (the only place migrations run, via migrate.yml) is Postgres,
+    # where ALTER TABLE ADD CONSTRAINT works directly. SQLite dev builds its
+    # schema from the ORM via init_db()/create_all (which already includes this
+    # constraint), and SQLite can't ADD CONSTRAINT in place, so skip it there.
+    bind = op.get_bind()
+    if bind.dialect.name == "sqlite":
+        return
+    op.create_unique_constraint(
+        "uq_users_auth_provider_identity",
+        "users",
+        ["auth_provider", "auth_provider_id"],
+    )
+
+
+def downgrade() -> None:
+    # Per project convention: rollback via DB backup, not down-migration.
+    pass

--- a/backend/src/ledger_sync/services/auth_service.py
+++ b/backend/src/ledger_sync/services/auth_service.py
@@ -98,11 +98,15 @@ class AuthService:
     ) -> Token:
         """Login or register a user via OAuth provider.
 
-        If a user with this email already exists, log them in and update
-        OAuth fields. If no user exists, create a new account.
+        Identity is keyed on (auth_provider, auth_provider_id), NOT on email.
+        Email is only used to link a provider to a pre-existing account that
+        has no provider yet (e.g. a legacy account). Silent cross-provider
+        linking is refused: if an account already exists for this email under
+        a different provider, the login is rejected to prevent account
+        takeover via a recycled/shared email address.
 
         Args:
-            email: Email from the OAuth provider.
+            email: Email from the OAuth provider (already provider-verified).
             full_name: Full name from the OAuth profile.
             provider: OAuth provider name ("google" or "github").
             provider_id: Unique user ID from the provider.
@@ -110,15 +114,39 @@ class AuthService:
         Returns:
             JWT tokens.
 
+        Raises:
+            HTTPException: If the email belongs to a different provider.
+
         """
-        user = self._get_user_by_email(email)
+        user = self._get_user_by_provider(provider, provider_id)
+
+        if user is None:
+            # No account for this provider identity — fall back to email to
+            # link a provider-less legacy account, or create a new one.
+            existing = self._get_user_by_email(email)
+            if existing is not None:
+                if existing.auth_provider and existing.auth_provider != provider:
+                    # Account exists under a different provider. Refuse to
+                    # silently merge — this is the cross-provider takeover path.
+                    logger.warning(
+                        "OAuth login refused: email already linked to provider %s, not %s",
+                        existing.auth_provider,
+                        provider,
+                    )
+                    raise HTTPException(
+                        status_code=status.HTTP_409_CONFLICT,
+                        detail=(
+                            "This email is already registered with a different "
+                            f"sign-in provider ({existing.auth_provider}). "
+                            "Please sign in with that provider."
+                        ),
+                    )
+                user = existing
 
         if user:
-            # Existing user — update OAuth fields if not already set
-            if not user.auth_provider:
-                user.auth_provider = provider
-                user.auth_provider_id = provider_id
-            # Update name if it was empty
+            # Existing account — log in and bind/refresh the provider identity.
+            user.auth_provider = provider
+            user.auth_provider_id = provider_id
             if not user.full_name and full_name:
                 user.full_name = full_name
             user.is_verified = True
@@ -187,6 +215,17 @@ class AuthService:
     def _get_user_by_email(self, email: str) -> User | None:
         """Get user by email address."""
         return self.session.execute(select(User).where(User.email == email)).scalar_one_or_none()
+
+    def _get_user_by_provider(self, provider: str, provider_id: str) -> User | None:
+        """Get user by OAuth provider identity (the authoritative login key)."""
+        if not provider_id:
+            return None
+        return self.session.execute(
+            select(User).where(
+                User.auth_provider == provider,
+                User.auth_provider_id == provider_id,
+            )
+        ).scalar_one_or_none()
 
     def _get_user_by_id(self, user_id: int) -> User | None:
         """Get user by ID."""

--- a/backend/tests/unit/test_ai_chat.py
+++ b/backend/tests/unit/test_ai_chat.py
@@ -278,17 +278,19 @@ def test_app_bedrock_mode_enforces_daily_message_limit(
     assert mock_boto.converse.call_count == 2
 
 
-def test_byok_mode_is_not_subject_to_app_message_cap(
+def test_byok_bedrock_is_subject_to_app_message_cap(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """BYOK users pay their own key; the app cap shouldn't gate them."""
+    """BYOK+bedrock still spends the SERVER's Bedrock token (the proxy has no
+    per-user AWS key path), so the app-wide daily cap must apply to it too --
+    otherwise flipping to byok bypasses all cost control."""
     monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "fake-token")
     from ledger_sync.config.settings import settings
 
-    monkeypatch.setattr(settings, "ai_daily_message_limit", 1)
+    monkeypatch.setattr(settings, "ai_daily_message_limit", 2)
 
     app, session, user = _make_app()
-    _make_prefs(session, user, mode="byok")  # uses the prefs model
+    _make_prefs(session, user, mode="byok")  # byok + bedrock provider
     client = TestClient(app)
 
     fake = {"output": {"message": {"content": [{"text": "OK"}]}}}
@@ -296,13 +298,21 @@ def test_byok_mode_is_not_subject_to_app_message_cap(
     mock_boto.converse.return_value = fake
 
     with patch("boto3.client", return_value=mock_boto):
-        # Would hit the 1-message cap if it applied -- it doesn't.
-        for _ in range(3):
+        for _ in range(2):
             r = client.post(
                 "/api/ai/bedrock/chat",
                 json={"messages": [{"role": "user", "content": "hi"}]},
             )
             assert r.status_code == 200
+        # Third call exceeds the 2/day app cap and is blocked.
+        r = client.post(
+            "/api/ai/bedrock/chat",
+            json={"messages": [{"role": "user", "content": "hi"}]},
+        )
+        assert r.status_code == 429
+
+    # The cap blocked the third call before hitting AWS.
+    assert mock_boto.converse.call_count == 2
 
 
 def test_tool_use_and_tool_result_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/frontend/src/components/analytics/cashFlowUtils.ts
+++ b/frontend/src/components/analytics/cashFlowUtils.ts
@@ -3,6 +3,21 @@ export function formatMonth(v: string) {
   return d.toLocaleDateString('en-US', { month: 'short', year: '2-digit' })
 }
 
+/**
+ * Add `n` months to a `YYYY-MM` key using integer arithmetic.
+ *
+ * Date-based month math (new Date(key+'-01') is UTC, setMonth() is local,
+ * toISOString() is UTC again) skips or duplicates months for non-UTC users.
+ * Integer math on the year/month is timezone-independent.
+ */
+export function addMonths(yyyymm: string, n: number): string {
+  const [year, month] = yyyymm.split('-').map(Number)
+  const zeroBased = year * 12 + (month - 1) + n
+  const newYear = Math.floor(zeroBased / 12)
+  const newMonth = (zeroBased % 12) + 1
+  return `${newYear}-${String(newMonth).padStart(2, '0')}`
+}
+
 export function computeGrowthRate(series: Array<{ income: number; expense: number }>) {
   if (series.length <= 1) return { incomeGrowth: 0, expenseGrowth: 0 }
   const first = series[0]
@@ -82,16 +97,13 @@ export function buildForecast(monthlyData: MonthlyData): ForecastResult | null {
   const stdDev = Math.sqrt(variance)
 
   // Generate 6-month forecast
-  const lastDate = new Date(lastComplete.month + '-01')
   const offset = (last.month === currentMonth && isIncomplete) ? 0 : 1
   const forecast = []
   let projIncome = lastComplete.income
   let projExpense = lastComplete.expense
 
   for (let i = offset; i <= offset + 11; i++) {
-    const fd = new Date(lastDate)
-    fd.setMonth(fd.getMonth() + i)
-    const ms = fd.toISOString().slice(0, 7)
+    const ms = addMonths(lastComplete.month, i)
     projIncome = projIncome * (1 + incomeGrowth * 0.5)
     projExpense = projExpense * (1 + expenseGrowth * 0.5)
     const net = projIncome - projExpense

--- a/frontend/src/components/shared/AnalyticsTimeFilter.tsx
+++ b/frontend/src/components/shared/AnalyticsTimeFilter.tsx
@@ -6,6 +6,21 @@ import { ChevronLeft, ChevronRight } from 'lucide-react'
 export type { AnalyticsViewMode } from '@/lib/dateUtils'
 import { type AnalyticsViewMode, getFYFromDate } from '@/lib/dateUtils'
 
+/**
+ * Shift a `YYYY-MM` key by `delta` months using integer arithmetic.
+ *
+ * Date-based math (new Date(key+'-01') is UTC midnight, setMonth() is local,
+ * toISOString() is UTC) skips/sticks on months for non-UTC users. Integer math
+ * on year/month is timezone-independent.
+ */
+function shiftMonth(yyyymm: string, delta: number): string {
+  const [year, month] = yyyymm.split('-').map(Number)
+  const zeroBased = year * 12 + (month - 1) + delta
+  const newYear = Math.floor(zeroBased / 12)
+  const newMonth = (zeroBased % 12) + 1
+  return `${newYear}-${String(newMonth).padStart(2, '0')}`
+}
+
 interface AnalyticsTimeFilterProps {
   readonly viewMode: AnalyticsViewMode
   readonly onViewModeChange: (mode: AnalyticsViewMode) => void
@@ -129,9 +144,7 @@ export default function AnalyticsTimeFilter({
         onYearChange(currentYear - 1)
         break
       case 'monthly': {
-        const prevDate = new Date(currentMonth + '-01')
-        prevDate.setMonth(prevDate.getMonth() - 1)
-        onMonthChange(prevDate.toISOString().substring(0, 7))
+        onMonthChange(shiftMonth(currentMonth, -1))
         break
       }
       case 'fy': {
@@ -153,9 +166,7 @@ export default function AnalyticsTimeFilter({
         onYearChange(currentYear + 1)
         break
       case 'monthly': {
-        const nextDate = new Date(currentMonth + '-01')
-        nextDate.setMonth(nextDate.getMonth() + 1)
-        onMonthChange(nextDate.toISOString().substring(0, 7))
+        onMonthChange(shiftMonth(currentMonth, 1))
         break
       }
       case 'fy': {

--- a/frontend/src/hooks/useAnalyticsTimeFilter.ts
+++ b/frontend/src/hooks/useAnalyticsTimeFilter.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { usePreferences } from '@/hooks/api/usePreferences'
 import { usePreferencesStore } from '@/store/preferencesStore'
 import {
@@ -62,6 +62,29 @@ export function useAnalyticsTimeFilter(
   const [currentMonth, setCurrentMonth] = useState(getCurrentMonth())
   const [currentFY, setCurrentFY] = useState(getCurrentFY(fiscalYearStartMonth))
 
+  // The state above is seeded ONCE from defaults (fiscalYearStartMonth falls
+  // back to 4) before /api/preferences resolves. useState initializers never
+  // re-run, so a user with a non-April fiscal year would be stuck on the wrong
+  // FY window until they touched the selector. When preferences arrive, adjust
+  // the FY during render (React's "adjust state while rendering" pattern -- no
+  // effect, no cascading render) -- but only until the user interacts, so we
+  // never clobber a deliberate selection. All gates are state (not refs), so
+  // the adjustment is a pure function of the current render.
+  const [userInteracted, setUserInteracted] = useState(false)
+  const [syncedFsm, setSyncedFsm] = useState<number | null>(null)
+  if (preferences && !userInteracted && syncedFsm !== fiscalYearStartMonth) {
+    setSyncedFsm(fiscalYearStartMonth)
+    setCurrentFY(getCurrentFY(fiscalYearStartMonth))
+    if (!options?.defaultViewMode && displayPreferences.defaultTimeRange) {
+      setViewMode(displayPreferences.defaultTimeRange as AnalyticsViewMode)
+    }
+  }
+
+  const markInteracted = <T,>(setter: (v: T) => void) => (v: T) => {
+    setUserInteracted(true)
+    setter(v)
+  }
+
   const dateRange = useMemo(() => {
     const raw = getAnalyticsDateRange({
       viewMode,
@@ -100,13 +123,13 @@ export function useAnalyticsTimeFilter(
 
   const timeFilterProps = {
     viewMode,
-    onViewModeChange: setViewMode,
+    onViewModeChange: markInteracted(setViewMode),
     currentYear,
     currentMonth,
     currentFY,
-    onYearChange: setCurrentYear,
-    onMonthChange: setCurrentMonth,
-    onFYChange: setCurrentFY,
+    onYearChange: markInteracted(setCurrentYear),
+    onMonthChange: markInteracted(setCurrentMonth),
+    onFYChange: markInteracted(setCurrentFY),
     minDate: dataDateRange.minDate,
     maxDate: dataDateRange.maxDate,
     fiscalYearStartMonth,

--- a/frontend/src/lib/__tests__/fileParser.test.ts
+++ b/frontend/src/lib/__tests__/fileParser.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { COLUMN_MAPPINGS, REQUIRED_COLUMNS, VALID_TYPES } from '@/constants/columns'
+import { parseDate } from '@/lib/fileParser'
 
 /**
  * Tests for the fileParser module's helper logic.
@@ -58,6 +59,37 @@ describe('Valid transaction types', () => {
   it('should reject unknown types', () => {
     expect(VALID_TYPES.has('refund')).toBe(false)
     expect(VALID_TYPES.has('credit')).toBe(false)
+  })
+})
+
+describe('parseDate (timezone-stable)', () => {
+  it('returns an ISO date verbatim (no timezone shift)', () => {
+    expect(parseDate('2024-04-01', 1)).toBe('2024-04-01')
+  })
+
+  it('takes the date part of an ISO datetime', () => {
+    expect(parseDate('2024-01-15 00:00:00', 1)).toBe('2024-01-15')
+  })
+
+  it('reads numeric slash dates as DD/MM/YYYY (India convention)', () => {
+    expect(parseDate('05/06/2024', 1)).toBe('2024-06-05')
+  })
+
+  it('reads numeric dash dates as DD-MM-YYYY', () => {
+    expect(parseDate('01-04-2024', 1)).toBe('2024-04-01')
+  })
+
+  it('parses text-month dates without shifting the day', () => {
+    expect(parseDate('15-Mar-2024', 1)).toBe('2024-03-15')
+  })
+
+  it('parses an Excel serial number via the UTC epoch', () => {
+    // Serial 45383 = 2024-04-01.
+    expect(parseDate(45383, 1)).toBe('2024-04-01')
+  })
+
+  it('throws on an unparseable date', () => {
+    expect(() => parseDate('not-a-date', 7)).toThrow(/Row 7/)
   })
 })
 

--- a/frontend/src/lib/__tests__/taxCalculator.test.ts
+++ b/frontend/src/lib/__tests__/taxCalculator.test.ts
@@ -48,6 +48,33 @@ describe('calculateTax - Section 87A rebate', () => {
     const result = calculateTax(1_500_000, TAX_SLABS_NEW_FY2025, 75_000, false, 0, true, 2025)
     expect(result.rebate87A).toBe(0)
   })
+
+  it('applies 87A marginal relief just above the new-regime ceiling', () => {
+    // Taxable 12,10,000 (no SD). Ceiling 12L; income above = 10,000.
+    // Base tax at 12.1L is far more than 10k, so total tax must be capped at
+    // the 10k earned above the ceiling (+ cess), NOT the full slab tax.
+    const result = calculateTax(1_210_000, TAX_SLABS_NEW_FY2025, 0, false, 0, true, 2025)
+    const taxAfterRebate = result.tax - result.rebate87A
+    expect(taxAfterRebate).toBeCloseTo(10_000, 0)
+    expect(result.totalTax).toBeCloseTo(10_400, 0) // 10k + 4% cess
+  })
+})
+
+describe('calculateTax - surcharge marginal relief', () => {
+  it('caps tax just above the 50L surcharge threshold', () => {
+    // Taxable just over 50L: the surcharge cliff (~10% of base tax, ~115k) must
+    // be capped by marginal relief so the base+surcharge increase cannot exceed
+    // the 10,000 of extra income. 4% cess still applies on top, so total tax
+    // rises by ~10,400 -- NOT the ~115k cliff without relief.
+    const just = calculateTax(5_010_000, TAX_SLABS_NEW_FY2025, 0, false, 0, true, 2025)
+    const at = calculateTax(5_000_000, TAX_SLABS_NEW_FY2025, 0, false, 0, true, 2025)
+    // base + surcharge increase is capped at the extra income (10,000).
+    const baseSurchargeDelta =
+      just.tax - just.rebate87A + just.surcharge - (at.tax - at.rebate87A + at.surcharge)
+    expect(baseSurchargeDelta).toBeCloseTo(10_000, 0)
+    // total delta is that plus 4% cess on the increment.
+    expect(just.totalTax - at.totalTax).toBeLessThanOrEqual(10_500)
+  })
 })
 
 describe('calculateTax - surcharge (computed on base tax, not post-rebate)', () => {

--- a/frontend/src/lib/ageOfMoneyCalculator.ts
+++ b/frontend/src/lib/ageOfMoneyCalculator.ts
@@ -77,25 +77,35 @@ export function computeDaysOfBuffering(
   transactions: Array<{ type: string; amount: number; date: string }>,
   lookbackDays = 90,
 ): number | null {
+  const now = new Date()
   const cutoff = new Date()
   cutoff.setDate(cutoff.getDate() - lookbackDays)
   const cutoffStr = cutoff.toISOString().substring(0, 10)
 
   let totalSpending = 0
   const expenseDays = new Set<string>()
+  let earliest = ''
 
   for (const tx of transactions) {
     if (tx.type !== 'Expense') continue
     if (tx.date < cutoffStr) continue
     totalSpending += Math.abs(tx.amount)
     expenseDays.add(tx.date)
+    if (earliest === '' || tx.date < earliest) earliest = tx.date
   }
 
   const daysWithExpenses = expenseDays.size
   if (daysWithExpenses === 0 || totalSpending === 0) return null
 
-  // Average daily spending across the lookback period
-  const avgDailySpending = totalSpending / lookbackDays
+  // Divide by the span actually covered by data, not the full lookback window.
+  // For users with < lookbackDays of history, using the fixed window dilutes
+  // the burn rate across empty days and massively overstates runway.
+  const MS_PER_DAY = 86_400_000
+  const earliestDate = new Date(`${earliest}T00:00:00Z`)
+  const observedSpanDays = Math.floor((now.getTime() - earliestDate.getTime()) / MS_PER_DAY) + 1
+  const spanDays = Math.max(1, Math.min(lookbackDays, observedSpanDays))
+
+  const avgDailySpending = totalSpending / spanDays
   if (avgDailySpending <= 0) return null
 
   return Math.round(liquidBalance / avgDailySpending)

--- a/frontend/src/lib/chatAdapters.ts
+++ b/frontend/src/lib/chatAdapters.ts
@@ -143,10 +143,16 @@ function toOpenAIMessages(system: string, messages: ChatMessage[]): OpenAIMessag
   return out
 }
 
+// OpenAI reasoning models (o1/o3/o4...) reject `max_tokens` and require
+// `max_completion_tokens`. Match the leading "o<digit>" family.
+const OPENAI_REASONING_MODEL = /^o\d/i
+
 async function callOpenAI(params: SendParams): Promise<ChatResponse> {
+  const tokenLimit = 1024
+  const isReasoning = OPENAI_REASONING_MODEL.test(params.model)
   const body = {
     model: params.model,
-    max_tokens: 1024,
+    ...(isReasoning ? { max_completion_tokens: tokenLimit } : { max_tokens: tokenLimit }),
     messages: toOpenAIMessages(params.systemPrompt, params.messages),
     tools: params.tools?.map((t) => ({
       type: 'function' as const,

--- a/frontend/src/lib/exportCsv.ts
+++ b/frontend/src/lib/exportCsv.ts
@@ -1,5 +1,16 @@
+// Characters that make a spreadsheet treat a cell as a formula. A cell that
+// starts with one of these (from imported, user-controlled data) could execute
+// on open -- CSV/formula injection. Neutralize by prefixing a single quote.
+const FORMULA_TRIGGERS = ['=', '+', '-', '@', '\t', '\r']
+
 function escapeCsvValue(val: string | number): string {
-  const str = String(val)
+  let str = String(val)
+  if (str.length > 0 && FORMULA_TRIGGERS.includes(str[0])) {
+    // Prefix with a single quote so Excel/Sheets treat it as text, and force
+    // quoting so the leading apostrophe survives the CSV round-trip.
+    str = `'${str}`
+    return '"' + str.replaceAll('"', '""') + '"'
+  }
   if (str.includes(',') || str.includes('"') || str.includes('\n')) {
     return '"' + str.replaceAll('"', '""') + '"'
   }

--- a/frontend/src/lib/fileParser.ts
+++ b/frontend/src/lib/fileParser.ts
@@ -73,23 +73,59 @@ function resolveColumnMapping(headers: string[]): Record<string, string> {
   return mapping
 }
 
-function parseDate(value: unknown, rowIndex: number): string {
+function pad2(n: number): string {
+  return String(n).padStart(2, '0')
+}
+
+/**
+ * Parse a date cell into a timezone-stable `YYYY-MM-DD` string.
+ *
+ * Every branch builds the result from explicit calendar components (or a UTC
+ * epoch) so the stored day never shifts with the user's timezone. Using
+ * `new Date(str).toISOString()` is unsafe: most non-ISO formats parse as LOCAL
+ * midnight, and toISOString() then reprojects to UTC, shifting the day for any
+ * non-UTC user (e.g. all of India, UTC+5:30). It also avoids `new Date()`'s
+ * MM/DD assumption for ambiguous numeric dates -- this app is India-first, so
+ * slash/dash numeric dates are read as DD/MM/YYYY.
+ */
+export function parseDate(value: unknown, rowIndex: number): string {
   if (value == null || value === '') {
     throw new FileParseError(`Row ${rowIndex}: Date is missing`)
   }
 
   if (typeof value === 'number') {
-    // SheetJS Excel serial date number
+    // SheetJS Excel serial date number (UTC epoch -> UTC components).
     const date = new Date(EXCEL_EPOCH + value * MS_PER_DAY)
-    return date.toISOString().split('T')[0]
+    return `${date.getUTCFullYear()}-${pad2(date.getUTCMonth() + 1)}-${pad2(date.getUTCDate())}`
   }
 
   const str = stringify(value).trim()
+
+  // 1. ISO date (optionally with a time component) -> take the date part verbatim.
+  const isoMatch = /^(\d{4})-(\d{2})-(\d{2})/.exec(str)
+  if (isoMatch) {
+    return `${isoMatch[1]}-${isoMatch[2]}-${isoMatch[3]}`
+  }
+
+  // 2. Numeric day/month/year separated by / or - (India convention: DD/MM/YYYY).
+  const dmyMatch = /^(\d{1,2})[/-](\d{1,2})[/-](\d{4})$/.exec(str)
+  if (dmyMatch) {
+    const day = Number(dmyMatch[1])
+    const month = Number(dmyMatch[2])
+    const year = Number(dmyMatch[3])
+    if (month >= 1 && month <= 12 && day >= 1 && day <= 31) {
+      return `${year}-${pad2(month)}-${pad2(day)}`
+    }
+  }
+
+  // 3. Fallback (text months like "15-Mar-2024" / "Mar 15 2024"): these parse
+  // as LOCAL midnight, so read LOCAL components to recover the intended day
+  // (reading UTC here would shift the day back for positive-offset users).
   const parsed = new Date(str)
   if (Number.isNaN(parsed.getTime())) {
     throw new FileParseError(`Row ${rowIndex}: Could not parse date '${str}'`)
   }
-  return parsed.toISOString().split('T')[0]
+  return `${parsed.getFullYear()}-${pad2(parsed.getMonth() + 1)}-${pad2(parsed.getDate())}`
 }
 
 function parseAmount(value: unknown, rowIndex: number): number {

--- a/frontend/src/lib/financialHealthCalculator.ts
+++ b/frontend/src/lib/financialHealthCalculator.ts
@@ -212,12 +212,15 @@ export function computeCFPScore(params: {
     avgMonthlyDebt,
     cumulativeNetSavings,
     netInvestments,
+    totalDebtOutstanding,
   } = params
 
   // Liquid assets = net savings minus money locked in investments
   const liquidAssets = Math.max(0, cumulativeNetSavings - Math.max(0, netInvestments))
   const totalAssets = liquidAssets + Math.max(0, netInvestments)
-  const netWorth = liquidAssets + Math.max(0, netInvestments)
+  // Net worth must subtract outstanding debt; otherwise solvency is always
+  // 100% (netWorth === totalAssets) and debt has no effect on the score.
+  const netWorth = totalAssets - Math.max(0, totalDebtOutstanding)
 
   const ratios: CFPRatio[] = [
     computeSavingsRate(totalIncome, totalExpenses),

--- a/frontend/src/lib/projectionCalculator.ts
+++ b/frontend/src/lib/projectionCalculator.ts
@@ -38,11 +38,24 @@ function offsetFY(fy: string, offset: number): string {
   return `${startYear}-${twoDigitYear(startYear + 1)}`
 }
 
-/** Get the FY string a date falls into given a fiscal year start month. */
+/** Get the FY string a date falls into given a fiscal year start month.
+ *
+ * Parses YYYY-MM components directly: `new Date('2025-04-01')` is UTC midnight
+ * but getMonth()/getFullYear() return local components, shifting a 1st-of-month
+ * date into the prior month (wrong FY) for negative-offset users.
+ */
 function dateToFY(dateStr: string, fyStartMonth: number): string {
-  const d = new Date(dateStr)
-  const month = d.getMonth() + 1
-  const year = d.getFullYear()
+  const isoMatch = /^(\d{4})-(\d{2})/.exec(dateStr)
+  let year: number
+  let month: number
+  if (isoMatch) {
+    year = Number(isoMatch[1])
+    month = Number(isoMatch[2])
+  } else {
+    const d = new Date(dateStr)
+    year = d.getUTCFullYear()
+    month = d.getUTCMonth() + 1
+  }
   const fyStartYear = month >= fyStartMonth ? year : year - 1
   return `${fyStartYear}-${twoDigitYear(fyStartYear + 1)}`
 }

--- a/frontend/src/lib/taxCalculator.ts
+++ b/frontend/src/lib/taxCalculator.ts
@@ -95,18 +95,46 @@ export function getTaxSlabs(
 // Surcharge rates (applicable on base tax)
 // ────────────────────────────────────────────
 
+/** Sum slab tax for a given taxable income (no surcharge/cess/rebate). */
+function computeBaseTax(taxableIncome: number, slabs: TaxSlab[]): number {
+  let tax = 0
+  for (const slab of slabs) {
+    if (taxableIncome > slab.lower) {
+      tax += (Math.min(taxableIncome, slab.upper) - slab.lower) * (slab.rate / 100)
+    }
+  }
+  return tax
+}
+
 function computeSurcharge(
   taxableIncome: number,
   baseTax: number,
   isNewRegime: boolean,
   fyStartYear: number,
+  slabs: TaxSlab[],
 ): number {
   const cfg = getTaxConfig(fyStartYear)
   const rates = isNewRegime ? cfg.newRegime.surcharge : cfg.oldRegime.surcharge
-  for (const { above, rate } of rates) {
-    if (taxableIncome > above) return baseTax * rate
-  }
-  return 0
+  // rates are ordered high->low threshold; the first crossed is the highest
+  // applicable tier. The NEXT entry (lower threshold) is the previous tier.
+  const tierIdx = rates.findIndex((t) => taxableIncome > t.above)
+  if (tierIdx < 0) return 0
+
+  const tier = rates[tierIdx]
+  const surcharge = baseTax * tier.rate
+
+  // Marginal relief: total tax (base + surcharge) on income just above a
+  // threshold cannot exceed [tax payable AT the threshold] + [income above it].
+  // The tax at the threshold already includes the surcharge of the PREVIOUS
+  // (lower) tier (e.g. at exactly 1Cr the 50L-1Cr rate still applies), so use
+  // that rate, not zero. Without this cap a few rupees over a threshold trigger
+  // lakhs of extra tax.
+  const prevRate = tierIdx + 1 < rates.length ? rates[tierIdx + 1].rate : 0
+  const taxAtThreshold = computeBaseTax(tier.above, slabs)
+  const totalAtThreshold = taxAtThreshold * (1 + prevRate)
+  const incomeAboveThreshold = taxableIncome - tier.above
+  const reliefCappedSurcharge = totalAtThreshold + incomeAboveThreshold - baseTax
+  return Math.max(0, Math.min(surcharge, reliefCappedSurcharge))
 }
 
 // ────────────────────────────────────────────
@@ -173,14 +201,23 @@ export function calculateTax(
 
   const fyConfig = getTaxConfig(fyStartYear)
 
-  // 2. Surcharge on base tax
-  const surcharge = computeSurcharge(taxableIncome, baseTax, isNewRegime, fyStartYear)
+  // 2. Surcharge on base tax (with marginal relief at the thresholds)
+  const surcharge = computeSurcharge(taxableIncome, baseTax, isNewRegime, fyStartYear, slabs)
 
   // 3. Section 87A rebate on base tax
   const rebateConfig = getRebateConfig(isNewRegime, fyStartYear)
   let rebate87A = 0
   if (taxableIncome <= rebateConfig.maxIncome) {
     rebate87A = Math.min(baseTax, rebateConfig.maxRebate)
+  } else {
+    // Marginal relief on 87A (Budget 2025, new regime): just above the rebate
+    // ceiling, total tax cannot exceed the income earned above the ceiling.
+    // Without this the rebate drops to 0 at the cliff, over-taxing by tens of
+    // thousands for incomes a few rupees over the ceiling.
+    const incomeAboveCeiling = taxableIncome - rebateConfig.maxIncome
+    if (baseTax > incomeAboveCeiling) {
+      rebate87A = baseTax - incomeAboveCeiling
+    }
   }
   const taxAfterRebate = Math.max(0, baseTax - rebate87A)
 
@@ -219,8 +256,10 @@ export interface GrossFromNetOptions {
 /**
  * Reverse-calculate gross income from net income (after tax).
  *
- * Uses an iterative approach converging within `maxIterations` rounds,
- * stopping when the error is less than Rs 1.
+ * `net(gross) = gross - totalTax(gross)` is monotonically increasing in gross,
+ * so we bisect on gross. Bisection converges reliably even across the surcharge
+ * thresholds where the marginal slope is steep (the old fixed-point iteration
+ * could stall there and silently return a non-converged value).
  */
 export function calculateGrossFromNet(
   netIncome: number,
@@ -233,16 +272,14 @@ export function calculateGrossFromNet(
     standardDeduction = 0,
     applyProfessionalTax = true,
     salaryMonthsCount = 12,
-    maxIterations = 10,
+    maxIterations = 60,
     isNewRegime = true,
     fyStartYear = 2025,
   } = options
 
-  let grossIncome = netIncome
-
-  for (let i = 0; i < maxIterations; i++) {
+  const netFor = (gross: number): number => {
     const { totalTax } = calculateTax(
-      grossIncome,
+      gross,
       slabs,
       standardDeduction,
       applyProfessionalTax,
@@ -250,17 +287,31 @@ export function calculateGrossFromNet(
       isNewRegime,
       fyStartYear,
     )
-    const calculatedNet = grossIncome - totalTax
-
-    if (Math.abs(calculatedNet - netIncome) < 1) {
-      return grossIncome
-    }
-
-    const diff = netIncome - calculatedNet
-    grossIncome += diff
+    return gross - totalTax
   }
 
-  return grossIncome
+  // Bracket: net <= gross always, so gross is at least netIncome. Grow the
+  // upper bound until its net exceeds the target.
+  let lo = netIncome
+  let hi = netIncome * 2 + 1
+  while (netFor(hi) < netIncome) {
+    hi *= 2
+  }
+
+  for (let i = 0; i < maxIterations; i++) {
+    const mid = (lo + hi) / 2
+    const calculatedNet = netFor(mid)
+    if (Math.abs(calculatedNet - netIncome) < 1) {
+      return mid
+    }
+    if (calculatedNet < netIncome) {
+      lo = mid
+    } else {
+      hi = mid
+    }
+  }
+
+  return (lo + hi) / 2
 }
 
 // ────────────────────────────────────────────
@@ -277,9 +328,21 @@ export function getFYFromDate(
   date: string,
   fiscalYearStartMonth: number = FY_START_MONTH,
 ): string {
-  const d = new Date(date)
-  const year = d.getFullYear()
-  const month = d.getMonth() + 1 // 1-indexed
+  // Parse the YYYY-MM-DD components directly. `new Date('2025-04-01')` parses
+  // as UTC midnight but getFullYear()/getMonth() return LOCAL components, so a
+  // 1st-of-month date can read as the previous month (wrong FY) for negative-
+  // offset users. Reading the string avoids any timezone dependence.
+  const isoMatch = /^(\d{4})-(\d{2})-(\d{2})/.exec(date)
+  let year: number
+  let month: number
+  if (isoMatch) {
+    year = Number(isoMatch[1])
+    month = Number(isoMatch[2]) // 1-indexed
+  } else {
+    const d = new Date(date)
+    year = d.getUTCFullYear()
+    month = d.getUTCMonth() + 1
+  }
 
   if (month >= fiscalYearStartMonth) {
     return `FY ${year}-${(year + 1).toString().slice(-2)}`

--- a/frontend/src/lib/tdsScheduleCalculator.ts
+++ b/frontend/src/lib/tdsScheduleCalculator.ts
@@ -81,9 +81,19 @@ export function rsuExtrasByFyMonth(
   const out: Record<number, number> = {}
   for (const grant of grants) {
     for (const v of grant.vestings) {
-      const d = new Date(v.date)
-      const m = d.getMonth() + 1 // 1-12
-      const y = d.getFullYear()
+      // Parse YYYY-MM directly: new Date(iso) reads local components and can
+      // shift a 1st-of-month vesting into the prior month/FY off-UTC.
+      const isoMatch = /^(\d{4})-(\d{2})/.exec(v.date)
+      let m: number
+      let y: number
+      if (isoMatch) {
+        y = Number(isoMatch[1])
+        m = Number(isoMatch[2]) // 1-12
+      } else {
+        const d = new Date(v.date)
+        y = d.getUTCFullYear()
+        m = d.getUTCMonth() + 1
+      }
       // Which FY does this vesting belong to?
       const vestingFyStart = m >= fyStartMonth ? y : y - 1
       if (vestingFyStart !== fyStartYear) continue

--- a/frontend/src/pages/goals/components/EditGoalForm.tsx
+++ b/frontend/src/pages/goals/components/EditGoalForm.tsx
@@ -18,7 +18,7 @@ export default function EditGoalForm({
 }>) {
   const [name, setName] = useState(goal.name)
   const [targetAmount, setTargetAmount] = useState(String(goal.target_amount))
-  const [targetDate, setTargetDate] = useState(goal.target_date.slice(0, 10))
+  const [targetDate, setTargetDate] = useState(goal.target_date?.slice(0, 10) ?? '')
 
   const handleSave = () => {
     if (!name.trim()) {

--- a/frontend/src/pages/goals/components/GoalProjections.tsx
+++ b/frontend/src/pages/goals/components/GoalProjections.tsx
@@ -15,7 +15,7 @@ export default function GoalProjections({
   projection,
   avgMonthlySavings,
 }: Readonly<{
-  goal: { target_date: string }
+  goal: { target_date: string | null }
   projection: GoalProjection
   avgMonthlySavings: number | null
 }>) {
@@ -42,7 +42,7 @@ export default function GoalProjections({
       <div className="flex items-center gap-2 text-xs text-text-secondary">
         <Calendar className="w-3.5 h-3.5 flex-shrink-0" style={{ color: rawColors.app.teal }} />
         <span>
-          Target: {new Date(goal.target_date).toLocaleDateString('en-US', { month: 'short', year: 'numeric' })}
+          Target: {goal.target_date ? new Date(goal.target_date).toLocaleDateString('en-US', { month: 'short', year: 'numeric' }) : 'No deadline'}
           {projection.monthsRemaining > 0 && (
             <span className="text-text-tertiary"> ({Math.ceil(projection.monthsRemaining)} months left)</span>
           )}

--- a/frontend/src/pages/goals/helpers.ts
+++ b/frontend/src/pages/goals/helpers.ts
@@ -41,13 +41,14 @@ export function formatMonthYear(date: Date): string {
 /** Determine the tracking status for a projected date vs. target date. */
 function resolveTrackingStatus(
   projected: Date,
-  target: Date,
+  target: Date | null,
   monthsRemaining: number,
 ): Pick<GoalProjection, 'status' | 'statusLabel' | 'statusColor' | 'monthsDelta'> {
   const projectedMonths = differenceInMonths(projected, new Date())
   const monthsDelta = monthsRemaining - projectedMonths // positive = ahead
 
-  if (projected <= target) {
+  // No deadline -> nothing to be behind on.
+  if (!target || projected <= target) {
     return { status: 'on_track', statusLabel: 'On Track', statusColor: rawColors.app.green, monthsDelta }
   }
   const monthsBehind = differenceInMonths(projected, target)
@@ -64,8 +65,11 @@ export function computeGoalProjection(
   avgMonthlySavings: number | null,
   now: Date,
 ): GoalProjection {
-  const targetDate = new Date(goal.target_date)
-  const monthsRemaining = Math.max(0, differenceInMonths(targetDate, now))
+  // target_date is nullable (goals can be open-ended). With no deadline there
+  // is no time pressure, so treat months-remaining as 0 (the required-savings
+  // branch below guards against divide-by-zero).
+  const targetDate = goal.target_date ? new Date(goal.target_date) : null
+  const monthsRemaining = targetDate ? Math.max(0, differenceInMonths(targetDate, now)) : 0
 
   if (currentAmount >= goal.target_amount) {
     return {

--- a/frontend/src/pages/goals/useGoalsState.ts
+++ b/frontend/src/pages/goals/useGoalsState.ts
@@ -88,7 +88,10 @@ export default function useGoalsState() {
       const bAchieved = b.is_achieved || (effectiveAmounts[b.id] ?? 0) >= b.target_amount
       if (aAchieved && !bAchieved) return 1
       if (!aAchieved && bAchieved) return -1
-      return new Date(a.target_date).getTime() - new Date(b.target_date).getTime()
+      // Dateless goals (null target_date) sort last instead of becoming NaN.
+      const aTime = a.target_date ? new Date(a.target_date).getTime() : Infinity
+      const bTime = b.target_date ? new Date(b.target_date).getTime() : Infinity
+      return aTime - bTime
     })
   }, [goals, effectiveAmounts])
 

--- a/frontend/src/pages/settings/sections/AIAssistantSection.tsx
+++ b/frontend/src/pages/settings/sections/AIAssistantSection.tsx
@@ -136,10 +136,13 @@ export default function AIAssistantSection({ index }: Readonly<Props>) {
           Authorization: `Bearer ${apiKey}`,
           'Content-Type': 'application/json',
         }
+        // o-series reasoning models reject max_tokens; they need
+        // max_completion_tokens (and reasoning eats tokens, so allow more).
+        const isReasoning = /^o\d/i.test(model)
         body = JSON.stringify({
           model,
           messages: [{ role: 'user', content: testPrompt }],
-          max_tokens: 5,
+          ...(isReasoning ? { max_completion_tokens: 16 } : { max_tokens: 5 }),
         })
       } else if (provider === 'anthropic') {
         url = 'https://api.anthropic.com/v1/messages'

--- a/frontend/src/pages/settings/sections/salary/fyHelpers.ts
+++ b/frontend/src/pages/settings/sections/salary/fyHelpers.ts
@@ -20,10 +20,20 @@ export function nextFY(fy: string): string {
 }
 
 export function dateToFY(dateStr: string): string {
-  const d = new Date(dateStr)
-  if (Number.isNaN(d.getTime())) return ''
-  const month = d.getMonth() + 1
-  const year = d.getFullYear()
+  // Parse YYYY-MM directly so a 1st-of-month date isn't shifted into the prior
+  // month/FY off-UTC (new Date(iso) is UTC midnight but getMonth() is local).
+  const isoMatch = /^(\d{4})-(\d{2})/.exec(dateStr)
+  let month: number
+  let year: number
+  if (isoMatch) {
+    year = Number(isoMatch[1])
+    month = Number(isoMatch[2])
+  } else {
+    const d = new Date(dateStr)
+    if (Number.isNaN(d.getTime())) return ''
+    month = d.getUTCMonth() + 1
+    year = d.getUTCFullYear()
+  }
   const fyStartYear = month >= FY_START_MONTH ? year : year - 1
   const endYear = (fyStartYear + 1) % 100
   return `${fyStartYear}-${String(endYear).padStart(2, '0')}`

--- a/frontend/src/services/api/analyticsV2.ts
+++ b/frontend/src/services/api/analyticsV2.ts
@@ -202,7 +202,7 @@ export interface FinancialGoal {
   current_amount: number
   progress_pct: number
   start_date: string
-  target_date: string
+  target_date: string | null
   is_achieved: boolean
   achieved_date: string | null
   notes: string | null


### PR DESCRIPTION
## What

Resolves 24 bugs from a deep multi-agent audit, each adversarially verified before fixing. Spans backend (Python/FastAPI) and frontend (React/TS).

### Security / auth
- OAuth identity keyed on `(provider, provider_id)`, not raw email; refuse silent cross-provider linking; enforce Google `verified_email`; unique constraint + migration
- OAuth CSRF state is now stateless HMAC-signed (survives serverless cold starts, unforgeable)
- AI daily cap applies to BYOK+Bedrock (shared server token no longer bypassable)
- rate-limit handler returns 429 (shared limiter attached to `app.state`)
- CSV export neutralizes formula-injection prefixes; HTML report escapes user category names

### Correctness
- timezone-stable + DD/MM-aware date parsing; UTC-safe FY classification across tax/projection/tds/fyHelpers
- income-tax surcharge + 87A marginal relief; gross-from-net via bisection
- solvency ratio subtracts debt; net-worth % divides by `abs(prev)`
- `tax_paid` matches whole-word "tax"; spending-velocity off-by-one
- integer YYYY-MM month math (cash-flow forecast + time-filter nav)
- days-of-buffering divides by actual data span; OpenAI reasoning models use `max_completion_tokens`

### Robustness
- upload tolerates analytics-recompute DB timeout (`OperationalError`)
- AI list tools capped; search count honors all filters
- analytics filter re-syncs once preferences load
- `FinancialGoal.target_date` typed nullable with guards

## Testing
- Backend: 214 pytest pass, ruff + mypy clean
- Frontend: 224 vitest pass (9 new tests), tsc + eslint clean
- DB migration verified on fresh SQLite + ORM metadata

## Notes
- The migration adds a unique constraint on `(auth_provider, auth_provider_id)`; assumes no existing prod rows violate it (real OAuth IDs are unique).
- OAuth CSRF fix is the deploy-safe half (stateless signed state); full PKCE browser-binding is a follow-up needing a frontend + CORS-credentials change.