### PR TITLE
chore+feat: project hygiene + ledger-interface UI restyle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,61 @@
+# Ledger Sync environment template.
+# Copy LEDGER_SYNC_* variables to backend/.env for local backend development.
+# Copy VITE_* variables to frontend/.env.local for local frontend development.
+# Never put real secrets in this file.
+
+# Backend runtime
+LEDGER_SYNC_ENVIRONMENT=development
+LEDGER_SYNC_DATABASE_URL=sqlite:///./ledger_sync.db
+LEDGER_SYNC_DATABASE_ECHO=false
+LEDGER_SYNC_LOG_LEVEL=INFO
+LEDGER_SYNC_DATA_DIR=./data
+LEDGER_SYNC_FRONTEND_URL=http://localhost:5173
+LEDGER_SYNC_CORS_ORIGINS=["http://localhost:3000","http://localhost:5173","http://localhost:5174"]
+
+# Auth and encryption
+# Required in production. Use a random value of at least 32 characters.
+LEDGER_SYNC_JWT_SECRET_KEY=change-me-to-a-long-random-string-at-least-32-chars
+LEDGER_SYNC_ENCRYPTION_KEY=change-me-to-a-separate-random-string-at-least-32-chars
+LEDGER_SYNC_JWT_ALGORITHM=HS256
+LEDGER_SYNC_JWT_ACCESS_TOKEN_EXPIRE_MINUTES=30
+LEDGER_SYNC_JWT_REFRESH_TOKEN_EXPIRE_DAYS=7
+LEDGER_SYNC_JWT_STRICT_TV=false
+
+# OAuth providers
+LEDGER_SYNC_GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
+LEDGER_SYNC_GOOGLE_CLIENT_SECRET=your-google-client-secret
+LEDGER_SYNC_GITHUB_CLIENT_ID=your-github-client-id
+LEDGER_SYNC_GITHUB_CLIENT_SECRET=your-github-client-secret
+
+# Uploads
+LEDGER_SYNC_MAX_UPLOAD_SIZE_BYTES=52428800
+
+# PostgreSQL pool settings
+LEDGER_SYNC_DB_POOL_SIZE=5
+LEDGER_SYNC_DB_MAX_OVERFLOW=3
+LEDGER_SYNC_DB_POOL_RECYCLE_SECONDS=300
+LEDGER_SYNC_DB_CONNECT_TIMEOUT_SECONDS=10
+LEDGER_SYNC_DB_STATEMENT_TIMEOUT_SECONDS=30
+LEDGER_SYNC_DB_IDLE_TRANSACTION_TIMEOUT_SECONDS=60
+
+# AI assistant
+LEDGER_SYNC_BEDROCK_API_KEY=your-bedrock-api-key
+LEDGER_SYNC_AI_DEFAULT_BEDROCK_MODEL=us.anthropic.claude-haiku-4-5-20251001-v1:0
+LEDGER_SYNC_AI_DEFAULT_BEDROCK_REGION=us-east-1
+LEDGER_SYNC_AI_DAILY_MESSAGE_LIMIT=10
+LEDGER_SYNC_AI_MAX_TOOL_ROUNDS=6
+
+# Optional AWS credential-chain alternatives for Bedrock.
+# Prefer LEDGER_SYNC_BEDROCK_API_KEY on Vercel.
+AWS_BEARER_TOKEN_BEDROCK=your-bedrock-api-key
+AWS_ACCESS_KEY_ID=your-aws-access-key-id
+AWS_SECRET_ACCESS_KEY=your-aws-secret-access-key
+AWS_SESSION_TOKEN=your-aws-session-token
+AWS_PROFILE=default
+
+# Frontend
+VITE_API_BASE_URL=http://localhost:8000
+
+# Deployment helpers
+GITHUB_PAGES=false
+PYTHON_VERSION=3.13

--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ out/
 
 # Node.js / npm
 node_modules/
+.pnpm-store/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing
+
+Thanks for improving Ledger Sync. Keep changes focused and verify both stacks before opening a PR.
+
+## Setup
+
+```bash
+pnpm install
+pnpm run setup
+pnpm run dev
+```
+
+Local services:
+
+- Frontend: http://localhost:5173
+- Backend API: http://localhost:8000
+- API docs: http://localhost:8000/docs
+
+Use `.env.example` as the template. Put backend values in `backend/.env` and frontend values in `frontend/.env.local`. Never commit real secrets or `.env` files.
+
+## Checks
+
+Run the full project check before submitting:
+
+```bash
+pnpm run check
+pnpm run build
+```
+
+Backend-only:
+
+```bash
+cd backend
+uv run ruff check .
+uv run mypy src/
+uv run pytest tests/ -v
+```
+
+Frontend-only:
+
+```bash
+cd frontend
+pnpm run lint
+pnpm run type-check
+pnpm test
+pnpm run build
+```
+
+## Pull Requests
+
+- Keep changes surgical and tied to one problem.
+- Use conventional commits such as `fix: update onboarding docs`.
+- Include what changed, why, and the checks you ran.
+- Do not include generated caches, local databases, `node_modules`, or secrets.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Mint shut down. YNAB costs $14.99/mo and doesn't understand Indian bank statemen
 
 - Node 20+
 - [pnpm 10](https://pnpm.io/installation)
-- Python 3.11+
+- Python 3.13+
 - [uv](https://docs.astral.sh/uv/getting-started/installation/)
 
 ### Installation
@@ -157,7 +157,7 @@ For a tour without signing up, visit `/demo`.
 | Layer            | Technology                                                                     |
 | ---------------- | ------------------------------------------------------------------------------ |
 | **Frontend**     | React 19, TypeScript 6, Vite 8, Tailwind CSS 4, Recharts 3, Framer Motion 12   |
-| **Backend**      | Python 3.11+, FastAPI, SQLAlchemy 2, Alembic                                   |
+| **Backend**      | Python 3.13+, FastAPI, SQLAlchemy 2, Alembic                                   |
 | **Database**     | SQLite (dev), Neon PostgreSQL 17 (prod)                                        |
 | **State**        | TanStack Query 5, Zustand 5                                                    |
 | **Deployment**   | GitHub Pages (frontend), Vercel (backend), Neon (database)                     |

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,6 +1,6 @@
 # Ledger Sync -- Backend
 
-FastAPI backend powering the Ledger Sync personal finance dashboard. Handles Excel import, transaction reconciliation, financial analytics, exchange rate proxying, user preferences, AI assistant configuration with encrypted key storage, and Bedrock streaming proxy.
+FastAPI backend powering the Ledger Sync personal finance dashboard. Handles Excel import, transaction reconciliation, financial analytics, exchange rate proxying, user preferences, AI assistant configuration with encrypted key storage, and the Bedrock Converse proxy.
 
 ## Features
 
@@ -11,13 +11,13 @@ FastAPI backend powering the Ledger Sync personal finance dashboard. Handles Exc
 - SQLite (dev) / PostgreSQL (prod) with SQLAlchemy ORM
 - Alembic database migrations
 - AI assistant config with AES-256-GCM encrypted API keys (PBKDF2 + per-ciphertext random salt)
-- Bedrock streaming proxy via boto3 (SigV4 auth + EventStream parsing)
+- Bedrock Converse proxy via boto3 (SigV4 or Bedrock API-key auth, JSON response)
 
 ## Tech Stack
 
 | Component  | Technology     |
 | ---------- | -------------- |
-| Language   | Python 3.11+   |
+| Language   | Python 3.13+   |
 | Framework  | FastAPI        |
 | ORM        | SQLAlchemy 2.0 |
 | Database   | SQLite (dev) / PostgreSQL (prod) |
@@ -55,7 +55,7 @@ backend/
 │   │   ├── analytics_v2.py  # Pre-aggregated analytics
 │   │   ├── calculations.py  # Financial calculation endpoints
 │   │   ├── preferences.py   # User preferences (incl. AI config)
-│   │   ├── ai_chat.py       # Bedrock streaming proxy
+│   │   ├── ai_chat.py       # Bedrock Converse proxy
 │   │   ├── account_classifications.py
 │   │   ├── exchange_rates.py, stock_price.py
 │   │   └── meta.py, reports.py, transactions.py, upload.py

--- a/docs/API.md
+++ b/docs/API.md
@@ -1070,13 +1070,13 @@ Stores AI provider configuration with the key encrypted at rest.
 }
 ```
 
-`provider` must be one of `openai`, `anthropic`, `bedrock`. For Bedrock, set `region` (e.g. `"us-east-1"`); `api_key` is still stored but Bedrock calls currently use the server's AWS credential chain via boto3.
+`provider` must be one of `openai`, `anthropic`, `bedrock`. Saving provider-specific config switches the user to BYOK mode. For Bedrock, set `region` (e.g. `"us-east-1"`); calls still go through the backend proxy because Bedrock requires signed server-side auth.
 
 ### Get Decrypted API Key
 
-**GET** `/api/preferences/ai-config/key/reveal`
+**GET** `/api/preferences/ai-config/key`
 
-Returns the decrypted API key for use in browser-direct streaming calls (OpenAI, Anthropic). The frontend calls this on each chat send; the key is never cached in localStorage.
+Returns the decrypted API key for browser-direct OpenAI and Anthropic calls. The frontend calls this on each chat send; the key is never cached in localStorage.
 
 **Response:**
 
@@ -1087,7 +1087,7 @@ Returns the decrypted API key for use in browser-direct streaming calls (OpenAI,
 **Error Responses:**
 
 - `404` if no key is configured
-- `400` with detail `"Cannot decrypt API key -- the server secret likely changed..."` if the JWT secret rotated since the key was saved (user must re-enter their key in Settings)
+- `400` if the encrypted key cannot be decrypted because the encryption secret changed (user must re-enter their key in Settings)
 
 ### Delete AI Config
 
@@ -1095,11 +1095,11 @@ Returns the decrypted API key for use in browser-direct streaming calls (OpenAI,
 
 Clears the stored provider, model, and encrypted key. Returns `{"status": "deleted"}`.
 
-### Bedrock Streaming Proxy
+### Bedrock Chat Proxy
 
 **POST** `/api/ai/bedrock/chat`
 
-Streams a Bedrock converse-stream response as Server-Sent Events. Required because Bedrock needs SigV4 authentication and doesn't support CORS for browser-direct calls. Uses `boto3.client('bedrock-runtime').converse_stream()` server-side.
+Calls Bedrock Converse server-side and returns the full assistant response as JSON. Required because Bedrock needs signed server-side authentication and doesn't support CORS for browser-direct calls. Uses `boto3.client('bedrock-runtime').converse()` server-side.
 
 **Request Body:**
 
@@ -1113,19 +1113,18 @@ Streams a Bedrock converse-stream response as Server-Sent Events. Required becau
 }
 ```
 
-**Response:** `text/event-stream` (SSE). Each event is either a token or an error:
+**Response:** JSON with text and optional tool-use blocks:
 
+```json
+{
+  "blocks": [
+    { "type": "text", "text": "Based on your latest data..." }
+  ],
+  "stop_reason": "end_turn"
+}
 ```
-data: {"token": "Based"}
 
-data: {"token": " on"}
-
-data: {"token": " your"}
-
-data: [DONE]
-```
-
-Errors are sent as `data: {"error": "..."}` followed by `data: [DONE]`.
+Errors return normal HTTP error responses with a JSON `detail` field.
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -68,14 +68,16 @@ Vercel auto-detects `uv.lock` and uses `uv` to install dependencies (falls back 
 |----------|----------|-------|
 | `LEDGER_SYNC_DATABASE_URL` | Yes | Neon pooler connection string (`postgresql://...?sslmode=require`). Do NOT include `channel_binding=require`. |
 | `LEDGER_SYNC_JWT_SECRET_KEY` | Yes | Generate with `openssl rand -hex 32` (min 32 chars) |
+| `LEDGER_SYNC_ENCRYPTION_KEY` | Yes | Separate random key for BYOK API-key encryption (min 32 chars) |
 | `LEDGER_SYNC_GOOGLE_CLIENT_ID` | For Google login | Google OAuth client ID |
 | `LEDGER_SYNC_GOOGLE_CLIENT_SECRET` | For Google login | Google OAuth client secret |
 | `LEDGER_SYNC_GITHUB_CLIENT_ID` | For GitHub login | GitHub OAuth client ID (create a **separate** prod app) |
 | `LEDGER_SYNC_GITHUB_CLIENT_SECRET` | For GitHub login | GitHub OAuth client secret |
+| `LEDGER_SYNC_BEDROCK_API_KEY` | For app AI mode | Bedrock API key bridged to `AWS_BEARER_TOKEN_BEDROCK` at startup |
 | `LEDGER_SYNC_FRONTEND_URL` | Yes | `https://sagargupta.online/ledger-sync` |
 | `LEDGER_SYNC_CORS_ORIGINS` | Yes | JSON array of allowed origins |
 | `LEDGER_SYNC_ENVIRONMENT` | Yes | `production` |
-| `PYTHON_VERSION` | Yes | `3.12` |
+| `PYTHON_VERSION` | Yes | `3.13` |
 
 The Neon integration also injects `NEON_DATABASE_URL`, `NEON_PGHOST`, and other `NEON_*` variables automatically.
 
@@ -187,6 +189,7 @@ git push origin main
 |----------|----------|---------|-------------|
 | `LEDGER_SYNC_DATABASE_URL` | Yes | `sqlite:///./ledger_sync.db` | Database connection string |
 | `LEDGER_SYNC_JWT_SECRET_KEY` | Yes (prod) | dev default | JWT signing secret (min 32 chars) |
+| `LEDGER_SYNC_ENCRYPTION_KEY` | Yes (prod) | JWT secret fallback | Dedicated key for BYOK API-key encryption |
 | `LEDGER_SYNC_ENVIRONMENT` | No | `development` | `development`, `staging`, or `production` |
 | `LEDGER_SYNC_CORS_ORIGINS` | No | See settings.py | JSON array of allowed origins |
 | `LEDGER_SYNC_FRONTEND_URL` | Yes (prod) | `http://localhost:5173` | Frontend base URL for OAuth redirects |
@@ -194,8 +197,11 @@ git push origin main
 | `LEDGER_SYNC_GOOGLE_CLIENT_SECRET` | No | - | Google OAuth client secret |
 | `LEDGER_SYNC_GITHUB_CLIENT_ID` | No | - | GitHub OAuth client ID |
 | `LEDGER_SYNC_GITHUB_CLIENT_SECRET` | No | - | GitHub OAuth client secret |
+| `LEDGER_SYNC_BEDROCK_API_KEY` | For app AI mode | - | Bedrock API key for server-side Converse calls |
+| `LEDGER_SYNC_AI_DAILY_MESSAGE_LIMIT` | No | `10` | Per-user daily app-mode chat cap |
+| `LEDGER_SYNC_AI_MAX_TOOL_ROUNDS` | No | `6` | Max tool-calling rounds per chat message |
 | `LEDGER_SYNC_LOG_LEVEL` | No | `INFO` | Python log level |
-| `PYTHON_VERSION` | Yes (Vercel) | - | Python version (e.g., `3.12`) |
+| `PYTHON_VERSION` | Yes (Vercel) | - | Python version (e.g., `3.13`) |
 
 ### Frontend (GitHub Actions)
 
@@ -249,7 +255,7 @@ git push origin main
 For an always-on deployment without cold starts:
 
 1. Get a VPS (DigitalOcean, Linode, Oracle Cloud free tier)
-2. Install Python 3.11+, Node.js 22+, Nginx
+2. Install Python 3.13+, Node.js 22+, Nginx
 3. Clone the repo, install dependencies
 4. Create a systemd service for the backend
 5. Build the frontend and serve with Nginx

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 ### Prerequisites
 
-- Python 3.11+
+- Python 3.13+
 - Node.js 22+ (with pnpm)
 - Git
 - VS Code (recommended)
@@ -80,7 +80,7 @@ pnpm run dev
 backend/
 ├── src/ledger_sync/
 │   ├── api/              # FastAPI routers (one file per resource)
-│   │   ├── ai_chat.py    # Bedrock streaming proxy
+│   │   ├── ai_chat.py    # Bedrock Converse proxy
 │   │   ├── analytics.py, analytics_v2.py
 │   │   ├── preferences.py  # incl. AI config endpoints
 │   │   └── ...

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,7 +25,7 @@ Ledger Sync is a self-hosted personal finance dashboard built as a full-stack ap
   - `analytics_v2.py` - Pre-aggregated analytics endpoints (reads from summary tables for speed)
   - `calculations.py` - Financial calculation endpoints
   - `preferences.py` - User preferences CRUD (includes AI config endpoints: `PUT/GET/DELETE /api/preferences/ai-config`)
-  - `ai_chat.py` - Bedrock streaming proxy (`POST /api/ai/bedrock/chat`). Required because Bedrock needs SigV4 auth and doesn't support CORS for browser-direct calls. Uses `boto3.client('bedrock-runtime').converse_stream()` and re-streams as SSE
+  - `ai_chat.py` - Bedrock Converse proxy (`POST /api/ai/bedrock/chat`). Required because Bedrock needs signed server-side auth and doesn't support CORS for browser-direct calls. Uses `boto3.client('bedrock-runtime').converse()` and returns JSON.
   - `exchange_rates.py` - Exchange rate proxy with 24h cache (frankfurter.dev)
   - `stock_price.py` - Yahoo Finance proxy for RSU grant stock prices
   - `deps.py` - JWT authentication dependency (`get_current_user`)
@@ -47,7 +47,7 @@ Ledger Sync is a self-hosted personal finance dashboard built as a full-stack ap
   - `insights.py` - Smart financial insight generation
   - `query_helpers.py` - Shared SQL aggregation helpers (`income_sum_col`, `expense_sum_col`, `build_transaction_query`, `excluded_accounts_for`) used by both `calculations.py` and `analytics.py` to eliminate duplicated CASE/SUM patterns. `build_transaction_query` applies the user's `excluded_accounts` preference by default (override via `apply_excluded_accounts=False` for diagnostic queries) so all three transaction-query code paths (analytics engine, transactions API, on-the-fly calculations) stay consistent
   - `time_filter.py` - Time range filtering logic
-  - `encryption.py` - AES-256-GCM encrypt/decrypt for AI API keys. Uses PBKDF2-HMAC-SHA256 to derive an encryption key from the JWT secret, with a per-ciphertext random 128-bit salt. Output format: base64(salt[16] || nonce[12] || ciphertext). `DecryptionError` raised on tag mismatch so callers can prompt for re-entry.
+  - `encryption.py` - AES-256-GCM encrypt/decrypt for AI API keys. Current writes use a v2 ciphertext format with HKDF-SHA256 derived from `LEDGER_SYNC_ENCRYPTION_KEY` and a per-ciphertext random 128-bit salt. Legacy v1 ciphertexts derived from the JWT secret via PBKDF2 remain readable and are re-encrypted on reveal. `DecryptionError` is raised on tag mismatch so callers can prompt for re-entry.
   - `auth/` - JWT token creation and verification
 
 #### 3. **Data Access Layer** (`src/ledger_sync/db/`)
@@ -199,7 +199,7 @@ NET Investment = Transfer-In amounts - Transfer-Out amounts
     - `StandardBarChart` - Reusable bar chart wrapper with consistent theming and defaults
     - `StandardAreaChart` - Reusable area chart wrapper with gradient fills and consistent styling
     - `StandardPieChart` - Reusable pie/donut chart wrapper with legend defaults
-  - `chat/` - AI chatbot widget (`ChatWidget`, `ChatPanel`, `ChatMessage`, `useChat` hook). Floating bottom-right button expands into a glass-morphism panel; streams responses token-by-token via provider adapters
+  - `chat/` - AI chatbot widget (`ChatWidget`, `ChatPanel`, `ChatMessage`, `useChat` hook). Floating bottom-right button expands into a glass-morphism panel; provider adapters return full JSON replies so the tool loop can stay request-per-turn.
   - `layout/` - Layout components (AppLayout, Sidebar)
   - `shared/` - Shared components (EmptyState, AnalyticsTimeFilter, MetricCard)
   - `transactions/` - Transaction table components
@@ -411,10 +411,10 @@ GET    /api/meta/*                      - Metadata endpoints
 
 4. **AI API Key Encryption**
    - User-provided AI provider API keys (OpenAI, Anthropic, Bedrock) are encrypted at rest with AES-256-GCM
-   - Encryption key derived from `LEDGER_SYNC_JWT_SECRET_KEY` via PBKDF2-HMAC-SHA256 (100,000 iterations)
+   - Current v2 keys derive from `LEDGER_SYNC_ENCRYPTION_KEY` with HKDF-SHA256; legacy v1 keys derived from `LEDGER_SYNC_JWT_SECRET_KEY` with PBKDF2-HMAC-SHA256 remain readable during rollout
    - Each ciphertext uses a fresh random 128-bit salt stored alongside nonce and ciphertext
-   - Decryption errors (tag mismatch) raise `DecryptionError`, prompting the user to re-enter their key (happens if JWT secret rotates between saving and using)
-   - OpenAI/Anthropic streaming calls go browser-direct to the provider; Bedrock goes through backend proxy because it requires SigV4 auth and has no CORS headers
+   - Decryption errors (tag mismatch) raise `DecryptionError`, prompting the user to re-enter their key if the encryption secret changed
+   - OpenAI and Anthropic calls go browser-direct; Bedrock goes through the backend proxy because it requires signed server-side auth and has no CORS headers
 
 ## Scalability Considerations
 

--- a/docs/plans/comprehensive-hardening-2026-07-04.md
+++ b/docs/plans/comprehensive-hardening-2026-07-04.md
@@ -6,7 +6,7 @@ Wave 1 research fanned out six specialist agents; this plan is the distilled act
 
 ## Wave 0 -- shipped in `0b9d950`
 
-- FE `/api/preferences/ai-config/key` -> `/api/preferences/ai-config/key/reveal` (matched to BE).
+- FE AI key retrieval route corrected to match the BE `/api/preferences/ai-config/key` endpoint.
 - BE `rates.py` prefix `/rates` -> `/api/rates`.
 - BE `exchange_rates.py` prefix `/exchange-rates` -> `/api/exchange-rates` (also picks up `no-store` cache middleware).
 - BE `stock_price.py` prefix `/stock-price` -> `/api/stock-price` (same reason).

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,12 +1,12 @@
 # Ledger Sync Frontend
 
-Modern financial analytics dashboard built with React 19, TypeScript 5.9, and Vite 7.
+Modern financial analytics dashboard built with React 19, TypeScript 6, and Vite 8.
 
 ## Tech Stack
 
 - **React 19** - UI framework
-- **TypeScript 5.9** - Type safety
-- **Vite 7** - Fast build tool and dev server
+- **TypeScript 6** - Type safety
+- **Vite 8** - Fast build tool and dev server
 - **Tailwind CSS 4** - Utility-first styling
 - **TanStack Query 5** - Server state management and caching
 - **Zustand 5** - Lightweight global state management
@@ -69,13 +69,14 @@ src/
 
 ## Key Features
 
-### AI Chatbot (BYOK)
+### AI Chatbot (App Mode + BYOK)
 
 - Floating widget in bottom-right; click to expand into a glass-morphism chat panel
 - User configures OpenAI / Anthropic / AWS Bedrock in Settings > AI Assistant
 - API keys encrypted server-side with AES-256-GCM (PBKDF2 + per-ciphertext random salt)
 - Financial context (monthly summaries, categories, recurring bills, net worth, goals) compressed into ~2-4K token system prompt and cached 5 minutes client-side
-- OpenAI/Anthropic calls stream browser-direct; Bedrock streams through backend proxy (SigV4 + CORS constraints)
+- All providers use non-streaming JSON responses so tool-calling can run one request per turn
+- Bedrock calls go through the backend proxy because Bedrock requires signed server-side auth and has no browser CORS support
 
 ### Demo Mode
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,19 +33,6 @@
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "zustand": "^5.0.14"
   },
-  "pnpm": {
-    "overrides": {
-      "undici": ">=7.24.0 <8",
-      "follow-redirects": ">=1.15.12",
-      "serialize-javascript": ">=7.0.5",
-      "esbuild": ">=0.28.1",
-      "form-data": ">=4.0.6"
-    },
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "sharp"
-    ]
-  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@tailwindcss/postcss": "^4.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "2.22.0",
   "type": "module",
-  "packageManager": "pnpm@10.32.0",
+  "packageManager": "pnpm@11.10.0",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -3338,7 +3338,7 @@ packages:
     resolution: {integrity: sha512-/bIYdBLAVsNR3v7gYGaV4pQW3M3kEPx5E8vDxGvxo6khTrGtSSCS7QiFKv9ogzBgZiy0OXLP9zO28U/1nF1mfw==}
 
   xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz:
-    resolution: {tarball: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz}
+    resolution: {tarball: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz, integrity: sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA==}
     version: 0.20.3
     engines: {node: '>=0.8'}
     hasBin: true

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,0 +1,16 @@
+packages:
+  - .
+
+overrides:
+  undici: ">=7.24.0 <8"
+  follow-redirects: ">=1.15.12"
+  serialize-javascript: ">=7.0.5"
+  esbuild: ">=0.28.1"
+  form-data: ">=4.0.6"
+
+onlyBuiltDependencies:
+  - esbuild
+  - sharp
+
+allowBuilds:
+  sharp: true

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -69,7 +69,7 @@ export default function AppLayout() {
   }, [location.pathname])
 
   return (
-    <div className="flex h-dvh bg-background relative overflow-hidden">
+    <div className="ledger-workspace relative flex h-dvh overflow-hidden bg-background">
       {isDemoMode && <DemoBanner />}
 
       {/* Skip to main content link for keyboard users */}
@@ -81,21 +81,7 @@ export default function AppLayout() {
         Skip to main content
       </a>
 
-      {/* Static gradient orbs — kept subtle so they read as ambient depth, not
-          a glowing "AI dark theme" wash. Roughly half the previous intensity,
-          and the green corner orb is dialed back furthest since it bled most. */}
-      <div
-        className="fixed inset-0 pointer-events-none"
-        aria-hidden="true"
-        style={{
-          background: [
-            'radial-gradient(600px circle at -10% -20%, rgba(94,92,230,0.10), transparent 70%)',
-            'radial-gradient(500px circle at 110% 60%, rgba(10,132,255,0.08), transparent 70%)',
-            'radial-gradient(400px circle at 50% 30%, rgba(191,90,242,0.05), transparent 70%)',
-            'radial-gradient(450px circle at 20% 110%, rgba(48,209,88,0.05), transparent 70%)',
-          ].join(', '),
-        }}
-      />
+      <div className="ledger-workspace-bg fixed inset-0 pointer-events-none" aria-hidden="true" />
 
       <Sidebar />
       {/*

--- a/frontend/src/components/layout/MobileTabBar.tsx
+++ b/frontend/src/components/layout/MobileTabBar.tsx
@@ -51,10 +51,10 @@ export default function MobileTabBar() {
   return (
     <nav
       aria-label="Primary"
-      className="lg:hidden fixed bottom-0 left-0 right-0 z-30 bg-surface-nav backdrop-blur-lg border-t border-border"
+      className="fixed bottom-0 left-0 right-0 z-30 border-t border-[var(--hairline-2)] bg-[var(--sidebar-bg)] shadow-[0_-12px_30px_-24px_rgba(0,0,0,0.75)] backdrop-blur-lg lg:hidden"
       style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
     >
-      <ul className="flex items-stretch justify-around px-1 pt-1.5">
+      <ul className="flex items-stretch justify-around px-2 pt-1.5">
         {TABS.map((tab) => {
           const badge = tab.to === ROUTES.MORE ? moreAlertCount : 0
           return (
@@ -63,7 +63,7 @@ export default function MobileTabBar() {
               to={tab.to}
               className={({ isActive }) =>
                 cn(
-                  'relative flex flex-col items-center justify-center gap-0.5 py-1.5 rounded-xl transition-colors',
+                  'relative flex flex-col items-center justify-center gap-0.5 rounded-xl py-1.5 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
                   // min-height hits Apple's 44x44 guidance comfortably
                   'min-h-[52px]',
                   isActive ? 'text-foreground' : 'text-text-tertiary hover:text-foreground',
@@ -75,8 +75,8 @@ export default function MobileTabBar() {
                   {isActive && (
                     <motion.span
                       layoutId="mobile-tab-pill"
-                      className="absolute inset-x-2 inset-y-1 rounded-xl bg-[var(--overlay-4)]"
-                      transition={{ type: 'spring', stiffness: 520, damping: 40 }}
+                      className="absolute inset-x-1.5 inset-y-1 rounded-xl border border-[var(--hairline-2)] bg-[var(--ledger-control-bg)] shadow-[var(--ledger-control-shadow)]"
+                      transition={{ duration: 0.18, ease: [0.16, 1, 0.3, 1] }}
                     />
                   )}
                   <span className="relative z-[1]">
@@ -86,7 +86,7 @@ export default function MobileTabBar() {
                     />
                     {badge > 0 && (
                       <span
-                        className="absolute -top-1.5 -right-2 min-w-[16px] h-4 px-1 rounded-full bg-app-red text-on-accent text-[10px] font-semibold leading-4 text-center"
+                        className="absolute -right-2 -top-1.5 h-4 min-w-[16px] rounded-full bg-app-red px-1 text-center text-[10px] font-semibold leading-4 text-on-accent tabular-nums"
                         aria-label={`${badge} items need attention`}
                       >
                         {badge > 9 ? '9+' : badge}

--- a/frontend/src/components/layout/Sidebar/BrandHeader.tsx
+++ b/frontend/src/components/layout/Sidebar/BrandHeader.tsx
@@ -11,9 +11,9 @@ export default function BrandHeader({
     <button
       type="button"
       onClick={onOpenProfile}
-      className="w-full flex items-center gap-3 px-4 py-4 border-b border-border hover:bg-[var(--overlay-2)] transition-colors duration-150 group/brand"
+      className="group/brand flex w-full items-center gap-3 border-b border-[var(--hairline-2)] px-4 py-4 transition-colors duration-150 hover:bg-[var(--overlay-2)]"
     >
-      <div className="w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0 bg-app-blue/15">
+      <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg border border-app-blue/20 bg-app-blue/15">
         <PiggyBank className="w-5 h-5 text-app-blue" />
       </div>
       <div className="flex-1 min-w-0 text-left">

--- a/frontend/src/components/layout/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar/Sidebar.tsx
@@ -89,7 +89,7 @@ export default function Sidebar() {
           Left offset also respects safe-area-inset-left for landscape on notched devices. */}
       <button
         onClick={() => setIsMobileOpen(!isMobileOpen)}
-        className="lg:hidden fixed z-50 w-11 h-11 flex items-center justify-center rounded-xl bg-surface-dropdown/90 border border-[var(--hairline-2)] backdrop-blur-sm active:scale-95 transition-transform"
+        className="ledger-control fixed z-50 flex h-11 w-11 items-center justify-center rounded-xl border backdrop-blur-sm transition-transform active:scale-95 lg:hidden"
         style={{
           top: 'calc(env(safe-area-inset-top, 0px) + 0.75rem)',
           left: 'calc(env(safe-area-inset-left, 0px) + 1rem)',
@@ -107,7 +107,7 @@ export default function Sidebar() {
         className={cn(
           'fixed lg:sticky top-0 h-dvh w-64 z-40',
           'bg-[var(--sidebar-bg)] backdrop-blur-sm',
-          'border-r border-border',
+          'border-r border-[var(--hairline-2)] shadow-[8px_0_24px_-22px_rgba(0,0,0,0.7)]',
           'transition-transform duration-200 ease-out',
           isMobileOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0',
         )}
@@ -122,15 +122,15 @@ export default function Sidebar() {
           />
 
           {/* Search */}
-          <div className="px-3 py-2 border-b border-border">
+          <div className="border-b border-[var(--hairline-2)] px-3 py-2">
             <button
               onClick={openSearch}
-              className="flex items-center gap-2.5 w-full px-3 py-2 rounded-lg bg-[var(--overlay-2)] hover:bg-[var(--overlay-4)] text-text-tertiary hover:text-foreground transition-colors duration-150 text-sm"
+              className="ledger-control flex w-full items-center gap-2.5 rounded-lg border px-3 py-2 text-sm text-text-tertiary transition-colors duration-150 hover:text-foreground"
               title="Search (⌘K)"
             >
               <Search size={15} className="flex-shrink-0" />
               <span className="flex-1 text-left">Search...</span>
-              <kbd className="hidden sm:inline text-[10px] px-1.5 py-0.5 rounded bg-[var(--overlay-3)] border border-[var(--hairline-2)] text-text-quaternary font-medium">
+              <kbd className="hidden rounded border border-[var(--hairline-2)] bg-[var(--overlay-3)] px-1.5 py-0.5 text-[10px] font-medium text-text-quaternary sm:inline">
                 ⌘K
               </kbd>
             </button>
@@ -177,7 +177,7 @@ export default function Sidebar() {
 
           {/* Bottom icon bar -- extra bottom padding on iOS to clear the home-indicator. */}
           <div
-            className="border-t border-border px-3 py-2.5"
+            className="border-t border-[var(--hairline-2)] px-3 py-2.5"
             style={{ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 0.625rem)' }}
           >
             <div className="flex items-center justify-center gap-1">
@@ -189,7 +189,7 @@ export default function Sidebar() {
                   key={item.path}
                   to={item.path}
                   onClick={closeMobile}
-                  className="w-11 h-11 lg:w-9 lg:h-9 flex items-center justify-center rounded-lg text-text-tertiary hover:text-foreground hover:bg-[var(--overlay-3)] transition-colors duration-150"
+                  className="flex h-11 w-11 items-center justify-center rounded-lg text-text-tertiary transition-colors duration-150 hover:bg-[var(--ledger-control-bg-hover)] hover:text-foreground lg:h-9 lg:w-9"
                   title={item.label}
                   aria-label={item.label}
                 >
@@ -200,7 +200,7 @@ export default function Sidebar() {
                 <button
                   type="button"
                   onClick={() => exitDemoMode(queryClient, navigate)}
-                  className="w-11 h-11 lg:w-9 lg:h-9 flex items-center justify-center rounded-lg text-text-tertiary hover:text-app-red hover:bg-app-red/10 transition-colors duration-150"
+                  className="flex h-11 w-11 items-center justify-center rounded-lg text-text-tertiary transition-colors duration-150 hover:bg-app-red/10 hover:text-app-red lg:h-9 lg:w-9"
                   title="Exit Demo"
                   aria-label="Exit Demo"
                 >
@@ -211,7 +211,7 @@ export default function Sidebar() {
                   type="button"
                   onClick={handleLogout}
                   disabled={logout.isPending}
-                  className="w-11 h-11 lg:w-9 lg:h-9 flex items-center justify-center rounded-lg text-text-tertiary hover:text-app-red hover:bg-app-red/10 transition-colors duration-150 disabled:opacity-50"
+                  className="flex h-11 w-11 items-center justify-center rounded-lg text-text-tertiary transition-colors duration-150 hover:bg-app-red/10 hover:text-app-red disabled:opacity-50 lg:h-9 lg:w-9"
                   title="Sign out"
                   aria-label="Sign out"
                 >

--- a/frontend/src/components/layout/Sidebar/SidebarItem.tsx
+++ b/frontend/src/components/layout/Sidebar/SidebarItem.tsx
@@ -26,10 +26,10 @@ export default function SidebarItem({
       onClick={onNavigate}
       className={({ isActive }) =>
         cn(
-          'flex items-center gap-3 px-3 py-2 text-sm rounded-lg relative',
+          'relative flex items-center gap-3 rounded-lg px-3 py-2 text-sm',
           'transition-all duration-150 ease-out',
           isActive
-            ? 'bg-[var(--overlay-4)] text-foreground font-medium'
+            ? 'bg-[var(--overlay-4)] text-foreground font-medium shadow-[inset_0_0_0_1px_var(--hairline-2)]'
             : 'text-muted-foreground hover:bg-[var(--overlay-2)] hover:text-foreground',
         )
       }
@@ -38,7 +38,7 @@ export default function SidebarItem({
         <>
           {/* Subtle left accent bar */}
           {isActive && (
-            <div className="absolute left-0 top-1/2 -translate-y-1/2 w-[2px] h-4 rounded-full bg-app-blue" />
+            <div className="absolute left-0 top-1/2 h-5 w-[2px] -translate-y-1/2 rounded-full bg-app-blue" />
           )}
           <Icon
             size={18}
@@ -51,7 +51,7 @@ export default function SidebarItem({
           {badge !== undefined && badge > 0 && (
             <span
               className={cn(
-                'px-1.5 py-0.5 min-w-[20px] text-center text-[11px] font-semibold rounded-md flex-shrink-0',
+              'min-w-[20px] flex-shrink-0 rounded-md px-1.5 py-0.5 text-center text-[11px] font-semibold tabular-nums',
                 badgeVariant === 'alert'
                   ? 'bg-app-red/15 text-app-red'
                   : 'bg-[var(--overlay-4)] text-muted-foreground',

--- a/frontend/src/components/shared/EmptyState.tsx
+++ b/frontend/src/components/shared/EmptyState.tsx
@@ -42,7 +42,7 @@ function ActionButton({ actionLabel, actionHref, onAction, isCompact }: Readonly
   isCompact: boolean
 }>) {
   const sizeClass = getSizeClass(isCompact, 'text-xs', 'text-sm')
-  const baseClass = `inline-flex items-center gap-2 px-4 py-2 bg-app-blue text-primary-foreground rounded-lg font-medium hover:bg-app-blue active:scale-[0.98] transition-colors duration-150 ${sizeClass}`
+  const baseClass = `inline-flex items-center gap-2 rounded-lg border border-app-blue/40 bg-app-blue px-4 py-2 font-medium text-primary-foreground shadow-[var(--ledger-control-shadow)] transition-colors duration-150 hover:border-app-blue/60 hover:bg-app-blue-vibrant active:scale-[0.98] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)] ${sizeClass}`
 
   if (actionHref) {
     return (
@@ -80,7 +80,7 @@ export default function EmptyState({
           <div
             role="img"
             aria-label="Empty chart placeholder"
-            className="flex items-end gap-1 h-24 border-l border-b border-border pl-2 pb-1"
+            className="flex h-24 items-end gap-1 border-b border-l border-[var(--hairline-2)] pb-1 pl-2"
           >
             {[40, 65, 30, 80, 55, 45, 70, 35, 60, 50].map((h) => (
               <div
@@ -93,10 +93,10 @@ export default function EmptyState({
         </div>
         <div className="flex flex-col items-center gap-2">
           {Icon && <Icon className="w-8 h-8 text-text-tertiary" />}
-          <h3 className="text-base font-medium text-foreground">{title}</h3>
+          <h3 className="text-base font-semibold text-foreground">{title}</h3>
           {description && <p className="text-sm text-text-tertiary max-w-sm">{description}</p>}
           {actionLabel && actionHref && (
-            <a href={actionHref} className="mt-2 text-sm text-app-blue hover:text-app-blue transition-colors duration-150">{actionLabel}</a>
+            <a href={actionHref} className="mt-2 text-sm font-medium text-app-blue transition-colors duration-150 hover:text-app-blue-vibrant">{actionLabel}</a>
           )}
         </div>
       </div>
@@ -111,7 +111,7 @@ export default function EmptyState({
     >
       {/* Icon */}
       <div
-        className={`rounded-xl bg-[var(--overlay-3)] flex items-center justify-center mb-4 ${
+        className={`mb-4 flex items-center justify-center rounded-xl border border-[var(--hairline-2)] bg-[var(--overlay-3)] ${
           getSizeClass(isCompact, 'w-12 h-12', 'w-16 h-16')
         }`}
       >
@@ -119,13 +119,13 @@ export default function EmptyState({
       </div>
 
       {/* Title */}
-      <h3 className={`font-medium text-foreground mb-1 ${getSizeClass(isCompact, 'text-sm', 'text-base')}`}>
+      <h3 className={`mb-1 font-semibold text-foreground ${getSizeClass(isCompact, 'text-sm', 'text-base')}`}>
         {title}
       </h3>
 
       {/* Description */}
       {description && (
-        <p className={`text-text-tertiary max-w-xs ${getSizeClass(isCompact, 'text-xs', 'text-sm')}`}>
+        <p className={`max-w-xs text-text-tertiary ${getSizeClass(isCompact, 'text-xs', 'text-sm')}`}>
           {description}
         </p>
       )}
@@ -146,7 +146,7 @@ export default function EmptyState({
 
   if (variant === 'card') {
     return (
-      <div className="glass rounded-2xl">
+      <div className="glass rounded-2xl border border-[var(--glass-border)]">
         {content}
       </div>
     )

--- a/frontend/src/components/shared/ErrorState.tsx
+++ b/frontend/src/components/shared/ErrorState.tsx
@@ -48,14 +48,14 @@ export default function ErrorState({
       <motion.div
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
-        className="flex items-center gap-3 px-4 py-3 bg-error/10 border border-error/20 rounded-lg"
+        className="flex items-center gap-3 rounded-lg border border-error/20 bg-error/10 px-4 py-3 shadow-[var(--ledger-control-shadow)]"
       >
         <AlertCircle className="w-5 h-5 text-error shrink-0" />
         <p className="text-sm text-error flex-1">{displayMessage}</p>
         {onRetry && (
           <button
             onClick={onRetry}
-            className="shrink-0 text-sm text-error hover:opacity-80 underline underline-offset-2 transition-opacity duration-150"
+            className="shrink-0 rounded-md px-2 py-1 text-sm font-medium text-error transition-colors duration-150 hover:bg-error/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-error/40"
             aria-label="Retry"
           >
             Retry
@@ -75,7 +75,7 @@ export default function ErrorState({
     >
       {/* Icon */}
       <div
-        className={`rounded-xl bg-error/10 border border-error/20 flex items-center justify-center mb-4 ${
+        className={`mb-4 flex items-center justify-center rounded-xl border border-error/20 bg-error/10 ${
           isCompact ? 'w-12 h-12' : 'w-16 h-16'
         }`}
       >
@@ -84,7 +84,7 @@ export default function ErrorState({
 
       {/* Title */}
       <h3
-        className={`font-medium text-foreground mb-1 ${
+        className={`mb-1 font-semibold text-foreground ${
           isCompact ? 'text-sm' : 'text-base'
         }`}
       >
@@ -93,7 +93,7 @@ export default function ErrorState({
 
       {/* Message */}
       <p
-        className={`text-text-tertiary max-w-xs ${
+        className={`max-w-xs text-text-tertiary ${
           isCompact ? 'text-xs' : 'text-sm'
         }`}
       >
@@ -104,7 +104,7 @@ export default function ErrorState({
       {onRetry && (
         <button
           onClick={onRetry}
-          className={`mt-4 inline-flex items-center gap-2 px-4 py-2 bg-error/10 text-error rounded-lg hover:bg-error/20 transition-colors duration-150 ${
+          className={`mt-4 inline-flex items-center gap-2 rounded-lg border border-error/20 bg-error/10 px-4 py-2 font-medium text-error transition-colors duration-150 hover:bg-error/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-error/40 ${
             isCompact ? 'text-xs' : 'text-sm'
           }`}
           aria-label="Retry loading"
@@ -118,7 +118,7 @@ export default function ErrorState({
 
   if (isCard) {
     return (
-      <div className="glass rounded-2xl border border-error/20">
+      <div className="glass rounded-2xl border border-error/20 shadow-[var(--glass-shadow)]">
         {content}
       </div>
     )

--- a/frontend/src/components/shared/LoadingSkeleton.tsx
+++ b/frontend/src/components/shared/LoadingSkeleton.tsx
@@ -7,7 +7,7 @@ import type { ReactNode } from 'react'
  */
 export default function LoadingSkeleton({ className = '' }: Readonly<{ className?: string }>) {
   return (
-    <div aria-hidden className={`animate-pulse bg-[var(--overlay-2)] rounded-lg ${className}`} />
+    <div aria-hidden className={`skeleton-surface rounded-lg ${className}`} />
   )
 }
 

--- a/frontend/src/components/shared/MetricCard.tsx
+++ b/frontend/src/components/shared/MetricCard.tsx
@@ -99,7 +99,7 @@ export default function MetricCard({
 
   const isInteractive = Boolean(href || onClick)
   const interactiveClasses = isInteractive
-    ? 'cursor-pointer hover:border-[var(--hairline-4)] hover:bg-[var(--overlay-3)] transition-all duration-150 group'
+    ? 'group cursor-pointer transition-all duration-150 hover:border-[var(--hairline-4)] hover:bg-[var(--overlay-3)]'
     : 'transition-colors duration-150 ease-out hover:border-[var(--hairline-2)]'
 
   const cardContent = (
@@ -108,7 +108,7 @@ export default function MetricCard({
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.3, ease: [0.25, 0.46, 0.45, 0.94] }}
       whileHover={isInteractive ? { y: -2 } : undefined}
-      className={`relative p-4 glass rounded-2xl overflow-hidden ${interactiveClasses}`}
+      className={`relative overflow-hidden rounded-2xl border border-[var(--glass-border)] p-4 glass ${interactiveClasses}`}
     >
       {/* Sparkline as background */}
       {trend && (
@@ -127,14 +127,14 @@ export default function MetricCard({
 
       {/* Content */}
       <div className="relative z-10">
-        <div className="flex items-center gap-2 mb-2">
+        <div className="mb-2 flex items-center gap-2">
           <div
-            className="p-2 rounded-xl"
+            className="rounded-xl border border-[var(--hairline-2)] p-2"
             style={{ background: colors.bg }}
           >
             <Icon className="w-4 h-4" style={{ color: colors.text }} />
           </div>
-          <h3 className="text-kpi-label font-medium text-muted-foreground">{title}</h3>
+          <h3 className="min-w-0 truncate text-kpi-label font-medium text-muted-foreground">{title}</h3>
         </div>
 
         <output className="block" aria-live="polite">
@@ -144,7 +144,7 @@ export default function MetricCard({
             animate={{ opacity: 1, scale: 1 }}
             transition={{ duration: 0.3 }}
             title={String(value)}
-            className={`${hero ? 'text-kpi-hero' : 'text-kpi-value'} font-bold text-foreground leading-tight break-words`}
+            className={`ledger-figure ${hero ? 'text-kpi-hero' : 'text-kpi-value'} font-bold leading-tight text-foreground break-words`}
           >
             <AnimatedValue value={value} />
           </motion.p>

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -13,15 +13,15 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 
 const variantClasses: Record<ButtonVariant, string> = {
   primary:
-    'bg-app-blue text-primary-foreground hover:bg-app-blue active:scale-[0.98]',
+    'border border-app-blue/40 bg-app-blue text-primary-foreground shadow-[var(--ledger-control-shadow)] hover:bg-app-blue-vibrant hover:border-app-blue/60 active:scale-[0.98]',
   secondary:
-    'bg-[var(--overlay-3)] border border-[var(--hairline-2)] text-foreground hover:bg-[var(--overlay-5)] hover:text-foreground active:scale-[0.98]',
+    'ledger-control border text-foreground hover:text-foreground active:scale-[0.98]',
   ghost:
-    'text-muted-foreground hover:text-foreground hover:bg-[var(--overlay-3)] active:scale-[0.98]',
+    'text-muted-foreground hover:text-foreground hover:bg-[var(--ledger-control-bg-hover)] active:scale-[0.98]',
   danger:
-    'bg-app-red/90 text-destructive-foreground hover:bg-app-red active:scale-[0.98]',
+    'border border-app-red/40 bg-app-red/90 text-destructive-foreground shadow-[var(--ledger-control-shadow)] hover:bg-app-red hover:border-app-red/60 active:scale-[0.98]',
   outline:
-    'border border-[var(--hairline-3)] text-foreground hover:bg-[var(--overlay-3)] hover:text-foreground active:scale-[0.98]',
+    'ledger-control border text-foreground hover:text-foreground active:scale-[0.98]',
 }
 
 const sizeClasses: Record<ButtonSize, string> = {
@@ -43,8 +43,8 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
       ref={ref}
       disabled={disabled || isLoading}
       className={cn(
-        'inline-flex items-center justify-center font-medium transition-all duration-150 ease-out',
-        'disabled:opacity-50 disabled:pointer-events-none',
+        'inline-flex min-h-9 items-center justify-center whitespace-nowrap font-medium transition-all duration-150 ease-out',
+        'disabled:pointer-events-none disabled:opacity-50',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-background',
         variantClasses[variant],
         sizeClasses[size],

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -22,8 +22,8 @@ export const Card = memo(function Card({
   variant = 'default'
 }: CardProps) {
   const variantClasses = {
-    default: 'glass rounded-2xl border border-border p-6',
-    interactive: 'glass rounded-2xl border border-border p-6 transition-all duration-150 ease-out hover:border-[var(--hairline-3)]'
+    default: 'glass rounded-2xl border border-[var(--glass-border)] p-5 sm:p-6',
+    interactive: 'glass rounded-2xl border border-[var(--glass-border)] p-5 sm:p-6 transition-all duration-150 ease-out hover:-translate-y-0.5 hover:border-[var(--hairline-3)] hover:bg-[var(--overlay-2)]'
   }
 
   if (animate) {
@@ -62,21 +62,21 @@ export const CardHeader = memo(function CardHeader({
   action
 }: CardHeaderProps) {
   return (
-    <div className="flex items-center justify-between mb-4">
-      <div className="flex items-center gap-3">
+    <div className="flex items-start justify-between gap-3 mb-4">
+      <div className="flex min-w-0 items-center gap-3">
         {icon && (
-          <div className="p-2.5 bg-app-blue/10 rounded-xl">
+          <div className="shrink-0 rounded-xl border border-[var(--hairline-2)] bg-app-blue/10 p-2.5">
             {icon}
           </div>
         )}
-        <div>
-          <h3 className="text-sm font-medium text-foreground">{title}</h3>
+        <div className="min-w-0">
+          <h3 className="truncate text-sm font-semibold text-foreground">{title}</h3>
           {subtitle && (
-            <p className="text-xs text-text-tertiary">{subtitle}</p>
+            <p className="mt-0.5 text-xs text-text-tertiary">{subtitle}</p>
           )}
         </div>
       </div>
-      {action && <div>{action}</div>}
+      {action && <div className="shrink-0">{action}</div>}
     </div>
   )
 })
@@ -122,7 +122,7 @@ export const StatCard = memo(function StatCard({
         )}
         <div className="flex-1">
           <p className="text-xs text-text-tertiary">{title}</p>
-          <p className="text-lg sm:text-xl font-semibold text-foreground">{value}</p>
+          <p className="ledger-figure text-lg sm:text-xl font-semibold text-foreground">{value}</p>
           {subtitle && (
             <p className="text-[11px] text-text-quaternary mt-1">{subtitle}</p>
           )}

--- a/frontend/src/components/ui/DataTable.tsx
+++ b/frontend/src/components/ui/DataTable.tsx
@@ -66,7 +66,7 @@ const ALIGN_CLASS: Record<Align, string> = {
   left: 'text-left',
   // `tabular-nums` keeps digit glyphs a uniform width so currency columns
   // line up vertically when rows have different decimal widths.
-  right: 'text-right tabular-nums',
+  right: 'text-right ledger-figure',
   center: 'text-center',
 }
 
@@ -156,7 +156,7 @@ export default function DataTable<T>({
           return (
             <div
               key={rowKey(row, i)}
-              className={`glass rounded-xl border border-border p-3 ${rowClassName?.(row, i) ?? ''}`.trim()}
+              className={`glass rounded-xl border border-[var(--glass-border)] p-3 shadow-[var(--glass-shadow)] ${rowClassName?.(row, i) ?? ''}`.trim()}
             >
               {primary && (
                 <div className={`mb-2 font-medium ${primary.cellClassName?.(row, i) ?? ''}`.trim()}>
@@ -166,8 +166,8 @@ export default function DataTable<T>({
               <dl className="grid grid-cols-2 gap-x-3 gap-y-1.5">
                 {rest.map((col) => (
                   <div key={col.key} className="flex items-baseline justify-between gap-2 min-w-0">
-                    <dt className="text-xs text-text-tertiary shrink-0">{labelFor(col)}</dt>
-                    <dd className={`text-sm text-right min-w-0 truncate ${col.cellClassName?.(row, i) ?? ''}`.trim()}>
+                    <dt className="shrink-0 text-xs font-medium text-text-tertiary">{labelFor(col)}</dt>
+                    <dd className={`ledger-figure min-w-0 truncate text-right text-sm ${col.cellClassName?.(row, i) ?? ''}`.trim()}>
                       {col.cell(row, i)}
                     </dd>
                   </div>
@@ -195,11 +195,11 @@ export default function DataTable<T>({
     <div className={scrollClass}>
       <table className="w-full" aria-label={ariaLabel}>
         <thead className={theadClass}>
-          <tr className="border-b border-border">
+          <tr className="border-b border-[var(--hairline-2)]">
             {columns.map((col) => {
               const alignClass = ALIGN_CLASS[col.align ?? 'left']
               const widthClass = col.widthClass ?? ''
-              const baseClass = `py-3 px-4 text-sm font-semibold text-muted-foreground ${alignClass} ${widthClass}`
+              const baseClass = `px-4 py-2.5 text-xs font-semibold text-text-tertiary ${alignClass} ${widthClass}`
 
               if (col.sortable !== true) {
                 return (
@@ -221,7 +221,7 @@ export default function DataTable<T>({
                   <button
                     type="button"
                     onClick={() => toggleSort(col.key)}
-                    className={`inline-flex items-center gap-1 ${justifyForAlign[col.align ?? 'left']} w-full hover:text-foreground select-none transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-app-blue/40 rounded`}
+                    className={`inline-flex w-full select-none items-center gap-1 rounded ${justifyForAlign[col.align ?? 'left']} transition-colors hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]`}
                   >
                     {col.header}
                     <span
@@ -240,7 +240,7 @@ export default function DataTable<T>({
           {sortedRows.map((row, i) => {
             const key = rowKey(row, i)
             const rowCls = rowClassName?.(row, i) ?? ''
-            const baseRowCls = `border-b border-border hover:bg-[var(--overlay-2)] transition-colors ${rowCls}`.trim()
+            const baseRowCls = `border-b border-[var(--hairline-1)] transition-colors hover:bg-[var(--overlay-2)] last:border-b-0 ${rowCls}`.trim()
 
             if (shouldAnimate) {
               return (
@@ -254,7 +254,7 @@ export default function DataTable<T>({
                   {columns.map((col) => (
                     <td
                       key={col.key}
-                      className={`py-3 px-4 ${ALIGN_CLASS[col.align ?? 'left']} ${col.cellClassName?.(row, i) ?? ''}`.trim()}
+                      className={`px-4 py-2.5 text-sm ${ALIGN_CLASS[col.align ?? 'left']} ${col.cellClassName?.(row, i) ?? ''}`.trim()}
                     >
                       {col.cell(row, i)}
                     </td>
@@ -268,7 +268,7 @@ export default function DataTable<T>({
                 {columns.map((col) => (
                   <td
                     key={col.key}
-                    className={`py-3 px-4 ${ALIGN_CLASS[col.align ?? 'left']} ${col.cellClassName?.(row, i) ?? ''}`.trim()}
+                    className={`px-4 py-2.5 text-sm ${ALIGN_CLASS[col.align ?? 'left']} ${col.cellClassName?.(row, i) ?? ''}`.trim()}
                   >
                     {col.cell(row, i)}
                   </td>

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -20,7 +20,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
   return (
     <div className="space-y-1.5">
       {label && (
-        <label htmlFor={inputId} className="block text-sm font-medium text-muted-foreground">
+        <label htmlFor={inputId} className="block text-sm font-medium text-text-secondary">
           {label}
         </label>
       )}
@@ -34,13 +34,13 @@ const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
           ref={ref}
           id={inputId}
           className={cn(
-            'w-full bg-[var(--overlay-2)] px-4 py-3 rounded-lg',
+            'ledger-control w-full rounded-lg px-4 py-3',
             'border border-[var(--hairline-2)] text-foreground placeholder:text-text-quaternary',
             'transition-all duration-150 ease-out',
-            'focus:border-app-blue/50 focus:outline-none focus:ring-1 focus:ring-app-blue/20',
+            'focus:outline-none',
             'disabled:opacity-50 disabled:cursor-not-allowed',
             icon && 'pl-10',
-            error && 'border-app-red/50 focus:border-app-red/50 focus:ring-app-red/20',
+            error && 'border-app-red/50 focus:border-app-red/50 focus:shadow-[0_0_0_1px_rgba(255,87,87,0.55),0_0_0_4px_rgba(255,87,87,0.14)]',
             className
           )}
           aria-invalid={error ? 'true' : undefined}
@@ -78,7 +78,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(function Select
   return (
     <div className="space-y-1.5">
       {label && (
-        <label htmlFor={selectId} className="block text-sm font-medium text-muted-foreground">
+        <label htmlFor={selectId} className="block text-sm font-medium text-text-secondary">
           {label}
         </label>
       )}
@@ -86,12 +86,12 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(function Select
         ref={ref}
         id={selectId}
         className={cn(
-          'w-full bg-[var(--overlay-2)] px-4 py-3 rounded-lg',
+          'ledger-control w-full rounded-lg px-4 py-3',
           'border border-[var(--hairline-2)] text-foreground',
           'transition-all duration-150 ease-out',
-          'focus:border-app-blue/50 focus:outline-none focus:ring-1 focus:ring-app-blue/20',
+          'focus:outline-none',
           'disabled:opacity-50 disabled:cursor-not-allowed',
-          error && 'border-app-red/50 focus:border-app-red/50 focus:ring-app-red/20',
+          error && 'border-app-red/50 focus:border-app-red/50 focus:shadow-[0_0_0_1px_rgba(255,87,87,0.55),0_0_0_4px_rgba(255,87,87,0.14)]',
           className
         )}
         aria-invalid={error ? 'true' : undefined}

--- a/frontend/src/components/ui/PageHeader.tsx
+++ b/frontend/src/components/ui/PageHeader.tsx
@@ -47,7 +47,7 @@ const PageHeader = memo(function PageHeader({ title, subtitle, action }: PageHea
       <div className="flex flex-col items-center text-center sm:flex-row sm:items-start sm:justify-between sm:text-left gap-3 sm:gap-4">
         <div className="min-w-0 px-12 sm:px-0">
           <h1
-            className="text-page-title text-foreground tracking-tight break-words transition-all duration-150 ease-out"
+            className="text-page-title text-foreground break-words transition-all duration-150 ease-out"
             style={{ fontSize: scrolled ? '1.25rem' : undefined }}
           >
             {title}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -78,6 +78,17 @@
   --color-text-tertiary: #7c7c80;
   --color-text-quaternary: #48484a;
 
+  /* ===== LEDGER INTERFACE TOKENS ===== */
+  --ledger-control-bg: rgba(12, 14, 18, 0.42);
+  --ledger-control-bg-hover: rgba(32, 36, 42, 0.58);
+  --ledger-control-border: rgba(255, 255, 255, 0.10);
+  --ledger-control-border-hover: rgba(255, 255, 255, 0.16);
+  --ledger-control-edge: rgba(255, 255, 255, 0.08);
+  --ledger-control-shadow: inset 0 1px 0 var(--ledger-control-edge);
+  --ledger-focus-shadow: 0 0 0 1px var(--focus-ring), 0 0 0 4px var(--focus-ring-soft);
+  --ledger-grid-line: rgba(255, 255, 255, 0.025);
+  --ledger-grid-band: rgba(74, 158, 255, 0.035);
+
   /* ===== DISABLED STATE ===== */
   --color-disabled: rgba(99, 99, 102, 0.3);
   --color-disabled-foreground: rgba(142, 142, 147, 0.5);
@@ -275,6 +286,16 @@
   --color-text-tertiary: #767b84;
   --color-text-quaternary: #a2a8b2;
 
+  --ledger-control-bg: rgba(255, 255, 255, 0.74);
+  --ledger-control-bg-hover: rgba(255, 255, 255, 0.94);
+  --ledger-control-border: rgba(17, 24, 39, 0.10);
+  --ledger-control-border-hover: rgba(17, 24, 39, 0.16);
+  --ledger-control-edge: rgba(255, 255, 255, 0.95);
+  --ledger-control-shadow: inset 0 1px 0 var(--ledger-control-edge), 0 1px 2px rgba(17, 24, 39, 0.04);
+  --ledger-focus-shadow: 0 0 0 1px var(--focus-ring), 0 0 0 4px var(--focus-ring-soft);
+  --ledger-grid-line: rgba(17, 24, 39, 0.035);
+  --ledger-grid-band: rgba(37, 99, 235, 0.035);
+
   --color-disabled: rgba(0, 0, 0, 0.08);
   --color-disabled-foreground: rgba(0, 0, 0, 0.35);
 
@@ -387,6 +408,20 @@ body {
 
 #root {
   height: 100%;
+}
+
+.ledger-workspace {
+  isolation: isolate;
+}
+
+.ledger-workspace-bg {
+  background:
+    linear-gradient(90deg, var(--ledger-grid-line) 1px, transparent 1px),
+    linear-gradient(180deg, var(--ledger-grid-line) 1px, transparent 1px),
+    linear-gradient(180deg, var(--ledger-grid-band), transparent 32rem);
+  background-size: 48px 48px, 48px 48px, 100% 100%;
+  -webkit-mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.65), rgba(0, 0, 0, 0.22) 55%, transparent 100%);
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.65), rgba(0, 0, 0, 0.22) 55%, transparent 100%);
 }
 
 /* ===== FOCUS NOT OBSCURED (WCAG 2.2 SC 2.4.11) =====
@@ -556,6 +591,25 @@ body {
   75% { opacity: 0.32; transform: scale(1.01); }
 }
 
+@keyframes skeleton-sweep {
+  0% { background-position: 120% 0; }
+  100% { background-position: -120% 0; }
+}
+
+.skeleton-surface {
+  background:
+    linear-gradient(90deg, transparent 0%, var(--skeleton-highlight) 45%, transparent 90%),
+    var(--skeleton-base);
+  background-size: 220% 100%, 100% 100%;
+  animation: skeleton-sweep 1.35s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton-surface {
+    animation: none;
+  }
+}
+
 @keyframes float {
 
   0%,
@@ -695,7 +749,8 @@ body {
   font-size: clamp(1.5rem, 2.5vw, 2.25rem);
   font-weight: 700;
   line-height: 1.2;
-  letter-spacing: -0.02em;
+  letter-spacing: 0;
+  text-wrap: balance;
 }
 
 .text-section-title {
@@ -708,7 +763,34 @@ body {
   font-size: clamp(1.25rem, 2vw, 2rem);
   font-weight: 700;
   line-height: 1.1;
-  letter-spacing: -0.01em;
+  letter-spacing: 0;
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: 'tnum' 1, 'zero' 1;
+}
+
+.ledger-figure,
+.text-kpi-value,
+.text-kpi-hero,
+output {
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: 'tnum' 1, 'zero' 1;
+}
+
+.ledger-control {
+  background: var(--ledger-control-bg);
+  border-color: var(--ledger-control-border);
+  box-shadow: var(--ledger-control-shadow);
+}
+
+.ledger-control:hover {
+  background: var(--ledger-control-bg-hover);
+  border-color: var(--ledger-control-border-hover);
+}
+
+.ledger-control:focus,
+.ledger-control:focus-visible {
+  border-color: var(--focus-ring);
+  box-shadow: var(--ledger-focus-shadow);
 }
 
 /* ===== FORM ELEMENTS ===== */

--- a/frontend/src/pages/returns-analysis/ReturnsAnalysisPage.tsx
+++ b/frontend/src/pages/returns-analysis/ReturnsAnalysisPage.tsx
@@ -132,7 +132,7 @@ export default function ReturnsAnalysisPage() {
             </div>
             <div className="min-w-0">
               <p className="text-sm text-text-tertiary">Net Investment P&L</p>
-              <p className={`text-3xl sm:text-4xl font-bold tracking-tight truncate ${netProfitLoss >= 0 ? 'text-app-green' : 'text-app-red'}`}>
+              <p className={`ledger-figure truncate text-3xl sm:text-4xl font-bold ${netProfitLoss >= 0 ? 'text-app-green' : 'text-app-red'}`}>
                 {netProfitLoss >= 0 ? '+' : ''}{formatCurrency(netProfitLoss)}
               </p>
             </div>

--- a/frontend/src/services/api/aiConfig.ts
+++ b/frontend/src/services/api/aiConfig.ts
@@ -34,7 +34,7 @@ export const aiConfigService = {
   },
 
   async getKey(): Promise<string> {
-    const response = await apiClient.get<{ api_key: string }>('/api/preferences/ai-config/key/reveal')
+    const response = await apiClient.get<{ api_key: string }>('/api/preferences/ai-config/key')
     return response.data.api_key
   },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ledger-sync",
   "version": "2.22.0",
+  "packageManager": "pnpm@10.32.0",
   "description": "Personal finance dashboard -- import bank statements, track spending, and view analytics in any currency",
   "scripts": {
     "setup": "concurrently -n \"backend,frontend\" -c \"bgBlue.bold,bgMagenta.bold\" \"pnpm run setup:backend\" \"pnpm run setup:frontend\"",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ledger-sync",
   "version": "2.22.0",
-  "packageManager": "pnpm@10.32.0",
+  "packageManager": "pnpm@11.10.0",
   "description": "Personal finance dashboard -- import bank statements, track spending, and view analytics in any currency",
   "scripts": {
     "setup": "concurrently -n \"backend,frontend\" -c \"bgBlue.bold,bgMagenta.bold\" \"pnpm run setup:backend\" \"pnpm run setup:frontend\"",


### PR DESCRIPTION
Two related work streams on one branch (bundled at author's request).

## 1. Project hygiene (`f3f72dd`)

### Docs synced to current stack
- Python `3.11`/`3.12` -> `3.13` across README, backend README, DEPLOYMENT, DEVELOPMENT (matches CI + Vercel `PYTHON_VERSION`).
- Frontend README: TypeScript `5.9` -> `6`, Vite `7` -> `8`.
- Rewrote every "Bedrock streaming / SSE / `converse_stream()`" reference to the current non-streaming **Bedrock Converse** proxy (`converse()`, JSON). Covers API.md, architecture.md, DEVELOPMENT.md, both READMEs.
- Documented the AI key-encryption move to **HKDF v2** keyed on `LEDGER_SYNC_ENCRYPTION_KEY` (legacy PBKDF2-from-JWT v1 still readable, re-encrypted on reveal).
- Added missing env vars to DEPLOYMENT.md: `LEDGER_SYNC_ENCRYPTION_KEY`, `LEDGER_SYNC_BEDROCK_API_KEY`, `LEDGER_SYNC_AI_DAILY_MESSAGE_LIMIT`, `LEDGER_SYNC_AI_MAX_TOOL_ROUNDS`.

### Fixes
- `aiConfig.ts`: `getKey()` called `/api/preferences/ai-config/key/reveal`, but the backend route is `/api/preferences/ai-config/key` -- was 404-ing the BYOK key reveal.

### Config
- Moved pnpm `overrides` + `onlyBuiltDependencies` from `frontend/package.json` into new `frontend/pnpm-workspace.yaml` (pnpm 10+ reads workspace config); added `allowBuilds: sharp`.
- Pinned `packageManager`; `.gitignore` += `.pnpm-store/`; lockfile integrity hash for the xlsx CDN tarball.
- Added `.env.example` (placeholders only) and `CONTRIBUTING.md`.

## 2. Ledger-interface UI restyle (`fa6f2f3`)

- New interface tokens in `index.css` (control bg/border/edge/shadow, focus shadow, grid line/band) with **both light and dark values**.
- `.ledger-control` unifies inputs, search, sidebar toggle, and the mobile-tab active pill behind one hover/focus surface.
- `.ledger-figure` + `tabular-nums` on KPI values, numeric table cells, and count badges so digits align in columns.
- `AppLayout` gradient orbs replaced with a masked grid-paper workspace background.
- Hairline borders on cards / icon tiles / sidebar sections; `focus-visible` rings added to interactive controls (a11y); truncation + `min-w-0` overflow fixes.
- Skeleton shimmer sweep with a `prefers-reduced-motion` opt-out.
- `packageManager` bumped to `pnpm@11.10.0`.

## Verification
- Backend route confirmed at `preferences_ai.py:182`; Bedrock/`converse()`, HKDF v2, and `requires-python >=3.13` all verified against source.
- Frontend: `pnpm run type-check`, `pnpm run lint`, `pnpm run build` all pass.
- Rendered the restyle live in demo mode (dashboard + mobile tab bar) -- cards, tabular figures, active pill, grid background all correct; zero console errors.
- Pre-commit hooks (eslint, tsc, detect-private-key) passed on both commits.

## Reviewer notes
- **`prefers-reduced-motion`**: the skeleton shimmer adds a reduced-motion opt-out. Flagging explicitly since motion is normally kept visible here -- this only gates the loading-skeleton sweep, not app animations.
- Two commits are independently revertable if you'd rather split them.