### PR TITLE
chore(skills): add 5 frontend craft skills (a11y, query-states, charts, react, design)

### DIFF
--- a/.claude/skills/accessible-ui/SKILL.md
+++ b/.claude/skills/accessible-ui/SKILL.md
@@ -1,0 +1,73 @@
+---
+description: Accessibility rules for ledger-sync UI — accessible names for icon-only controls, modal dialog semantics + focus, label/input association, color contrast, and color-as-only-signal. Auto-loads when editing frontend components/pages. Use when adding a button, modal, form input, icon control, or any interactive element.
+user-invocable: false
+paths:
+  - "frontend/src/components/**/*.tsx"
+  - "frontend/src/pages/**/*.tsx"
+---
+
+# Accessible UI
+
+A static audit found accessibility was this app's biggest defect cluster (9 of 20 findings): icon-only buttons with no accessible name, modals missing dialog semantics, filter inputs not associated with labels, and low-contrast helper text. These are mostly one-attribute fixes — do them as you write, not in a later sweep.
+
+## Every interactive element needs an accessible name
+
+An icon-only button labelled only with `title` is invisible to screen readers and gives mobile users no tooltip at all. Add `aria-label` (keep `title` too if you want the desktop tooltip):
+
+```tsx
+<button onClick={signOut} title="Sign out" aria-label="Sign out">
+  <LogOut size={18} />
+</button>
+```
+
+Applies to: sidebar utility/logout buttons, CurrencySwitcher, chat send/textarea, any `<button>`/`<Link>` whose only child is an icon. Decorative icons that sit next to visible text need no label (the text is the name); mark them `aria-hidden` if anything.
+
+For a dropdown trigger also add `aria-haspopup` + `aria-expanded={open}`.
+
+## Modals: dialog semantics + focus + Escape
+
+Per the ARIA Authoring Practices, a modal needs ALL of:
+
+```tsx
+<div
+  role="dialog"            // or "alertdialog" for confirm/destructive
+  aria-modal="true"
+  aria-labelledby="x-title"   // points at the visible heading
+  aria-describedby="x-desc"   // optional; omit for complex content
+>
+  <h3 id="x-title">…</h3>
+  <p id="x-desc">…</p>
+</div>
+```
+
+Plus behavior: **Escape closes**, focus **moves into** the dialog on open and **returns to the trigger** on close, and Tab is **trapped** inside. `ConfirmDialog` already does Escape + overlay-click close; `AuthModal`/`ProfileModal` carry the ARIA attrs. When the backdrop is a *separate* sibling element, mark it `aria-hidden="true"`. Only set `aria-modal` if the dialog truly blocks outside interaction — the APG warns marking a non-modal as modal is worse than not.
+
+## Associate every input with a label
+
+Either wire `htmlFor`/`id`, or give the control an `aria-label`. A placeholder is **not** a label — it vanishes the moment the user types (the create-goal form bug). Prefer a real visible label; use `aria-label` only for genuinely compact controls.
+
+```tsx
+<label htmlFor="filter-min-amount">Min Amount</label>
+<input id="filter-min-amount" type="number" />
+// or, compact:
+<input type="text" placeholder="Goal name *" aria-label="Goal name" />
+```
+
+## Color contrast (WCAG 2.2 AA)
+
+- Normal text ≥ **4.5:1** against its background.
+- Large text (≥ 24px, or ≥ 18.5px bold) ≥ **3:1**.
+- UI component boundaries / meaningful graphics ≥ **3:1** (1.4.11).
+
+This app is dark-only. The dim grays bite: `--color-text-tertiary` was lifted to `#7c7c80` for readable helper text. Don't use `text-text-quaternary` (`#48484a`) for anything a user must read — it's for disabled/decorative only. When in doubt, step one tier lighter.
+
+## Don't encode meaning in color alone
+
+Income-green vs expense-red is fine as *reinforcement*, but never the *only* signal (1.4.1) — a red/green colorblind user can't tell them apart. Pair color with a sign (`+`/`-`), an icon (arrow up/down), or a label. Most amounts in this app already carry a sign; keep it that way.
+
+## Quick checklist
+- [ ] Icon-only control has `aria-label`.
+- [ ] Modal: `role` + `aria-modal` + labelled + Escape + focus return.
+- [ ] Input has `htmlFor`/`id` or `aria-label`; placeholder is not the label.
+- [ ] Readable text clears 4.5:1 (3:1 for large/UI).
+- [ ] Meaning isn't carried by color alone.

--- a/.claude/skills/design-system-ui/SKILL.md
+++ b/.claude/skills/design-system-ui/SKILL.md
@@ -1,0 +1,51 @@
+---
+description: ledger-sync design-system rules — use CSS design tokens (not hardcoded colors), Tailwind 4 conventions, mobile-first responsive + 44px touch targets, h-dvh not h-screen, and banned AI-slop patterns (side-stripe borders, gradient text, dark-mode prefixes). Auto-loads when editing frontend components, pages, or styles. Use when styling anything, building a layout, or reviewing visual consistency.
+user-invocable: false
+paths:
+  - "frontend/src/**/*.tsx"
+  - "frontend/src/**/*.css"
+---
+
+# Design system & styling
+
+Dark-theme-only, iOS-inspired OLED palette, hairline borders. Tailwind 4 with design tokens defined in `index.css`. These rules keep new UI consistent with the existing 25 pages and avoid the generic-AI look.
+
+## Colors: tokens only, never raw hex/named Tailwind colors
+
+Use the semantic CSS custom properties / `app-*` utilities, not `text-green-400`, `#8884d8`, or `rgb(...)`:
+
+- Financial semantics: income = `app-green`, expense = `app-red`, savings = `app-purple`, transfer = `app-teal`, investment = `app-blue`.
+- Text tiers: `text-text-primary` / `secondary` / `tertiary` (`#7c7c80`, contrast-safe) / `quaternary` (disabled/decorative only).
+- In Tailwind classes use the token utilities (`text-app-green`, `bg-app-red/10`). In JS that needs a resolved string (Recharts `fill`, framer `animate`), use `rawColors.app.*` from `constants/colors.ts`.
+
+Hardcoded `green-400`/`red-400` drifted from the palette in CashFlowForecast/TaxSummaryCards — a real finding. Tailwind 4 generates `app-*` utilities from `@theme`/token vars, so the utility always matches the token.
+
+## Spacing, radius, shadows: follow the scale
+
+Use the spacing scale (`p-4`, `gap-6`) not arbitrary `p-[13px]`. Card frame is `glass rounded-2xl border border-border`; don't invent new radii/shadow combos per component. Don't nest cards in cards.
+
+## Mobile-first + real touch targets
+
+Most users are on phones. Tailwind is mobile-first: style unprefixed for mobile, layer `sm:`/`md:`/`lg:` for larger. `<lg` (<1024px) is the phone breakpoint that swaps the sidebar for the bottom `MobileTabBar`.
+
+- Interactive controls need ≥ **44px** touch height on phone. Compact desktop pills (`py-1.5`, ~32px) must bump up on mobile (`py-2.5 sm:py-1.5`) — the time-filter pills were 32px everywhere; fixed to ~44px on phone.
+- Grids must collapse: `grid-cols-2 md:grid-cols-4`, never a bare `grid-cols-4` that overflows phones.
+- Wrap wide tables in `overflow-x-auto` (not `overflow-hidden`, which clips); long text gets `truncate`/`break-words`.
+
+## Forbidden: h-screen, and the AI-slop tells
+
+- **`h-screen` is banned in layout** — use `h-dvh` so height tracks the mobile address-bar toggle. (`AppLayout` uses `h-dvh`.)
+- **No `dark:` prefixes** — the app is dark-only; `dark:` variants are dead code.
+- **No gradient text** (`background-clip: text` + gradient) — solid color only; use weight/size for emphasis.
+- **Side-stripe borders** (`border-l-4` colored accent) are an over-used AI tell. A few exist in this codebase; don't add more. Prefer a full hairline border, a leading icon, or a background tint. If you must match an existing striped card, match its width (4px) for consistency rather than introducing a third weight.
+- No glassmorphism-everywhere, no decorative drop-shadowed rounded rectangles for their own sake.
+
+## Sticky headers + safe areas
+
+`PageHeader` is `sticky top-0` and bakes `env(safe-area-inset-*)` into its padding so titles clear the iOS notch. Its horizontal padding scales with the breakout margins so the title aligns with page content (don't override `paddingLeft` with a flat inline value — that caused a 16px title/content misalignment). In demo mode the fixed banner needs top clearance on phone (`<main>` gets `pt-14 sm:pt-0`).
+
+## Checklist
+- [ ] Colors via tokens/`app-*` / `rawColors.*` — no hex or raw `green-400`.
+- [ ] Spacing on-scale; standard `glass rounded-2xl border` card; no nested cards.
+- [ ] Mobile-first; grids collapse; tables scroll; touch targets ≥44px on phone.
+- [ ] `h-dvh` not `h-screen`; no `dark:`, no gradient text, no new side-stripes.

--- a/.claude/skills/query-states/SKILL.md
+++ b/.claude/skills/query-states/SKILL.md
@@ -1,0 +1,84 @@
+---
+description: How to render TanStack Query data safely in ledger-sync — loading vs empty vs error states, and guarding against undefined/partial API data so a page never blanks or crashes. Auto-loads when editing frontend pages, hooks, or components. Use when adding a page/widget that reads a query, when a page renders blank/NaN, or when wiring an EmptyState.
+user-invocable: false
+paths:
+  - "frontend/src/pages/**/*.tsx"
+  - "frontend/src/pages/**/*.ts"
+  - "frontend/src/hooks/**/*.ts"
+  - "frontend/src/components/**/*.tsx"
+  - "frontend/src/services/api/**/*.ts"
+---
+
+# Query states — render data without blanking or crashing
+
+This codebase has been bitten repeatedly by two bugs: pages that **crash** on undefined API data, and pages that **show a loading skeleton forever** for users with no data. Both are preventable with one discipline: handle the four states **loading → error → empty → success** in that order, and never read a nested field off data you haven't guarded.
+
+Real incidents this skill encodes:
+- SIP Projections white-screened on `rates.ppf.rate_pct` (data undefined).
+- Settings rendered blank on `usage.limits.app_daily_messages` (partial payload).
+- Year in Review showed `PageSkeleton` forever because `transactions.length === 0` was checked **without** an `isLoading` gate, and the query uses `staleTime: Infinity` (the empty array is cached, so the skeleton never resolves).
+
+## The order is not optional
+
+Always branch in this exact order. Skipping or reordering is the bug.
+
+```tsx
+const { data = [], isLoading, isError } = useThing()
+
+if (isLoading) return <PageSkeleton />          // 1. still fetching
+if (isError)   return <ErrorState onRetry={refetch} /> // 2. fetch failed
+if (data.length === 0) return <EmptyState ... /> // 3. fetched, genuinely empty
+return <RealContent data={data} />               // 4. success
+```
+
+Why the order matters: with `staleTime: Infinity` (this repo's default — see `lib/queryClient.ts`), a successful-but-empty result is cached permanently. If you check emptiness **before** loading, a fresh load that happens to be empty-so-far renders your empty state too early; and a genuinely-empty result that you route to `<PageSkeleton/>` (the Year-in-Review bug) spins forever. `isLoading` first, then empty.
+
+`isLoading` vs `isPending`: in v5, `isLoading === isPending && isFetching`. Use **`isLoading`** for the "first fetch in flight, no data yet" spinner gate. `isPending` alone can be true while not fetching (e.g. a disabled query), which would hang the UI.
+
+## Always default the destructure
+
+A query's `data` is `undefined` until it resolves, on every error, and in demo mode where some queries 401/404. Default it at the destructure so `.length` / `.map` never throw:
+
+```tsx
+const { data: transactions = [] } = useTransactions()   // never undefined
+const { data: prefs } = usePreferences()                 // object: guard reads with ?.
+```
+
+## Never read a nested field off unguarded data
+
+This is the crash class. The fixes that shipped:
+
+- **Hook/service normalizes the shape** (best — fixes every consumer at once):
+  - `useInstrumentRates` deep-merges the response over `FALLBACK_RATES` so `.epf/.ppf/.nps` always exist.
+  - `aiUsageService.get()` spreads `limits` over `DEFAULT_LIMITS` so `usage.limits.app_daily_messages` is always present.
+- **Consumer guards** when you can't touch the source: `usage?.limits?.app_daily_messages ?? 10`, `goal.target_date ? new Date(goal.target_date) : null`.
+
+Rule: if you write `a.b.c` where `a` came from a query, either the hook guarantees the shape or you write `a?.b?.c ?? fallback`. No exceptions — a single unguarded chain blanks the whole route.
+
+## Empty states teach, they don't apologize
+
+Use the shared `EmptyState` component (`components/shared/EmptyState.tsx`) — never raw text (the Investment Analytics page used to). Give it an icon, a title, a description that says what to do, and an action:
+
+```tsx
+<EmptyState
+  icon={Flame}
+  title="No transaction data yet"
+  description="Upload your bank statements to see your annual review."
+  actionLabel="Upload Data"
+  actionHref="/upload"
+  variant="card"
+/>
+```
+
+For a single empty chart inside an otherwise-populated page, use `ChartEmptyState` (keeps the chart's height so the layout doesn't jump).
+
+## After a mutation, invalidate — don't rely on staleTime
+
+Because `staleTime: Infinity`, data will NOT refetch on its own. After a create/update/delete, call `queryClient.invalidateQueries({ queryKey: [...] })` for every affected key, or the UI shows stale numbers. (See `useChat`/upload flow for the pattern.)
+
+## Checklist before you commit a data-driven view
+- [ ] `isLoading` gate is first.
+- [ ] `isError` handled (not silently blank).
+- [ ] Genuinely-empty success routes to an `EmptyState`/`ChartEmptyState`, not a skeleton or `null`.
+- [ ] `data` defaulted at the destructure; every nested read is guarded or shape-guaranteed by the hook.
+- [ ] Mutations invalidate the right query keys.

--- a/.claude/skills/react-patterns/SKILL.md
+++ b/.claude/skills/react-patterns/SKILL.md
@@ -1,0 +1,67 @@
+---
+description: React 19.2 correctness patterns for ledger-sync — useEffectEvent for non-reactive effect logic, stable list keys, avoiding stale state/dates, lazy-load + Suspense, and the project's lint rules (no setState-in-effect, no index keys on reorderable lists). Auto-loads when editing frontend hooks/components/pages. Use when writing an effect, a list, a hook, or wiring a route.
+user-invocable: false
+paths:
+  - "frontend/src/**/*.tsx"
+  - "frontend/src/hooks/**/*.ts"
+---
+
+# React 19.2 patterns
+
+The app is on React 19.2 with `eslint-plugin-react-hooks` v7 (flat config, strict). These are the patterns that keep the linter quiet AND the UI correct.
+
+## useEffectEvent for non-reactive effect logic
+
+When an effect must re-run on some deps but only *read* others without reacting, extract the non-reactive part into a `useEffectEvent` instead of a ref shim + `eslint-disable exhaustive-deps`. This is already used in `TransactionFilters` (debounced search reads the latest `filters`/`onFilterChange` without re-subscribing).
+
+```tsx
+const onApply = useEffectEvent((q: string) => {
+  setFilters({ ...filters, query: q })   // reads latest filters, non-reactively
+  onFilterChange({ ...filters, query: q })
+})
+useEffect(() => { onApply(debouncedQuery) }, [debouncedQuery]) // ✅ event NOT in deps
+```
+
+Rules (enforced): only call Effect Events **inside effects**, **never** list them in a dep array, **never** pass them to other components/hooks, and don't use them to silence a dependency that *should* re-run the effect. If a value should trigger re-sync, keep it a real dependency.
+
+## List keys: stable id, never index on reorderable lists
+
+Use a stable unique field (`item.id`, `item.name` when unique) as the key. An index key — or `${name}-${index}` — remounts rows when the list re-sorts/filters, flashing animations and stranding state on the wrong row (the AccountsTable re-sort bug). Index keys are only acceptable on a list that never reorders, filters, or has items inserted/removed.
+
+```tsx
+{rows.map((r) => <Row key={r.id} … />)}      // ✅
+{rows.map((r, i) => <Row key={i} … />)}      // 🔴 on any sortable/filterable list
+```
+
+## Don't read stale captured values
+
+`useMemo(() => new Date(), [])` freezes "now" at mount; a "Go to today" handler then navigates to the wrong day on a long-open tab (the bill-calendar bug). For a value that must be current at the moment of an action, read it fresh inside the handler (`const today = new Date()`), not from a mount-time memo. Same for any time/random value.
+
+## No setState in effect / no setState during render
+
+The v7 linter flags both (`react-hooks/set-state-in-effect`). To derive/seed state from props or query data, prefer the "adjust state during render" pattern with a guard, not an effect:
+
+```tsx
+const [synced, setSynced] = useState<number | null>(null)
+if (prefs && !userInteracted && synced !== prefs.fyStartMonth) {
+  setSynced(prefs.fyStartMonth)
+  setCurrentFY(getCurrentFY(prefs.fyStartMonth))   // runs during render, no effect, no cascade
+}
+```
+
+Don't read a ref's `.current` during render either (also flagged) — gate on state, not refs.
+
+## Memo deps must list every value used
+
+`useMemo`/`useCallback` whose callback reads a value not in its deps produces stale UI. Don't suppress `exhaustive-deps` to "fix" a re-render — either add the dep, wrap the offending value in `useEffectEvent` (effects only), or restructure. Suppression hides the bug.
+
+## Lazy pages + Suspense
+
+Every page is `React.lazy`-imported in `App.tsx` and wrapped in `Suspense`/`ChunkErrorBoundary`. New pages follow suit (lazy import, never eager). A crash inside a route is contained by the page-scoped `ErrorBoundary` in `AppLayout` (keyed on pathname) so the sidebar/nav survive — don't add a second app-level boundary around a page.
+
+## Checklist
+- [ ] Effect deps are honest; non-reactive reads use `useEffectEvent` (not in deps, effects only).
+- [ ] List keys are stable ids, not index, on anything that reorders.
+- [ ] "Current" values (now/today) read fresh in handlers, not mount-time memos.
+- [ ] No setState in render/effect except the guarded adjust-during-render pattern.
+- [ ] New pages are lazy-imported with Suspense.

--- a/.claude/skills/recharts-viz/SKILL.md
+++ b/.claude/skills/recharts-viz/SKILL.md
@@ -1,0 +1,54 @@
+---
+description: How to build charts in ledger-sync with Recharts 3 — ChartContainer + ResponsiveContainer, design-token colors, NaN/empty-data guards, tooltips, and accessibility. Auto-loads when editing analytics/chart components. Use when adding or fixing any chart, sparkline, or visualization.
+user-invocable: false
+paths:
+  - "frontend/src/components/analytics/**/*.tsx"
+  - "frontend/src/components/analytics/**/*.ts"
+  - "frontend/src/components/ui/ChartContainer*.tsx"
+---
+
+# Recharts visualizations
+
+The app has 30+ Recharts components. Consistency and a few guards keep them from rendering blank boxes or off-palette colors.
+
+## Wrap charts the project way
+
+Use the shared `ChartContainer` (`components/ui/`) for the card frame, and Recharts `ResponsiveContainer` for sizing. Never hardcode pixel width/height on the chart itself — `ResponsiveContainer width="100%"` plus a fixed `height` (or aspect ratio) is the rule, so charts reflow on mobile.
+
+```tsx
+<ChartContainer title="Net Worth Trend">
+  <ResponsiveContainer width="100%" height={300}>
+    <AreaChart data={data}>…</AreaChart>
+  </ResponsiveContainer>
+</ChartContainer>
+```
+
+## Colors come from tokens, not hex literals
+
+Pull series colors from `constants/colors.ts` / `constants/chartColors.ts` (`rawColors.app.green`, etc.) and the financial semantics: income = green, expense = red, savings = purple, transfer = teal, investment = blue. Don't write `fill="#8884d8"` or `text-green-400` in a chart — it drifts from the rest of the app (a real finding in CashFlowForecast/TaxSummaryCards). Recharts needs a resolved color string, so use the `rawColors.*` JS values (not the CSS-var class) for `fill`/`stroke`.
+
+## Guard the data BEFORE it reaches the chart
+
+Recharts renders an empty/blank box for `[]`, and renders nothing useful for `NaN`/`Infinity` values — these look like "the chart is broken" to users.
+
+- Empty: branch to `ChartEmptyState` (keeps height so layout doesn't jump):
+  ```tsx
+  {data.length === 0 ? <ChartEmptyState height={300} /> : <ResponsiveContainer>…</ResponsiveContainer>}
+  ```
+- NaN/Infinity: never feed raw division into a chart. Guard the denominator (`total > 0 ? x / total : 0`) and coerce with a real default, not `|| 0` on a value that could legitimately be 0. A single `NaN` y-value can drop a whole line/area.
+- Strings-as-numbers: amounts that arrive as strings (Decimal serialized by the backend) must be `Number(v)`-coerced before charting, or the axis scale breaks.
+
+## Tooltips
+
+Format values through the app formatters (`formatCurrency`, `formatPercent`) inside a custom tooltip or the `formatter` prop — raw numbers (`1234.5`) in a finance app read as unfinished. Custom tooltip components must return `null` when `!active` (don't render an empty shell).
+
+## Accessibility
+
+Recharts 3 enables the keyboard `accessibilityLayer` by default — keep it on. Give the chart a `title`/`aria-label` describing what it shows so it isn't an unlabeled SVG to screen readers. Remember charts are non-text contrast (3:1) — don't rely on near-identical hues to distinguish series; the semantic palette already separates them.
+
+## Checklist
+- [ ] `ResponsiveContainer width="100%"` + fixed height (no hardcoded px width).
+- [ ] Colors from `rawColors.*` / semantic palette, no hex literals.
+- [ ] Empty data → `ChartEmptyState`; denominators guarded; string amounts coerced.
+- [ ] Values formatted via app formatters in tooltips/labels.
+- [ ] Chart has an accessible name; `accessibilityLayer` left on.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,16 @@ Repo-specific skills live in [`.claude/skills/<name>/SKILL.md`](.claude/skills/)
 | `deployment-atlas` | Editing workflows, vercel.json, settings |
 | `indian-finance-expert` | Editing tax/investment/savings code — domain-expert reference |
 
+**Frontend craft skills** (`user-invocable: false`) — practice/best-practice guides grounded in current library docs + this repo's actual fixed bugs. Auto-load by `paths:` when editing frontend code.
+
+| Craft skill | Auto-loads when... |
+| --- | --- |
+| `query-states` | Editing pages/hooks/components — loading/empty/error states + undefined-data guards (TanStack Query v5) |
+| `accessible-ui` | Editing components/pages — ARIA names, modal semantics, label association, contrast |
+| `recharts-viz` | Editing analytics/chart components — ResponsiveContainer, token colors, NaN/empty guards |
+| `react-patterns` | Editing any frontend TS/TSX — useEffectEvent, stable keys, stale-state, lazy/Suspense, hooks lint |
+| `design-system-ui` | Editing components/pages/CSS — design tokens, mobile-first + 44px touch, h-dvh, banned AI-slop patterns |
+
 **Task skills** (user-invocable, also auto-trigger on phrasing) — recipes for recurring work. Consolidated to broad workflows rather than one skill per layer.
 
 | Task skill | Trigger when... |

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -25,6 +25,18 @@ These are `user-invocable: false` skills — they don't show in the `/` menu. Th
 | [deployment-atlas](.claude/skills/deployment-atlas/SKILL.md) | Editing workflows, vercel.json, settings | Topology, env vars, CI/CD, migration deploy, OAuth caveats, when-something-breaks |
 | [indian-finance-expert](.claude/skills/indian-finance-expert/SKILL.md) | Editing tax/investment/savings code | Tax regimes, sections, capital gains, savings instruments, ITR forms, advance tax, real-world rules of thumb |
 
+## Frontend craft skills (best practices)
+
+Also `user-invocable: false`, auto-load by `paths:`. Unlike the atlases (which map the codebase), these hold frontend *practice* — distilled from current library docs (TanStack Query v5, React 19.2, Recharts 3, Tailwind 4, WAI-ARIA APG, WCAG 2.2) and grounded in this repo's own fixed bugs.
+
+| Skill | Loads when... | Holds |
+|---|---|---|
+| [query-states](.claude/skills/query-states/SKILL.md) | Editing pages/hooks/components/services | loading→error→empty→success order, undefined-data guards, EmptyState usage, mutation invalidation |
+| [accessible-ui](.claude/skills/accessible-ui/SKILL.md) | Editing components/pages | ARIA names for icon controls, modal dialog semantics + focus, label association, WCAG contrast, color-as-only-signal |
+| [recharts-viz](.claude/skills/recharts-viz/SKILL.md) | Editing analytics/chart components | ResponsiveContainer + ChartContainer, token colors, NaN/empty guards, tooltip formatting, a11y layer |
+| [react-patterns](.claude/skills/react-patterns/SKILL.md) | Editing any frontend TS/TSX | useEffectEvent, stable list keys, stale-state/date, no-setState-in-effect, lazy/Suspense, hooks-lint v7 |
+| [design-system-ui](.claude/skills/design-system-ui/SKILL.md) | Editing components/pages/CSS | design tokens (no raw hex), mobile-first + 44px touch, h-dvh, banned AI-slop patterns (side-stripes, gradient text, dark:) |
+
 ## Task skills (recipes for recurring work)
 
 Normal user-invocable skills — they show in `/` menu and Claude can also auto-trigger them based on phrasing. Consolidated to **6 broad workflows** rather than one skill per layer (per [Anthropic skill design guidance](https://code.claude.com/docs/en/skills): create a skill when you keep pasting the same procedure, not for every conceivable task).


### PR DESCRIPTION
## What

Five auto-loading frontend best-practice skills (`user-invocable: false`, scoped via `paths:`), so future sessions get the right guidance in context only when editing relevant frontend files.

Each is grounded in **two** sources: current library docs (researched live) **and** this repo's own bugs fixed in the recent audit PRs (#186–#189) — so the advice is concrete and cites real incidents.

| Skill | Loads when editing | Distilled from |
|---|---|---|
| `query-states` | pages/hooks/components/services | TanStack Query v5 docs + the SIP/Settings crashes + Year-in-Review skeleton-forever bug |
| `accessible-ui` | components/pages | WAI-ARIA APG (modal pattern), WCAG 2.2 contrast + the 9 a11y findings |
| `recharts-viz` | analytics/chart components | Recharts 3 docs + the color-token drift findings |
| `react-patterns` | any frontend TS/TSX | React 19.2 `useEffectEvent` docs + the AccountsTable key + bill-calendar stale-date bugs |
| `design-system-ui` | components/pages/CSS | Tailwind 4 theme docs + the touch-target / `h-screen` / side-stripe findings |

## Why this shape
Follows the repo's existing skill conventions: knowledge skills are `user-invocable: false` and auto-load by `paths:` (like the `*-atlas` family), kept focused (51–84 lines each), and indexed in both `CLAUDE.md` (new "Frontend craft skills" table) and `MEMORY.md`.

## Verification
- All 5 frontmatters YAML-validated (caught + fixed a `dark:` colon that broke one).
- `paths:` globs confirmed to match real source files.
- No app code touched — docs/skills only.