### PR TITLE
fix(ci): drop hardcoded pnpm version in frontend deploy

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -21,9 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
+      # No `version:` here -- action-setup reads it from the root
+      # package.json `packageManager` field (pnpm@11.10.0). Pinning a
+      # second version conflicts with packageManager (ERR_PNPM_BAD_PM_VERSION).
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
-        with:
-          version: 10
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:


### PR DESCRIPTION
## What
Remove `version: 10` from the `pnpm/action-setup` step in `deploy-frontend.yml` so it reads the version from the root `package.json` `packageManager` field (`pnpm@11.10.0`).

## Why
PR #205 bumped `packageManager` to `pnpm@11.10.0`. `pnpm/action-setup` refuses to run when a `version:` input conflicts with `packageManager` (`ERR_PNPM_BAD_PM_VERSION`). The **GitHub Pages deploy failed on the #205 merge commit** because this workflow still pinned `version: 10`.

It slipped through #205's CI because `deploy-frontend.yml` only runs on push to `main`, not on PRs -- and the CI workflow (shared `node-ci.yml`) auto-detects the version instead of pinning it, so it passed.

## Fix
Drop the pin; let `action-setup` resolve from `packageManager` (same approach CI already uses).

## Impact
Restores the frontend deploy to GitHub Pages. No app code changes.