### PR TITLE
fix(budget): guard remaining budget-limit inputs against negative/NaN

### DIFF
--- a/frontend/src/components/analytics/components/AddBudgetForm.tsx
+++ b/frontend/src/components/analytics/components/AddBudgetForm.tsx
@@ -34,9 +34,12 @@ export default function AddBudgetForm({
         <input
           type="number"
           inputMode="decimal"
+          min="0"
+          step="any"
           value={newLimit}
           onChange={(e) => onLimitChange(e.target.value)}
           placeholder="Budget limit"
+          aria-label="Budget limit"
           className="w-32 px-3 py-2 rounded-lg bg-background/50 border border-border text-sm"
         />
         <button

--- a/frontend/src/pages/budget/components/BudgetRowItem.tsx
+++ b/frontend/src/pages/budget/components/BudgetRowItem.tsx
@@ -87,13 +87,20 @@ export function BudgetRowItem(props: Readonly<BudgetRowItemProps>) {
             <input
               type="number"
               inputMode="decimal"
+              min="0"
+              step="any"
+              aria-label={`Budget limit for ${row.category}`}
               defaultValue={row.limit}
               onBlur={(e) => {
-                onSave(Number.parseFloat(e.target.value), row.period)
+                const v = Number.parseFloat(e.target.value)
+                if (Number.isFinite(v) && v >= 0) onSave(v, row.period)
+                else onCancelEdit()
               }}
               onKeyDown={(e) => {
                 if (e.key === 'Enter') {
-                  onSave(Number.parseFloat((e.target as HTMLInputElement).value), row.period)
+                  const v = Number.parseFloat((e.target as HTMLInputElement).value)
+                  if (Number.isFinite(v) && v >= 0) onSave(v, row.period)
+                  else onCancelEdit()
                 }
                 if (e.key === 'Escape') onCancelEdit()
               }}


### PR DESCRIPTION
Skill-lens sweep found two more budget-limit inputs in the same class as the earlier AddBudgetForm fix — no `min`, no validation.

- `analytics/components/AddBudgetForm.tsx`: add `min=0` + `step` + `aria-label`.
- `budget/components/BudgetRowItem.tsx` (inline edit): add `min=0` + `aria-label`; guard `onSave` so empty/negative cancels the edit instead of persisting NaN.

227 vitest pass; tsc + eslint clean.