### PR TITLE
fix(uiux): 20 static-audit findings — a11y, empty states, write-action safety, tokens

### DIFF
--- a/frontend/src/components/analytics/CashFlowForecast.tsx
+++ b/frontend/src/components/analytics/CashFlowForecast.tsx
@@ -39,10 +39,10 @@ export default function CashFlowForecast() {
       <div className="glass rounded-2xl p-6">
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center gap-3">
-            <div className={`p-3 rounded-xl ${insights.trend === 'positive' ? 'bg-green-500/10' : 'bg-red-500/10'}`}>
+            <div className={`p-3 rounded-xl ${insights.trend === 'positive' ? 'bg-app-green/10' : 'bg-app-red/10'}`}>
               {insights.trend === 'positive'
-                ? <TrendingUp className="w-6 h-6 text-green-400" />
-                : <TrendingDown className="w-6 h-6 text-red-400" />}
+                ? <TrendingUp className="w-6 h-6 text-app-green" />
+                : <TrendingDown className="w-6 h-6 text-app-red" />}
             </div>
             <div>
               <h3 className="text-lg font-semibold text-white">Future Cash Flow Forecast</h3>
@@ -135,21 +135,21 @@ export default function CashFlowForecast() {
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-4">
         <div className="bg-white/[0.04] border border-border rounded-xl p-4">
           <p className="text-[10px] font-semibold uppercase tracking-widest text-text-quaternary mb-1">Avg Monthly Income</p>
-          <p className="text-xl font-bold text-green-400">{formatCurrencyShort(insights.avgIncome)}</p>
+          <p className="text-xl font-bold text-app-green">{formatCurrencyShort(insights.avgIncome)}</p>
           <p className="text-xs text-text-tertiary mt-1">
             {insights.incomeGrowth >= 0 ? '↑' : '↓'} {Math.abs(insights.incomeGrowth).toFixed(1)}% monthly trend
           </p>
         </div>
         <div className="bg-white/[0.04] border border-border rounded-xl p-4">
           <p className="text-[10px] font-semibold uppercase tracking-widest text-text-quaternary mb-1">Avg Monthly Expenses</p>
-          <p className="text-xl font-bold text-red-400">{formatCurrencyShort(insights.avgExpense)}</p>
+          <p className="text-xl font-bold text-app-red">{formatCurrencyShort(insights.avgExpense)}</p>
           <p className="text-xs text-text-tertiary mt-1">
             {insights.expenseGrowth >= 0 ? '↑' : '↓'} {Math.abs(insights.expenseGrowth).toFixed(1)}% monthly trend
           </p>
         </div>
         <div className="bg-white/[0.04] border border-border rounded-xl p-4">
           <p className="text-[10px] font-semibold uppercase tracking-widest text-text-quaternary mb-1">1-Year Projected Savings</p>
-          <p className={`text-xl font-bold ${insights.projectedSavings >= 0 ? 'text-blue-400' : 'text-red-400'}`}>
+          <p className={`text-xl font-bold ${insights.projectedSavings >= 0 ? 'text-app-blue' : 'text-app-red'}`}>
             {insights.projectedSavings >= 0 ? '+' : ''}{formatCurrencyShort(insights.projectedSavings)}
           </p>
           <p className="text-xs text-text-tertiary mt-1">Based on current trends</p>

--- a/frontend/src/components/analytics/TaxSummaryCards.tsx
+++ b/frontend/src/components/analytics/TaxSummaryCards.tsx
@@ -20,8 +20,8 @@ function YoyBadge({ current, previous }: Readonly<{ current: number; previous: n
 
   const isUp = pct >= 0
   const Icon = isUp ? TrendingUp : TrendingDown
-  const color = isUp ? 'text-app-green' : 'text-red-400'
-  const bg = isUp ? 'bg-app-green/10' : 'bg-red-400/10'
+  const color = isUp ? 'text-app-green' : 'text-app-red'
+  const bg = isUp ? 'bg-app-green/10' : 'bg-app-red/10'
 
   return (
     <span className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md text-overline font-medium ${color} ${bg}`}>

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -133,6 +133,7 @@ export default function ChatPanel({
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="Ask about your finances..."
+            aria-label="Ask about your finances"
             rows={1}
             className="flex-1 resize-none bg-white/5 border border-border rounded-xl px-3 py-2 text-sm text-white placeholder:text-muted-foreground focus:outline-none focus:border-primary transition-colors"
           />

--- a/frontend/src/components/layout/Sidebar/CurrencySwitcher.tsx
+++ b/frontend/src/components/layout/Sidebar/CurrencySwitcher.tsx
@@ -71,6 +71,9 @@ export default function CurrencySwitcher() {
             : 'text-text-tertiary hover:text-white hover:bg-white/[0.06]',
         )}
         title={`Display currency: ${displayCurrency}`}
+        aria-label={`Change display currency (currently ${displayCurrency})`}
+        aria-haspopup="listbox"
+        aria-expanded={open}
       >
         <span>{displayCurrency}</span>
         <ChevronDown size={12} />

--- a/frontend/src/components/layout/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar/Sidebar.tsx
@@ -320,6 +320,7 @@ export default function Sidebar() {
                   onClick={closeMobile}
                   className="w-11 h-11 lg:w-9 lg:h-9 flex items-center justify-center rounded-lg text-text-tertiary hover:text-white hover:bg-white/[0.06] transition-colors duration-150"
                   title={item.label}
+                  aria-label={item.label}
                 >
                   <item.icon size={18} />
                 </Link>
@@ -330,6 +331,7 @@ export default function Sidebar() {
                   onClick={() => exitDemoMode(queryClient, navigate)}
                   className="w-11 h-11 lg:w-9 lg:h-9 flex items-center justify-center rounded-lg text-text-tertiary hover:text-red-400 hover:bg-red-500/10 transition-colors duration-150"
                   title="Exit Demo"
+                  aria-label="Exit Demo"
                 >
                   <LogOut size={18} />
                 </button>
@@ -340,6 +342,7 @@ export default function Sidebar() {
                   disabled={logout.isPending}
                   className="w-11 h-11 lg:w-9 lg:h-9 flex items-center justify-center rounded-lg text-text-tertiary hover:text-red-400 hover:bg-red-500/10 transition-colors duration-150 disabled:opacity-50"
                   title="Sign out"
+                  aria-label="Sign out"
                 >
                   <LogOut size={18} />
                 </button>

--- a/frontend/src/components/shared/AuthModal.tsx
+++ b/frontend/src/components/shared/AuthModal.tsx
@@ -82,11 +82,15 @@ export function AuthModal({ isOpen, onClose }: Readonly<AuthModalProps>) {
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             onClick={onClose}
+            aria-hidden="true"
             className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50"
           />
 
           {/* Modal */}
           <motion.div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="auth-modal-title"
             initial={{ opacity: 0, scale: 0.95, y: 20 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.95, y: 20 }}
@@ -97,6 +101,7 @@ export function AuthModal({ isOpen, onClose }: Readonly<AuthModalProps>) {
               {/* Close Button */}
               <button
                 onClick={onClose}
+                aria-label="Close sign-in dialog"
                 className="absolute top-4 right-4 p-2 rounded-lg text-text-tertiary hover:text-white hover:bg-white/[0.06] transition-colors duration-150 ease-out"
               >
                 <X className="w-5 h-5" />
@@ -107,7 +112,7 @@ export function AuthModal({ isOpen, onClose }: Readonly<AuthModalProps>) {
                 <div className="p-3 rounded-xl bg-blue-500/10 mb-3">
                   <PiggyBank className="w-8 h-8 text-blue-400" />
                 </div>
-                <h2 className="text-xl font-semibold text-white">
+                <h2 id="auth-modal-title" className="text-xl font-semibold text-white">
                   Welcome to Ledger Sync
                 </h2>
                 <p className="text-muted-foreground text-sm mt-1">

--- a/frontend/src/components/shared/ProfileModal.tsx
+++ b/frontend/src/components/shared/ProfileModal.tsx
@@ -133,6 +133,9 @@ function ProfileModalContent({ onClose }: Readonly<{ onClose: () => void }>) {
       onClick={handleClose}
     >
       <motion.div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Profile and account settings"
         initial={{ opacity: 0, scale: 0.95 }}
         animate={{ opacity: 1, scale: 1 }}
         exit={{ opacity: 0, scale: 0.95 }}

--- a/frontend/src/components/transactions/TransactionFilters.tsx
+++ b/frontend/src/components/transactions/TransactionFilters.tsx
@@ -202,11 +202,12 @@ export default function TransactionFilters({ onFilterChange, categories, account
 
               {/* Start Date */}
               <div className="space-y-2">
-                <label className="text-sm font-medium text-muted-foreground flex items-center gap-1">
+                <label htmlFor="filter-start-date" className="text-sm font-medium text-muted-foreground flex items-center gap-1">
                   <Calendar className="w-3 h-3" />
                   Start Date
                 </label>
                 <input
+                  id="filter-start-date"
                   type="date"
                   value={filters.start_date || ''}
                   onChange={(e) => handleFilterChange('start_date', e.target.value)}
@@ -216,11 +217,12 @@ export default function TransactionFilters({ onFilterChange, categories, account
 
               {/* End Date */}
               <div className="space-y-2">
-                <label className="text-sm font-medium text-muted-foreground flex items-center gap-1">
+                <label htmlFor="filter-end-date" className="text-sm font-medium text-muted-foreground flex items-center gap-1">
                   <Calendar className="w-3 h-3" />
                   End Date
                 </label>
                 <input
+                  id="filter-end-date"
                   type="date"
                   value={filters.end_date || ''}
                   onChange={(e) => handleFilterChange('end_date', e.target.value)}
@@ -230,8 +232,9 @@ export default function TransactionFilters({ onFilterChange, categories, account
 
               {/* Min Amount */}
               <div className="space-y-2">
-                <label className="text-sm font-medium text-muted-foreground">Min Amount ({currencySymbol})</label>
+                <label htmlFor="filter-min-amount" className="text-sm font-medium text-muted-foreground">Min Amount ({currencySymbol})</label>
                 <input
+                  id="filter-min-amount"
                   type="number"
                   inputMode="decimal"
                   placeholder="0"
@@ -243,8 +246,9 @@ export default function TransactionFilters({ onFilterChange, categories, account
 
               {/* Max Amount */}
               <div className="space-y-2">
-                <label className="text-sm font-medium text-muted-foreground">Max Amount ({currencySymbol})</label>
+                <label htmlFor="filter-max-amount" className="text-sm font-medium text-muted-foreground">Max Amount ({currencySymbol})</label>
                 <input
+                  id="filter-max-amount"
                   type="number"
                   inputMode="decimal"
                   placeholder="∞"

--- a/frontend/src/components/ui/ConfirmDialog.tsx
+++ b/frontend/src/components/ui/ConfirmDialog.tsx
@@ -58,6 +58,10 @@ export default function ConfirmDialog({
           onClick={handleClose}
         >
           <motion.div
+            role="alertdialog"
+            aria-modal="true"
+            aria-labelledby="confirm-dialog-title"
+            aria-describedby="confirm-dialog-desc"
             initial={{ opacity: 0, scale: 0.95, y: 10 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.95, y: 10 }}
@@ -65,8 +69,8 @@ export default function ConfirmDialog({
             className="bg-[#1a1a1c] rounded-2xl border border-white/[0.08] p-6 max-w-md w-full shadow-2xl"
             onClick={(e) => e.stopPropagation()}
           >
-            <h3 className="text-lg font-semibold text-white mb-2">{title}</h3>
-            <p className="text-sm text-muted-foreground mb-6">{description}</p>
+            <h3 id="confirm-dialog-title" className="text-lg font-semibold text-white mb-2">{title}</h3>
+            <p id="confirm-dialog-desc" className="text-sm text-muted-foreground mb-6">{description}</p>
             <div className="flex justify-end gap-3">
               <button
                 type="button"

--- a/frontend/src/constants/colors.ts
+++ b/frontend/src/constants/colors.ts
@@ -126,7 +126,7 @@ function buildRawColors() {
     text: {
       primary:    r('--color-text-primary',    '#f5f5f7'),
       secondary:  r('--color-text-secondary',  '#8e8e93'),
-      tertiary:   r('--color-text-tertiary',   '#636366'),
+      tertiary:   r('--color-text-tertiary',   '#7c7c80'),
       quaternary: r('--color-text-quaternary', '#48484a'),
     },
   }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -76,7 +76,7 @@
   /* ===== TEXT COLORS ===== */
   --color-text-primary: #f5f5f7;
   --color-text-secondary: #8e8e93;
-  --color-text-tertiary: #636366;
+  --color-text-tertiary: #7c7c80;
   --color-text-quaternary: #48484a;
 
   /* ===== DISABLED STATE ===== */

--- a/frontend/src/pages/bill-calendar/useBillCalendar.ts
+++ b/frontend/src/pages/bill-calendar/useBillCalendar.ts
@@ -39,9 +39,12 @@ export function useBillCalendar() {
   }
 
   const goToToday = () => {
+    // Read a fresh date at click time — `now` is captured at mount and would
+    // be stale if the tab has been open across a day boundary.
+    const today = new Date()
     setSelectedDay(null)
-    setViewYear(now.getFullYear())
-    setViewMonth(now.getMonth())
+    setViewYear(today.getFullYear())
+    setViewMonth(today.getMonth())
   }
 
   const billMap = useMemo(

--- a/frontend/src/pages/budget/components/AddBudgetForm.tsx
+++ b/frontend/src/pages/budget/components/AddBudgetForm.tsx
@@ -143,6 +143,8 @@ export function AddBudgetForm(props: Readonly<AddBudgetFormProps>) {
                 id="budget-limit"
                 type="number"
                 inputMode="decimal"
+                min="0"
+                step="any"
                 value={formLimit}
                 onChange={(e) => setFormLimit(e.target.value)}
                 placeholder="Amount"

--- a/frontend/src/pages/budget/useBudget.ts
+++ b/frontend/src/pages/budget/useBudget.ts
@@ -1,5 +1,7 @@
 import { useCallback, useMemo, useState } from 'react'
 
+import { toast } from 'sonner'
+
 import { useCategoryBreakdown } from '@/hooks/api/useAnalytics'
 import { usePreferences } from '@/hooks/api/usePreferences'
 import { useTransactions } from '@/hooks/api/useTransactions'
@@ -227,13 +229,17 @@ export function useBudget() {
       viewMode === 'subcategory' && formSubcategory
         ? `${formCategory}::${formSubcategory}`
         : formCategory
-    if (key && formLimit) {
-      setBudget(key, Number.parseFloat(formLimit), budgetPeriod)
-      setFormCategory('')
-      setFormSubcategory('')
-      setFormLimit('')
-      setIsAdding(false)
+    if (!key || !formLimit) return
+    const limit = Number.parseFloat(formLimit)
+    if (!Number.isFinite(limit) || limit <= 0) {
+      toast.error('Enter a budget limit greater than 0')
+      return
     }
+    setBudget(key, limit, budgetPeriod)
+    setFormCategory('')
+    setFormSubcategory('')
+    setFormLimit('')
+    setIsAdding(false)
   }, [formCategory, formSubcategory, formLimit, viewMode, budgetPeriod, setBudget])
 
   const handleQuickAdd = useCallback(

--- a/frontend/src/pages/goals/components/CreateGoalForm.tsx
+++ b/frontend/src/pages/goals/components/CreateGoalForm.tsx
@@ -35,12 +35,14 @@ export default function CreateGoalForm({
           <input
             type="text"
             placeholder="Goal name *"
+            aria-label="Goal name"
             value={formData.name}
             onChange={(e) => onFormDataChange({ ...formData, name: e.target.value })}
             className="px-4 py-2.5 bg-surface-dropdown/80 border border-border rounded-xl text-sm text-foreground focus:outline-none focus:border-app-purple/50"
           />
           <select
             value={formData.goal_type}
+            aria-label="Goal type"
             onChange={(e) => onFormDataChange({ ...formData, goal_type: e.target.value })}
             className="px-4 py-2.5 bg-surface-dropdown/80 border border-border rounded-xl text-sm text-foreground focus:outline-none focus:border-app-purple/50"
           >
@@ -54,13 +56,16 @@ export default function CreateGoalForm({
           <input
             type="number"
             inputMode="decimal"
+            min="0"
             placeholder="Target amount *"
+            aria-label="Target amount"
             value={formData.target_amount}
             onChange={(e) => onFormDataChange({ ...formData, target_amount: e.target.value })}
             className="px-4 py-2.5 bg-surface-dropdown/80 border border-border rounded-xl text-sm text-foreground focus:outline-none focus:border-app-purple/50"
           />
           <input
             type="date"
+            aria-label="Target date"
             value={formData.target_date}
             onChange={(e) => onFormDataChange({ ...formData, target_date: e.target.value })}
             className="px-4 py-2.5 bg-surface-dropdown/80 border border-border rounded-xl text-sm text-foreground focus:outline-none focus:border-app-purple/50"
@@ -69,6 +74,7 @@ export default function CreateGoalForm({
         <input
           type="text"
           placeholder="Notes (optional)"
+          aria-label="Notes"
           value={formData.notes}
           onChange={(e) => onFormDataChange({ ...formData, notes: e.target.value })}
           className="w-full px-4 py-2.5 bg-surface-dropdown/80 border border-border rounded-xl text-sm text-foreground focus:outline-none focus:border-app-purple/50"

--- a/frontend/src/pages/goals/components/GoalCard.tsx
+++ b/frontend/src/pages/goals/components/GoalCard.tsx
@@ -1,7 +1,9 @@
+import { useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Pencil, Trash2, Edit3 } from 'lucide-react'
 import type { FinancialGoal } from '@/hooks/api/useAnalyticsV2'
 import { formatCurrency, formatCurrencyCompact } from '@/lib/formatters'
+import ConfirmDialog from '@/components/ui/ConfirmDialog'
 import { GOAL_TYPE_COLORS, GOAL_TYPE_LABELS } from '../constants'
 import type { GoalProjection } from '../types'
 import CircularProgress from './CircularProgress'
@@ -36,6 +38,7 @@ export default function GoalCard({
   onCancelEdit: () => void
   onDelete: (goalId: number) => void
 }>) {
+  const [confirmDelete, setConfirmDelete] = useState(false)
   const color = GOAL_TYPE_COLORS[goal.goal_type]
   const progressPct = goal.target_amount > 0 ? (effectiveAmount / goal.target_amount) * 100 : 0
   const remaining = Math.max(0, goal.target_amount - effectiveAmount)
@@ -60,8 +63,9 @@ export default function GoalCard({
                 <Edit3 className="w-3.5 h-3.5" />
               </button>
               <button
-                onClick={() => onDelete(goal.id)}
+                onClick={() => setConfirmDelete(true)}
                 title="Delete goal"
+                aria-label={`Delete goal: ${goal.name}`}
                 className="p-1.5 rounded-lg text-text-tertiary hover:text-app-red hover:bg-red-500/10 transition-colors"
               >
                 <Trash2 className="w-3.5 h-3.5" />
@@ -149,6 +153,16 @@ export default function GoalCard({
           />
         )}
       </AnimatePresence>
+
+      <ConfirmDialog
+        open={confirmDelete}
+        onOpenChange={setConfirmDelete}
+        title="Delete this goal?"
+        description={`"${goal.name}" will be permanently removed. This can't be undone.`}
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={() => onDelete(goal.id)}
+      />
     </motion.div>
   )
 }

--- a/frontend/src/pages/investment-analytics/InvestmentAnalyticsPage.tsx
+++ b/frontend/src/pages/investment-analytics/InvestmentAnalyticsPage.tsx
@@ -1,6 +1,7 @@
-import { motion } from 'framer-motion'
+import { TrendingUp } from 'lucide-react'
 
 import AnalyticsTimeFilter from '@/components/shared/AnalyticsTimeFilter'
+import EmptyState from '@/components/shared/EmptyState'
 import { PageSkeleton } from '@/components/shared/LoadingSkeleton'
 import { PageHeader } from '@/components/ui'
 
@@ -13,6 +14,8 @@ import { useInvestmentAnalytics } from './useInvestmentAnalytics'
 export default function InvestmentAnalyticsPage() {
   const m = useInvestmentAnalytics()
 
+  if (m.isLoading) return <PageSkeleton />
+
   if (m.totalInvestmentValue === 0) {
     return (
       <div className="min-h-screen p-4 md:p-6 lg:p-8">
@@ -21,27 +24,18 @@ export default function InvestmentAnalyticsPage() {
             title="Investment Analytics"
             subtitle="Monitor your investment portfolio performance"
           />
-
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            className="glass rounded-2xl border border-border p-4 md:p-6 lg:p-8 text-center"
-          >
-            <p className="text-muted-foreground mb-4">No investment accounts classified yet.</p>
-            <p className="text-sm text-muted-foreground">
-              Go to{' '}
-              <a href="/settings" className="text-primary hover:underline">
-                Settings
-              </a>{' '}
-              to classify your accounts as Investments.
-            </p>
-          </motion.div>
+          <EmptyState
+            icon={TrendingUp}
+            title="No investment accounts classified"
+            description="Classify your accounts as Investments in Settings to track portfolio value, allocation, and growth over time."
+            actionLabel="Go to Settings"
+            actionHref="/settings"
+            variant="card"
+          />
         </div>
       </div>
     )
   }
-
-  if (m.isLoading) return <PageSkeleton />
 
   return (
     <div className="min-h-screen p-4 md:p-6 lg:p-8">

--- a/frontend/src/pages/investment-analytics/components/AccountsTable.tsx
+++ b/frontend/src/pages/investment-analytics/components/AccountsTable.tsx
@@ -67,7 +67,7 @@ export function AccountsTable({
           <tbody>
             {sortedPortfolioData.map((item, index) => (
               <motion.tr
-                key={`${item.name}-${index}`}
+                key={item.name}
                 className="border-b border-border hover:bg-white/10 transition-colors"
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}

--- a/frontend/src/pages/year-in-review/YearInReviewPage.tsx
+++ b/frontend/src/pages/year-in-review/YearInReviewPage.tsx
@@ -36,6 +36,7 @@ import {
   BAR_RADIUS,
 } from '@/components/ui'
 import ChartEmptyState from '@/components/shared/ChartEmptyState'
+import EmptyState from '@/components/shared/EmptyState'
 import AnalyticsTimeFilter from '@/components/shared/AnalyticsTimeFilter'
 import StatCard from '@/pages/year-in-review/components/StatCard'
 import InsightRow from '@/pages/year-in-review/components/InsightRow'
@@ -51,6 +52,7 @@ export default function YearInReviewPage() {
   const dims = useChartDimensions()
   const {
     transactions,
+    isLoading,
     mode,
     setMode,
     hoveredDay,
@@ -74,7 +76,21 @@ export default function YearInReviewPage() {
     monthlyBarData,
   } = useYearInReview()
 
-  if (transactions.length === 0) return <PageSkeleton />
+  if (isLoading) return <PageSkeleton />
+  if (transactions.length === 0) {
+    return (
+      <div className="p-4 md:p-6 lg:p-8">
+        <EmptyState
+          icon={Flame}
+          title="No transaction data yet"
+          description="Upload your bank statements to see your annual financial review — spending heatmaps, streaks, and year-over-year highlights."
+          actionLabel="Upload Data"
+          actionHref="/upload"
+          variant="card"
+        />
+      </div>
+    )
+  }
 
   return (
     <div className="p-4 md:p-6 lg:p-8 space-y-6 md:space-y-8">

--- a/frontend/src/pages/year-in-review/components/StatCard.tsx
+++ b/frontend/src/pages/year-in-review/components/StatCard.tsx
@@ -13,7 +13,7 @@ export default function StatCard({ label, value, icon: Icon, color }: Readonly<S
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
       className="glass rounded-2xl border border-border p-6"
-      style={{ borderLeft: `3px solid ${color}` }}
+      style={{ borderLeft: `4px solid ${color}` }}
     >
       <div className="flex items-center gap-3">
         <div className="p-2.5 rounded-xl" style={{ backgroundColor: `${color}22` }}>

--- a/frontend/src/pages/year-in-review/useYearInReview.ts
+++ b/frontend/src/pages/year-in-review/useYearInReview.ts
@@ -15,7 +15,7 @@ import {
 import { MONTHS_SHORT, type HeatmapMode } from './types'
 
 export function useYearInReview() {
-  const { data: transactions = [] } = useTransactions()
+  const { data: transactions = [], isLoading } = useTransactions()
   const { data: dailySummaries = [] } = useDailySummaries()
   const { data: preferences } = usePreferences()
   const fiscalYearStartMonth = preferences?.fiscal_year_start_month || 4
@@ -117,6 +117,7 @@ export function useYearInReview() {
 
   return {
     transactions,
+    isLoading,
     mode,
     setMode,
     hoveredDay,


### PR DESCRIPTION
## What

Code-only UI/UX audit (no browser): 8 specialized readers, every finding adversarially verified against the real code. 48 candidates → **20 confirmed** → fixed here.

### Write-action safety
- **Goal delete now confirms** via the existing `ConfirmDialog` (was instant, no undo, on a tiny icon).
- **Budget limit rejects ≤ 0** (`min="0"` + validation toast). Goal target amount gets `min="0"`.

### Empty / loading states
- **Year in Review** gated on `isLoading` first, then a real `EmptyState` (previously showed a loading skeleton *forever* for users with no data — `staleTime: Infinity` cached the empty array).
- **Investment Analytics** uses the `EmptyState` component (was raw instructional text) and checks `isLoading` before the empty branch.

### Accessibility
- `aria-modal`/`role`/`aria-labelledby` on **AuthModal, ProfileModal, ConfirmDialog**; backdrop `aria-hidden` + labelled close on AuthModal.
- `aria-label` on icon-only controls (sidebar utility + logout, CurrencySwitcher, chat textarea) alongside the existing `title` tooltips.
- `htmlFor`/`id` on transaction date + amount filter inputs; `aria-label`s on create-goal fields (placeholders vanished on type).

### React correctness
- `AccountsTable` row key → `item.name` (was `name+index` → remount/animation flash on re-sort).
- bill-calendar **"Go to today"** reads a fresh `Date` (was a mount-time stale one → wrong day on a long-open tab).

### Visual consistency
- Hardcoded `green-400`/`red-400`/`blue-400` → `app-green`/`app-red`/`app-blue` (CashFlowForecast, TaxSummaryCards).
- StatCard accent stripe 3px → 4px to match other cards.
- `--color-text-tertiary` `#636366` → `#7c7c80` for readable helper text (token + `colors.ts` fallback in sync; lifts contrast across ~75 consumers).

## Not done (deliberate)
- PeriodSelectors hardcoded `#fff` (active-tab text on a blue pill) — renders correctly, cosmetic-only maintainability nit, skipped to avoid churn.

## Testing
- tsc + eslint clean, **227 vitest pass**.
- 28 of the 48 candidates were refuted by the verifiers (e.g. "create goal accepts negative amounts" — blocked by a DB CHECK constraint), so this set is the verified remainder.