### PR TITLE
feat(a11y): respect prefers-reduced-motion at root + enrich craft skills from kalchar

### DIFF
--- a/.claude/skills/accessible-ui/SKILL.md
+++ b/.claude/skills/accessible-ui/SKILL.md
@@ -65,9 +65,22 @@ This app is dark-only. The dim grays bite: `--color-text-tertiary` was lifted to
 
 Income-green vs expense-red is fine as *reinforcement*, but never the *only* signal (1.4.1) — a red/green colorblind user can't tell them apart. Pair color with a sign (`+`/`-`), an icon (arrow up/down), or a label. Most amounts in this app already carry a sign; keep it that way.
 
+## Prefer native elements over ARIA roles
+
+(Proven in the sibling kalchar repo — they cleared 8 Sonar findings doing this.) A real `<button>`/`<a>`/`<nav>`/`<ul><li>` comes with keyboard operability, focus, and semantics for free; `<div role="button">` makes you re-implement all of it (and usually you miss `onKeyDown`). Reach for ARIA only when there's no native equivalent:
+- Use `<button>` not `<div role="button" onClick>`. (ledger-sync is already clean here — keep it.)
+- Use `<nav>`/`<ul>`/`<li>` for nav lists, not `role="list"`.
+- **Tabs are the legit exception** — HTML has no native tab widget, so `role="tablist"`/`role="tab"` is correct (the time-filter/comparison selectors use it rightly). ARIA tabs additionally need arrow-key navigation + `aria-selected`.
+- Mark purely decorative elements (icons next to text, gradient orbs) `aria-hidden="true"` so they don't pollute the AT tree.
+
+## Touch targets
+
+Interactive controls need ≥ **44px** hit area on phone (most users). Compact desktop pills (`py-1.5` ≈ 32px) must bump up on mobile — `py-2.5 sm:py-1.5` — same fix the time-filter pills got.
+
 ## Quick checklist
 - [ ] Icon-only control has `aria-label`.
 - [ ] Modal: `role` + `aria-modal` + labelled + Escape + focus return.
 - [ ] Input has `htmlFor`/`id` or `aria-label`; placeholder is not the label.
-- [ ] Readable text clears 4.5:1 (3:1 for large/UI).
+- [ ] Native element used where one exists; ARIA only for true gaps (tabs); decorative = `aria-hidden`.
+- [ ] Readable text clears 4.5:1 (3:1 for large/UI); ≥44px tap targets on phone.
 - [ ] Meaning isn't carried by color alone.

--- a/.claude/skills/design-system-ui/SKILL.md
+++ b/.claude/skills/design-system-ui/SKILL.md
@@ -44,8 +44,17 @@ Most users are on phones. Tailwind is mobile-first: style unprefixed for mobile,
 
 `PageHeader` is `sticky top-0` and bakes `env(safe-area-inset-*)` into its padding so titles clear the iOS notch. Its horizontal padding scales with the breakout margins so the title aligns with page content (don't override `paddingLeft` with a flat inline value — that caused a 16px title/content misalignment). In demo mode the fixed banner needs top clearance on phone (`<main>` gets `pt-14 sm:pt-0`).
 
+## Motion (visible by default, respectful when asked)
+
+ledger-sync uses framer-motion heavily and motion is **wanted** — fade-up reveals, hover lifts, stagger. Keep it. Two rules borrowed from the sibling kalchar repo make it polished without dulling anything:
+
+- **Reduced-motion is handled at the library level**, not per-component: `<MotionConfig reducedMotion="user">` wraps the app, so motion stays full for everyone *except* users whose OS sets `prefers-reduced-motion: reduce` (vestibular/accessibility need). That's WCAG 2.3.3 with zero cost to normal viewing — don't hand-gate every animation.
+- **Named motion tokens, no magic timings.** Reuse the variants in `constants/animations.ts` (`fadeUpItem`, `staggerContainer`, …) rather than inlining `duration: 0.37`. Animate compositor-friendly props (opacity/transform), never layout (width/top/height) — that janks.
+- Desktop-only hover springs should gate on `@media (hover:hover) and (pointer:fine)` so phones don't pay for motion they can't trigger.
+
 ## Checklist
 - [ ] Colors via tokens/`app-*` / `rawColors.*` — no hex or raw `green-400`.
 - [ ] Spacing on-scale; standard `glass rounded-2xl border` card; no nested cards.
 - [ ] Mobile-first; grids collapse; tables scroll; touch targets ≥44px on phone.
 - [ ] `h-dvh` not `h-screen`; no `dark:`, no gradient text, no new side-stripes.
+- [ ] Motion reuses animation tokens + transform/opacity only; reduced-motion left to the root `MotionConfig`.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense, useEffect, useRef, useState } from 'react'
 import { BrowserRouter, Routes, Route, Link } from 'react-router-dom'
 
 import { QueryClientProvider } from '@tanstack/react-query'
+import { MotionConfig } from 'framer-motion'
 import { Toaster } from 'sonner'
 
 import { queryClient } from '@/lib/queryClient'
@@ -194,6 +195,10 @@ const TOASTER_OPTIONS = {
 function App() {
   return (
     <ErrorBoundary>
+      {/* reducedMotion="user" keeps motion full for everyone EXCEPT users whose
+          OS requests reduced motion (WCAG 2.3.3) — library-level, so individual
+          components don't each need a prefers-reduced-motion gate. */}
+      <MotionConfig reducedMotion="user">
       <QueryClientProvider client={queryClient}>
         <AuthInitializer>
           <PreferencesProvider>
@@ -254,6 +259,7 @@ function App() {
           </PreferencesProvider>
         </AuthInitializer>
       </QueryClientProvider>
+      </MotionConfig>
     </ErrorBoundary>
   )
 }


### PR DESCRIPTION
## What

Cross-pollinated proven patterns from the sibling **kalchar** repo (same React 19 + Tailwind 4 + lucide stack, so its house rules are battle-tested, not aspirational).

### Code
- Wrapped the app in `<MotionConfig reducedMotion="user">`. framer-motion animations now reduce **only** for users whose OS sets `prefers-reduced-motion: reduce` (WCAG 2.3.3). Motion stays **fully visible for everyone else** — zero cost to normal viewing, and no per-component gating needed (107 motion files covered at the root).

### Skills enriched
- **accessible-ui**: prefer native elements over ARIA roles (kalchar cleared 8 Sonar findings this way; tabs are the legit ARIA exception), decorative elements `aria-hidden`, 44px tap targets.
- **design-system-ui**: new Motion section — named tokens not magic timings, animate transform/opacity not layout, gate desktop hover springs to `(hover:hover) and (pointer:fine)`, reduced-motion handled at root.

### Deliberately NOT ported
- kalchar's uniform `rounded-md` — ledger-sync's varied radius scale (`rounded-2xl` cards / `rounded-lg` controls / `rounded-full` pills) is its own intentional language.
- kalchar's SEO/metadata/JSON-LD/sitemap rules — ledger-sync is a private auth-gated dashboard, not a public marketing site.

## Verification
- 227 vitest pass; tsc + eslint clean
- `MotionConfig` is a valid framer-motion 12.41 export; wraps inside ErrorBoundary so render errors still surface