### PR TITLE
fix(ui): replace hardcoded palette colors with semantic design tokens

### DIFF
--- a/frontend/src/components/analytics/CashFlowForecast.tsx
+++ b/frontend/src/components/analytics/CashFlowForecast.tsx
@@ -50,7 +50,7 @@ export default function CashFlowForecast() {
             </div>
           </div>
           {insights.monthsUntilNegative && (
-            <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-orange-500/10 border border-orange-500/20 text-orange-400 text-xs font-medium">
+            <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-app-orange/10 border border-app-orange/20 text-app-orange text-xs font-medium">
               <AlertTriangle className="w-3.5 h-3.5" />
               Deficit in {insights.monthsUntilNegative}mo
             </div>
@@ -125,7 +125,7 @@ export default function CashFlowForecast() {
             Forecast
           </span>
           <span className="flex items-center gap-1.5">{' '}
-            <span className="w-3 h-1.5 rounded-sm bg-blue-500/15" />{' '}
+            <span className="w-3 h-1.5 rounded-sm bg-app-blue/15" />{' '}
             Confidence
           </span>
         </div>

--- a/frontend/src/components/chat/ChatWidget.tsx
+++ b/frontend/src/components/chat/ChatWidget.tsx
@@ -79,6 +79,8 @@ export default function ChatWidget() {
         whileTap={{ scale: 0.95 }}
         onClick={handleToggle}
         title={isConfigured ? 'AI Assistant' : 'Configure AI key in Settings'}
+        aria-label={isConfigured ? 'Open AI Assistant' : 'AI Assistant — configure API key in Settings'}
+        aria-expanded={isOpen}
         className={`w-12 h-12 rounded-full flex items-center justify-center shadow-lg transition-colors ${
           isConfigured
             ? 'bg-gradient-to-br from-primary to-secondary text-white hover:shadow-primary/25'

--- a/frontend/src/components/layout/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar/Sidebar.tsx
@@ -143,8 +143,8 @@ function BrandHeader({
       onClick={onOpenProfile}
       className="w-full flex items-center gap-3 px-4 py-4 border-b border-border hover:bg-white/[0.04] transition-colors duration-150 group/brand"
     >
-      <div className="w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0 bg-blue-500/15">
-        <PiggyBank className="w-5 h-5 text-blue-400" />
+      <div className="w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0 bg-app-blue/15">
+        <PiggyBank className="w-5 h-5 text-app-blue" />
       </div>
       <div className="flex-1 min-w-0 text-left">
         <p className="text-[15px] font-semibold text-white truncate leading-tight">
@@ -329,7 +329,7 @@ export default function Sidebar() {
                 <button
                   type="button"
                   onClick={() => exitDemoMode(queryClient, navigate)}
-                  className="w-11 h-11 lg:w-9 lg:h-9 flex items-center justify-center rounded-lg text-text-tertiary hover:text-red-400 hover:bg-red-500/10 transition-colors duration-150"
+                  className="w-11 h-11 lg:w-9 lg:h-9 flex items-center justify-center rounded-lg text-text-tertiary hover:text-app-red hover:bg-app-red/10 transition-colors duration-150"
                   title="Exit Demo"
                   aria-label="Exit Demo"
                 >
@@ -340,7 +340,7 @@ export default function Sidebar() {
                   type="button"
                   onClick={handleLogout}
                   disabled={logout.isPending}
-                  className="w-11 h-11 lg:w-9 lg:h-9 flex items-center justify-center rounded-lg text-text-tertiary hover:text-red-400 hover:bg-red-500/10 transition-colors duration-150 disabled:opacity-50"
+                  className="w-11 h-11 lg:w-9 lg:h-9 flex items-center justify-center rounded-lg text-text-tertiary hover:text-app-red hover:bg-app-red/10 transition-colors duration-150 disabled:opacity-50"
                   title="Sign out"
                   aria-label="Sign out"
                 >

--- a/frontend/src/components/layout/Sidebar/SidebarItem.tsx
+++ b/frontend/src/components/layout/Sidebar/SidebarItem.tsx
@@ -38,13 +38,13 @@ export default function SidebarItem({
         <>
           {/* Subtle left accent bar */}
           {isActive && (
-            <div className="absolute left-0 top-1/2 -translate-y-1/2 w-[2px] h-4 rounded-full bg-blue-400" />
+            <div className="absolute left-0 top-1/2 -translate-y-1/2 w-[2px] h-4 rounded-full bg-app-blue" />
           )}
           <Icon
             size={18}
             className={cn(
               'flex-shrink-0 transition-colors duration-150',
-              isActive ? 'text-blue-400' : 'text-text-tertiary',
+              isActive ? 'text-app-blue' : 'text-text-tertiary',
             )}
           />
           <span className="flex-1 truncate">{label}</span>
@@ -53,7 +53,7 @@ export default function SidebarItem({
               className={cn(
                 'px-1.5 py-0.5 min-w-[20px] text-center text-[11px] font-semibold rounded-md flex-shrink-0',
                 badgeVariant === 'alert'
-                  ? 'bg-red-500/15 text-red-400'
+                  ? 'bg-app-red/15 text-app-red'
                   : 'bg-white/[0.08] text-muted-foreground',
               )}
             >

--- a/frontend/src/components/shared/AuthModal.tsx
+++ b/frontend/src/components/shared/AuthModal.tsx
@@ -109,8 +109,8 @@ export function AuthModal({ isOpen, onClose }: Readonly<AuthModalProps>) {
 
               {/* Header */}
               <div className="flex flex-col items-center mb-8">
-                <div className="p-3 rounded-xl bg-blue-500/10 mb-3">
-                  <PiggyBank className="w-8 h-8 text-blue-400" />
+                <div className="p-3 rounded-xl bg-app-blue/10 mb-3">
+                  <PiggyBank className="w-8 h-8 text-app-blue" />
                 </div>
                 <h2 id="auth-modal-title" className="text-xl font-semibold text-white">
                   Welcome to Ledger Sync

--- a/frontend/src/components/shared/EmptyState.tsx
+++ b/frontend/src/components/shared/EmptyState.tsx
@@ -42,7 +42,7 @@ function ActionButton({ actionLabel, actionHref, onAction, isCompact }: Readonly
   isCompact: boolean
 }>) {
   const sizeClass = getSizeClass(isCompact, 'text-xs', 'text-sm')
-  const baseClass = `inline-flex items-center gap-2 px-4 py-2 bg-blue-500 text-white rounded-lg font-medium hover:bg-blue-400 active:scale-[0.98] transition-colors duration-150 ${sizeClass}`
+  const baseClass = `inline-flex items-center gap-2 px-4 py-2 bg-app-blue text-white rounded-lg font-medium hover:bg-app-blue active:scale-[0.98] transition-colors duration-150 ${sizeClass}`
 
   if (actionHref) {
     return (
@@ -92,7 +92,7 @@ export default function EmptyState({
           <h3 className="text-base font-medium text-white">{title}</h3>
           {description && <p className="text-sm text-text-tertiary max-w-sm">{description}</p>}
           {actionLabel && actionHref && (
-            <a href={actionHref} className="mt-2 text-sm text-blue-400 hover:text-blue-300 transition-colors duration-150">{actionLabel}</a>
+            <a href={actionHref} className="mt-2 text-sm text-app-blue hover:text-app-blue transition-colors duration-150">{actionLabel}</a>
           )}
         </div>
       </div>

--- a/frontend/src/components/shared/ProfileModal.tsx
+++ b/frontend/src/components/shared/ProfileModal.tsx
@@ -176,19 +176,19 @@ function ProfileModalContent({ onClose }: Readonly<{ onClose: () => void }>) {
             )}
             Icon={RotateCcw}
             title="Reset Transactions"
-            toneText="text-orange-400"
-            toneBorder="border-orange-500/15"
-            toneBg="bg-orange-500/5"
+            toneText="text-app-orange"
+            toneBorder="border-app-orange/15"
+            toneBg="bg-app-orange/5"
             description="Clears all transactions, import history, and analytics. Your preferences, budgets, goals, and account classifications will be preserved."
             confirmKeyword="RESET"
-            confirmKeywordBg="bg-orange-500/20"
+            confirmKeywordBg="bg-app-orange/20"
             confirmText={resetConfirmText}
             setConfirmText={setResetConfirmText}
-            inputBorderFocus="focus:border-orange-500/50"
+            inputBorderFocus="focus:border-app-orange/50"
             actionButton={{
               label: 'Clear Transactions',
               pendingLabel: 'Resetting...',
-              bgClass: 'bg-orange-500/90 hover:bg-orange-500',
+              bgClass: 'bg-app-orange/90 hover:bg-app-orange',
               onClick: () => handleReset('transactions'),
               pending: resetAccount.isPending,
             }}
@@ -203,19 +203,19 @@ function ProfileModalContent({ onClose }: Readonly<{ onClose: () => void }>) {
             )}
             Icon={RotateCcw}
             title="Complete Reset"
-            toneText="text-amber-500"
-            toneBorder="border-amber-600/15"
-            toneBg="bg-amber-600/5"
+            toneText="text-app-yellow"
+            toneBorder="border-app-yellow/15"
+            toneBg="bg-app-yellow/5"
             description="Permanently deletes all data -- transactions, preferences, budgets, goals, import history, and analytics. Your account and login method will be preserved."
             confirmKeyword="RESET"
-            confirmKeywordBg="bg-amber-500/20"
+            confirmKeywordBg="bg-app-yellow/20"
             confirmText={resetConfirmText}
             setConfirmText={setResetConfirmText}
-            inputBorderFocus="focus:border-amber-500/50"
+            inputBorderFocus="focus:border-app-yellow/50"
             actionButton={{
               label: 'Yes, Reset Everything',
               pendingLabel: 'Resetting...',
-              bgClass: 'bg-amber-600/90 hover:bg-amber-600',
+              bgClass: 'bg-app-yellow/90 hover:bg-app-yellow',
               onClick: () => handleReset('full'),
               pending: resetAccount.isPending,
             }}
@@ -226,19 +226,19 @@ function ProfileModalContent({ onClose }: Readonly<{ onClose: () => void }>) {
             setExpanded={setShowDeleteConfirm}
             Icon={Trash2}
             title="Delete Account"
-            toneText="text-red-400"
-            toneBorder="border-red-500/15"
-            toneBg="bg-red-500/5"
+            toneText="text-app-red"
+            toneBorder="border-app-red/15"
+            toneBg="bg-app-red/5"
             description="Permanently delete your account and all associated data. This action cannot be undone."
             confirmKeyword="DELETE"
-            confirmKeywordBg="bg-red-500/20"
+            confirmKeywordBg="bg-app-red/20"
             confirmText={deleteConfirmText}
             setConfirmText={setDeleteConfirmText}
-            inputBorderFocus="focus:border-red-500/50"
+            inputBorderFocus="focus:border-app-red/50"
             actionButton={{
               label: 'Permanently Delete',
               pendingLabel: 'Deleting...',
-              bgClass: 'bg-red-500/90 hover:bg-red-500',
+              bgClass: 'bg-app-red/90 hover:bg-app-red',
               onClick: handleDelete,
               pending: deleteAccount.isPending,
             }}

--- a/frontend/src/components/shared/RecentTransactions.tsx
+++ b/frontend/src/components/shared/RecentTransactions.tsx
@@ -30,8 +30,8 @@ const TransactionRow = memo(function TransactionRow({
         <div
           className={`p-2 rounded-lg transition-colors duration-150 ${
             transaction.type === 'Income'
-              ? 'bg-green-500/10 text-app-green'
-              : 'bg-red-500/10 text-app-red'
+              ? 'bg-app-green/10 text-app-green'
+              : 'bg-app-red/10 text-app-red'
           }`}
         >
           {transaction.type === 'Income' ? <TrendingUp className="w-5 h-5" /> : <TrendingDown className="w-5 h-5" />}

--- a/frontend/src/components/shared/profile-modal/EditNameRow.tsx
+++ b/frontend/src/components/shared/profile-modal/EditNameRow.tsx
@@ -26,7 +26,7 @@ export function EditNameRow(props: Readonly<EditNameRowProps>) {
           <button
             type="button"
             onClick={onStartEdit}
-            className="text-xs text-blue-400 hover:text-blue-300 transition-colors duration-150 ease-out"
+            className="text-xs text-app-blue hover:text-app-blue transition-colors duration-150 ease-out"
           >
             Edit
           </button>
@@ -44,14 +44,14 @@ export function EditNameRow(props: Readonly<EditNameRowProps>) {
               if (e.key === 'Escape') onCancelEdit()
             }}
             autoFocus
-            className="flex-1 px-3 py-1.5 bg-white/[0.04] border border-white/[0.08] rounded-lg text-white text-sm focus:border-blue-500/50 focus:outline-none transition-colors duration-150 ease-out"
+            className="flex-1 px-3 py-1.5 bg-white/[0.04] border border-white/[0.08] rounded-lg text-white text-sm focus:border-app-blue/50 focus:outline-none transition-colors duration-150 ease-out"
             placeholder="Your name"
           />
           <button
             type="button"
             onClick={onSave}
             disabled={isPending}
-            className="p-1.5 rounded-lg bg-blue-500/15 text-blue-400 hover:bg-blue-500/25 transition-colors duration-150 ease-out disabled:opacity-50"
+            className="p-1.5 rounded-lg bg-app-blue/15 text-app-blue hover:bg-app-blue/25 transition-colors duration-150 ease-out disabled:opacity-50"
           >
             <Check size={14} />
           </button>

--- a/frontend/src/components/shared/profile-modal/LogoutButton.tsx
+++ b/frontend/src/components/shared/profile-modal/LogoutButton.tsx
@@ -12,7 +12,7 @@ export function LogoutButton({ isPending, onLogout }: Readonly<LogoutButtonProps
         type="button"
         onClick={onLogout}
         disabled={isPending}
-        className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl bg-red-500/10 text-red-400 hover:bg-red-500/15 transition-colors duration-150 ease-out text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+        className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl bg-app-red/10 text-app-red hover:bg-app-red/15 transition-colors duration-150 ease-out text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
       >
         <LogOut size={16} />
         <span>{isPending ? 'Signing out...' : 'Sign Out'}</span>

--- a/frontend/src/components/transactions/Pagination.tsx
+++ b/frontend/src/components/transactions/Pagination.tsx
@@ -73,7 +73,7 @@ export default function Pagination({
                   key={pageNum}
                   onClick={() => onPageChange(pageNum)}
                   className={`px-3 py-1 rounded-lg text-sm font-medium transition-colors duration-150 ${currentPage === pageNum
-                      ? 'bg-blue-500/20 text-blue-400'
+                      ? 'bg-app-blue/20 text-app-blue'
                       : 'text-muted-foreground hover:bg-white/[0.06] hover:text-white'
                     }`}
                 >

--- a/frontend/src/components/transactions/TransactionFilters.tsx
+++ b/frontend/src/components/transactions/TransactionFilters.tsx
@@ -117,7 +117,7 @@ export default function TransactionFilters({ onFilterChange, categories, account
           {hasActiveFilters && (
             <button
               onClick={clearFilters}
-              className="flex items-center gap-2 px-4 py-2 rounded-lg text-red-400 hover:text-red-300 hover:bg-white/[0.06] transition-colors duration-150"
+              className="flex items-center gap-2 px-4 py-2 rounded-lg text-app-red hover:text-app-red hover:bg-white/[0.06] transition-colors duration-150"
               aria-label="Clear all filters"
             >
               <X className="w-4 h-4" aria-hidden="true" />

--- a/frontend/src/components/transactions/transactionColumns.tsx
+++ b/frontend/src/components/transactions/transactionColumns.tsx
@@ -74,9 +74,9 @@ export const transactionColumns: ColumnDef<Transaction>[] = [
       const isTransfer = type === 'Transfer'
 
       const colorClass = (() => {
-        if (isTransfer) return 'text-teal-400'
-        if (isIncome) return 'text-green-400'
-        return 'text-red-400'
+        if (isTransfer) return 'text-app-teal'
+        if (isIncome) return 'text-app-green'
+        return 'text-app-red'
       })()
 
       const prefix = (() => {

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -13,13 +13,13 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 
 const variantClasses: Record<ButtonVariant, string> = {
   primary:
-    'bg-blue-500 text-white hover:bg-blue-400 active:scale-[0.98]',
+    'bg-app-blue text-white hover:bg-app-blue active:scale-[0.98]',
   secondary:
     'bg-white/[0.06] border border-white/[0.08] text-white hover:bg-white/[0.10] hover:text-white active:scale-[0.98]',
   ghost:
     'text-muted-foreground hover:text-white hover:bg-white/[0.06] active:scale-[0.98]',
   danger:
-    'bg-red-500/90 text-white hover:bg-red-500 active:scale-[0.98]',
+    'bg-app-red/90 text-white hover:bg-app-red active:scale-[0.98]',
   outline:
     'border border-white/[0.10] text-white hover:bg-white/[0.06] hover:text-white active:scale-[0.98]',
 }
@@ -45,7 +45,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
       className={cn(
         'inline-flex items-center justify-center font-medium transition-all duration-150 ease-out',
         'disabled:opacity-50 disabled:pointer-events-none',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background',
         variantClasses[variant],
         sizeClasses[size],
         className

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -65,7 +65,7 @@ export const CardHeader = memo(function CardHeader({
     <div className="flex items-center justify-between mb-4">
       <div className="flex items-center gap-3">
         {icon && (
-          <div className="p-2.5 bg-blue-500/10 rounded-xl">
+          <div className="p-2.5 bg-app-blue/10 rounded-xl">
             {icon}
           </div>
         )}
@@ -129,7 +129,7 @@ export const StatCard = memo(function StatCard({
           {trend && (
             <p className={cn(
               'text-xs mt-1 font-medium',
-              trend.isPositive ? 'text-green-400' : 'text-red-400'
+              trend.isPositive ? 'text-app-green' : 'text-app-red'
             )}>
               {trend.isPositive ? '\u2191' : '\u2193'} {Math.abs(trend.value)}%
             </p>

--- a/frontend/src/components/ui/CollapsibleSection.tsx
+++ b/frontend/src/components/ui/CollapsibleSection.tsx
@@ -38,7 +38,7 @@ export default function CollapsibleSection({
         <Icon className="w-5 h-5 text-muted-foreground shrink-0" />
         <span className="text-base font-semibold text-white flex-1">{title}</span>
         {badge !== undefined && (
-          <span className="px-2 py-0.5 text-xs font-medium rounded-full bg-blue-500/15 text-blue-400">
+          <span className="px-2 py-0.5 text-xs font-medium rounded-full bg-app-blue/15 text-app-blue">
             {badge}
           </span>
         )}

--- a/frontend/src/components/ui/ConfirmDialog.tsx
+++ b/frontend/src/components/ui/ConfirmDialog.tsx
@@ -44,8 +44,8 @@ export default function ConfirmDialog({
 
   const confirmColors =
     variant === 'danger'
-      ? 'bg-red-500/90 hover:bg-red-500 text-white'
-      : 'bg-orange-500/90 hover:bg-orange-500 text-white'
+      ? 'bg-app-red/90 hover:bg-app-red text-white'
+      : 'bg-app-orange/90 hover:bg-app-orange text-white'
 
   return (
     <AnimatePresence>

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -37,10 +37,10 @@ const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
             'w-full bg-white/[0.04] px-4 py-3 rounded-lg',
             'border border-white/[0.08] text-white placeholder:text-text-quaternary',
             'transition-all duration-150 ease-out',
-            'focus:border-blue-400/50 focus:outline-none focus:ring-1 focus:ring-blue-400/20',
+            'focus:border-app-blue/50 focus:outline-none focus:ring-1 focus:ring-app-blue/20',
             'disabled:opacity-50 disabled:cursor-not-allowed',
             icon && 'pl-10',
-            error && 'border-red-400/50 focus:border-red-400/50 focus:ring-red-400/20',
+            error && 'border-app-red/50 focus:border-app-red/50 focus:ring-app-red/20',
             className
           )}
           aria-invalid={error ? 'true' : undefined}
@@ -49,7 +49,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
         />
       </div>
       {error && (
-        <p id={inputId ? `${inputId}-error` : undefined} className="text-xs text-red-400" role="alert">
+        <p id={inputId ? `${inputId}-error` : undefined} className="text-xs text-app-red" role="alert">
           {error}
         </p>
       )}
@@ -89,9 +89,9 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(function Select
           'w-full bg-white/[0.04] px-4 py-3 rounded-lg',
           'border border-white/[0.08] text-white',
           'transition-all duration-150 ease-out',
-          'focus:border-blue-400/50 focus:outline-none focus:ring-1 focus:ring-blue-400/20',
+          'focus:border-app-blue/50 focus:outline-none focus:ring-1 focus:ring-app-blue/20',
           'disabled:opacity-50 disabled:cursor-not-allowed',
-          error && 'border-red-400/50 focus:border-red-400/50 focus:ring-red-400/20',
+          error && 'border-app-red/50 focus:border-app-red/50 focus:ring-app-red/20',
           className
         )}
         aria-invalid={error ? 'true' : undefined}
@@ -105,7 +105,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(function Select
         ))}
       </select>
       {error && (
-        <p id={selectId ? `${selectId}-error` : undefined} className="text-xs text-red-400" role="alert">
+        <p id={selectId ? `${selectId}-error` : undefined} className="text-xs text-app-red" role="alert">
           {error}
         </p>
       )}

--- a/frontend/src/components/upload/DropZone.tsx
+++ b/frontend/src/components/upload/DropZone.tsx
@@ -168,7 +168,7 @@ export default function DropZone({ onFileSelect, isUploading, compact }: Readonl
         className={cn(
           'relative border-2 border-dashed rounded-xl text-center cursor-pointer transition-all duration-150 ease-out',
           'hover:border-white/[0.15] hover:bg-white/[0.02]',
-          isDragActive && 'border-blue-400/50 bg-blue-500/5 scale-[1.01]',
+          isDragActive && 'border-app-blue/50 bg-app-blue/5 scale-[1.01]',
           isUploading && 'opacity-50 cursor-not-allowed',
           selectedFile ? 'border-white/[0.15] bg-white/[0.02]' : 'border-white/[0.10]',
           compact ? 'p-4' : 'p-12 rounded-2xl'

--- a/frontend/src/components/upload/UploadResults.tsx
+++ b/frontend/src/components/upload/UploadResults.tsx
@@ -23,7 +23,7 @@ export default function UploadResults({ stats, fileName, uploadTime }: Readonly<
       <div className="flex items-start justify-between">
         <div className="space-y-1">
           <h3 className="text-lg font-semibold flex items-center gap-2">
-            <CheckCircle className="w-5 h-5 text-green-400" />
+            <CheckCircle className="w-5 h-5 text-app-green" />
             Upload Successful
           </h3>
           <p className="text-sm text-text-tertiary">{fileName}</p>

--- a/frontend/src/pages/goals/components/GoalCard.tsx
+++ b/frontend/src/pages/goals/components/GoalCard.tsx
@@ -66,7 +66,7 @@ export default function GoalCard({
                 onClick={() => setConfirmDelete(true)}
                 title="Delete goal"
                 aria-label={`Delete goal: ${goal.name}`}
-                className="p-1.5 rounded-lg text-text-tertiary hover:text-app-red hover:bg-red-500/10 transition-colors"
+                className="p-1.5 rounded-lg text-text-tertiary hover:text-app-red hover:bg-app-red/10 transition-colors"
               >
                 <Trash2 className="w-3.5 h-3.5" />
               </button>

--- a/frontend/src/pages/returns-analysis/ReturnsAnalysisPage.tsx
+++ b/frontend/src/pages/returns-analysis/ReturnsAnalysisPage.tsx
@@ -92,14 +92,14 @@ export default function ReturnsAnalysisPage() {
             className="glass rounded-2xl p-6"
           >
             <div className="flex items-center gap-4 mb-6">
-              <div className={`p-4 rounded-2xl ${netProfitLoss >= 0 ? 'bg-green-500/10' : 'bg-red-500/10'}`}>
+              <div className={`p-4 rounded-2xl ${netProfitLoss >= 0 ? 'bg-app-green/10' : 'bg-app-red/10'}`}>
                 {netProfitLoss >= 0
-                  ? <TrendingUp className="w-8 h-8 text-green-400" />
-                  : <TrendingDown className="w-8 h-8 text-red-400" />}
+                  ? <TrendingUp className="w-8 h-8 text-app-green" />
+                  : <TrendingDown className="w-8 h-8 text-app-red" />}
               </div>
               <div>
                 <p className="text-sm text-text-tertiary">Net Investment P&L</p>
-                <p className={`text-4xl font-bold tracking-tight ${netProfitLoss >= 0 ? 'text-green-400' : 'text-red-400'}`}>
+                <p className={`text-4xl font-bold tracking-tight ${netProfitLoss >= 0 ? 'text-app-green' : 'text-app-red'}`}>
                   {netProfitLoss >= 0 ? '+' : ''}{formatCurrency(netProfitLoss)}
                 </p>
               </div>
@@ -107,10 +107,10 @@ export default function ReturnsAnalysisPage() {
             {/* Quick stats row */}
             <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
               {[
-                { label: 'CAGR', value: isLoading ? '...' : formatPercent(estimatedCAGR), color: estimatedCAGR >= 0 ? 'text-green-400' : 'text-red-400' },
-                { label: 'Monthly ROI', value: isLoading ? '...' : formatPercent(roi), color: roi >= 0 ? 'text-green-400' : 'text-red-400' },
-                { label: 'Total Income', value: formatCurrencyShort(totalIncome), color: 'text-green-400' },
-                { label: 'Total Costs', value: formatCurrencyShort(totalExpenses), color: 'text-red-400' },
+                { label: 'CAGR', value: isLoading ? '...' : formatPercent(estimatedCAGR), color: estimatedCAGR >= 0 ? 'text-app-green' : 'text-app-red' },
+                { label: 'Monthly ROI', value: isLoading ? '...' : formatPercent(roi), color: roi >= 0 ? 'text-app-green' : 'text-app-red' },
+                { label: 'Total Income', value: formatCurrencyShort(totalIncome), color: 'text-app-green' },
+                { label: 'Total Costs', value: formatCurrencyShort(totalExpenses), color: 'text-app-red' },
               ].map(stat => (
                 <div key={stat.label} className="bg-white/[0.04] border border-border rounded-lg p-3">
                   <p className="text-[10px] font-semibold uppercase tracking-widest text-text-quaternary">{stat.label}</p>
@@ -129,7 +129,7 @@ export default function ReturnsAnalysisPage() {
           className="glass rounded-2xl p-6"
         >
           <div className="flex items-center gap-3 mb-6">
-            <Activity className="w-5 h-5 text-blue-400" />
+            <Activity className="w-5 h-5 text-app-blue" />
             <div>
               <h3 className="text-lg font-semibold text-white">Monthly Investment P&L</h3>
               <p className="text-xs text-text-tertiary">Bars show monthly net, line shows cumulative growth</p>
@@ -225,7 +225,7 @@ export default function ReturnsAnalysisPage() {
                     title={`${m.month}: ${formatCurrency(m.net)}`}
                   >
                     <p className="text-[10px] text-muted-foreground mb-1">{m.month}</p>
-                    <p className={`text-xs font-bold ${m.net >= 0 ? 'text-green-300' : 'text-red-300'}`}>
+                    <p className={`text-xs font-bold ${m.net >= 0 ? 'text-app-green' : 'text-app-red'}`}>
                       {m.net >= 0 ? '+' : ''}{formatCurrencyShort(m.net)}
                     </p>
                   </div>
@@ -245,16 +245,16 @@ export default function ReturnsAnalysisPage() {
           >
             <h3 className="text-lg font-semibold text-white mb-4">Detailed Breakdown</h3>
             <motion.div className="grid grid-cols-1 md:grid-cols-2 gap-4" initial="hidden" animate="visible" variants={staggerContainer}>
-              <motion.div variants={fadeUpItem} className="bg-green-500/5 border border-green-500/15 rounded-xl p-5">
+              <motion.div variants={fadeUpItem} className="bg-app-green/5 border border-app-green/15 rounded-xl p-5">
                 <div className="flex items-center gap-2 mb-3">
-                  <Banknote className="w-4 h-4 text-green-400" />
+                  <Banknote className="w-4 h-4 text-app-green" />
                   <p className="text-sm font-medium text-white">Income Sources</p>
                 </div>
                 <div className="space-y-3">
                   {[
-                    { label: 'Investment Profit', value: investmentProfit, color: 'text-green-400' },
-                    { label: 'Dividend Income', value: dividendIncome, color: 'text-green-400' },
-                    { label: 'Interest Income', value: interestIncome, color: 'text-teal-400' },
+                    { label: 'Investment Profit', value: investmentProfit, color: 'text-app-green' },
+                    { label: 'Dividend Income', value: dividendIncome, color: 'text-app-green' },
+                    { label: 'Interest Income', value: interestIncome, color: 'text-app-teal' },
                   ].map(item => (
                     <div key={item.label}>
                       <div className="flex justify-between mb-1">
@@ -271,21 +271,21 @@ export default function ReturnsAnalysisPage() {
                       )}
                     </div>
                   ))}
-                  <div className="flex justify-between border-t border-green-500/10 pt-3">
+                  <div className="flex justify-between border-t border-app-green/10 pt-3">
                     <span className="text-sm font-semibold text-white">Total</span>
-                    <span className="text-lg font-bold text-green-400">{formatCurrency(totalIncome)}</span>
+                    <span className="text-lg font-bold text-app-green">{formatCurrency(totalIncome)}</span>
                   </div>
                 </div>
               </motion.div>
-              <motion.div variants={fadeUpItem} className="bg-red-500/5 border border-red-500/15 rounded-xl p-5">
+              <motion.div variants={fadeUpItem} className="bg-app-red/5 border border-app-red/15 rounded-xl p-5">
                 <div className="flex items-center gap-2 mb-3">
-                  <Receipt className="w-4 h-4 text-red-400" />
+                  <Receipt className="w-4 h-4 text-app-red" />
                   <p className="text-sm font-medium text-white">Costs & Losses</p>
                 </div>
                 <div className="space-y-3">
                   {[
-                    { label: 'Investment Loss', value: investmentLoss, color: 'text-red-400' },
-                    { label: 'Broker Fees', value: brokerFees, color: 'text-orange-400' },
+                    { label: 'Investment Loss', value: investmentLoss, color: 'text-app-red' },
+                    { label: 'Broker Fees', value: brokerFees, color: 'text-app-orange' },
                   ].map(item => (
                     <div key={item.label}>
                       <div className="flex justify-between mb-1">
@@ -302,9 +302,9 @@ export default function ReturnsAnalysisPage() {
                       )}
                     </div>
                   ))}
-                  <div className="flex justify-between border-t border-red-500/10 pt-3">
+                  <div className="flex justify-between border-t border-app-red/10 pt-3">
                     <span className="text-sm font-semibold text-white">Total</span>
-                    <span className="text-lg font-bold text-red-400">{formatCurrency(totalExpenses)}</span>
+                    <span className="text-lg font-bold text-app-red">{formatCurrency(totalExpenses)}</span>
                   </div>
                 </div>
               </motion.div>
@@ -313,7 +313,7 @@ export default function ReturnsAnalysisPage() {
             <div className="mt-4 bg-white/[0.04] border border-border rounded-xl p-5">
               <div className="flex justify-between items-center">
                 <span className="text-lg font-semibold text-white">Net Profit/Loss</span>
-                <span className={`text-2xl font-bold ${netProfitLoss >= 0 ? 'text-green-400' : 'text-red-400'}`}>
+                <span className={`text-2xl font-bold ${netProfitLoss >= 0 ? 'text-app-green' : 'text-app-red'}`}>
                   {netProfitLoss >= 0 ? '+' : ''}{formatCurrency(netProfitLoss)}
                 </span>
               </div>

--- a/frontend/src/pages/settings/sections/salary/RsuGrants.tsx
+++ b/frontend/src/pages/settings/sections/salary/RsuGrants.tsx
@@ -126,7 +126,7 @@ export function RsuGrants(props: Readonly<RsuGrantsProps>) {
             <button
               type="button"
               onClick={() => onRemoveGrant(grant.id)}
-              className="p-2 rounded-lg text-red-400 hover:bg-red-500/10 transition-colors mt-6"
+              className="p-2 rounded-lg text-app-red hover:bg-app-red/10 transition-colors mt-6"
               title="Delete grant"
             >
               <Trash2 className="w-4 h-4" />
@@ -189,7 +189,7 @@ export function RsuGrants(props: Readonly<RsuGrantsProps>) {
                           <button
                             type="button"
                             onClick={() => onRemoveVesting(grant.id, vi)}
-                            className="p-1 rounded text-red-400 hover:bg-red-500/10 transition-colors"
+                            className="p-1 rounded text-app-red hover:bg-app-red/10 transition-colors"
                             title="Remove vesting"
                           >
                             <X className="w-3.5 h-3.5" />

--- a/frontend/src/pages/subscription-tracker/SubscriptionTrackerPage.tsx
+++ b/frontend/src/pages/subscription-tracker/SubscriptionTrackerPage.tsx
@@ -252,7 +252,7 @@ function RecurringCard({
               {item.is_active ? <Power className="w-3.5 h-3.5" /> : <PowerOff className="w-3.5 h-3.5" />}
             </button>
             <button type="button" onClick={onDelete}
-              title="Delete" className="p-1.5 rounded-lg text-text-tertiary hover:text-app-red hover:bg-red-500/10 transition-colors">
+              title="Delete" className="p-1.5 rounded-lg text-text-tertiary hover:text-app-red hover:bg-app-red/10 transition-colors">
               <Trash2 className="w-3.5 h-3.5" />
             </button>
           </div>

--- a/frontend/src/pages/tax-planning/TaxPlanningPage.tsx
+++ b/frontend/src/pages/tax-planning/TaxPlanningPage.tsx
@@ -282,8 +282,8 @@ export default function TaxPlanningPage() {
                   className="glass rounded-2xl border border-border p-4 md:p-6"
                 >
                   <div className="flex items-center gap-3 mb-4">
-                    <div className="p-2.5 bg-blue-500/10 rounded-xl">
-                      <TrendingUp className="w-5 h-5 text-blue-400" />
+                    <div className="p-2.5 bg-app-blue/10 rounded-xl">
+                      <TrendingUp className="w-5 h-5 text-app-blue" />
                     </div>
                     <div>
                       <h3 className="text-lg font-semibold">Tax Per Year</h3>


### PR DESCRIPTION
## What

Applied the new `design-system-ui` craft skill (PR #190) as an audit lens. It found **83 hardcoded Tailwind palette colors** (`text-red-400`, `bg-blue-500/10`, `border-amber-600`, …) across **24 files** that drifted from the app's `app-*` semantic tokens — rendering subtly different greens/reds/blues page-to-page.

## Changes
- Swept all 83 → `app-*` tokens, preserving opacity suffixes (`/10`, `/50`, …) and variant prefixes (`focus:`, `hover:`):
  - red/rose → `app-red`, green/emerald → `app-green`, blue → `app-blue`, purple → `app-purple`, teal → `app-teal`, orange → `app-orange`, yellow/amber → `app-yellow`, indigo → `app-indigo`, pink → `app-pink`
  - ProfileModal's two warning tiers kept visually distinct (orange vs yellow)
- **ChatWidget** floating button gained `aria-label` + `aria-expanded` (was `title`-only — unlabeled for screen readers on every page).

## Not changed (checked, deliberately left)
- Side-stripe `border-l-4` accents (DashboardPage, FlowSummaryCards, AnomalyReviewPage) — a consistent existing design choice, not drift.
- `InstrumentProjections` / `StaleDataBadge` "title" attributes — those are `MetricCard` titles and a text-labelled `<output>`, not icon-button a11y gaps (heuristic false-positives, verified by reading).

## Verification
- **0** hardcoded palette colors remain (`grep` clean)
- 227 vitest pass; tsc + eslint clean
- Mechanical class-string swaps only — no logic touched