### PR TITLE
fix: calc-correctness wave -- net-worth projection, GST cutover, buffering, cache keys, auth

### DIFF
--- a/frontend/src/components/shared/AuthModal.tsx
+++ b/frontend/src/components/shared/AuthModal.tsx
@@ -49,28 +49,45 @@ function buildAuthorizeUrl(provider: OAuthProviderConfig): string {
 }
 
 export function AuthModal({ isOpen, onClose }: Readonly<AuthModalProps>) {
-  // null = not yet fetched, [] = fetched but empty
-  const [oauthProviders, setOauthProviders] = useState<OAuthProviderConfig[] | null>(null)
+  // 'loading' -> providers[] on success. 'failed' when the request errored:
+  // a cold serverless backend or network blip must NOT render the "not
+  // configured" message (that copy is for a truly empty provider list), so
+  // failures get their own retry state instead of collapsing to [].
+  const [providersState, setProvidersState] = useState<
+    { status: 'loading' | 'failed' } | { status: 'loaded'; providers: OAuthProviderConfig[] }
+  >({ status: 'loading' })
+  const [retryToken, setRetryToken] = useState(0)
+
+  const retry = () => {
+    setProvidersState({ status: 'loading' })
+    setRetryToken((t) => t + 1)
+  }
 
   // Fetch available OAuth providers when modal opens
   useEffect(() => {
     if (!isOpen) return
     let cancelled = false
     authApi.getOAuthProviders()
-      .then((providers) => { if (!cancelled) setOauthProviders(providers) })
-      .catch(() => { if (!cancelled) setOauthProviders([]) })
+      .then((providers) => {
+        if (!cancelled) setProvidersState({ status: 'loaded', providers })
+      })
+      .catch(() => {
+        if (!cancelled) setProvidersState({ status: 'failed' })
+      })
     return () => { cancelled = true }
-  }, [isOpen])
+  }, [isOpen, retryToken])
 
   const handleOAuthLogin = (provider: OAuthProviderConfig) => {
     // Navigate to provider's authorize URL — will redirect back to /auth/callback/:provider
     globalThis.location.assign(buildAuthorizeUrl(provider))
   }
 
-  const isLoadingProviders = oauthProviders === null
-  const googleProvider = oauthProviders?.find(p => p.provider === 'google')
-  const githubProvider = oauthProviders?.find(p => p.provider === 'github')
-  const hasOAuth = (oauthProviders?.length ?? 0) > 0
+  const isLoadingProviders = providersState.status === 'loading'
+  const loadFailed = providersState.status === 'failed'
+  const oauthProviders = providersState.status === 'loaded' ? providersState.providers : []
+  const googleProvider = oauthProviders.find(p => p.provider === 'google')
+  const githubProvider = oauthProviders.find(p => p.provider === 'github')
+  const hasOAuth = oauthProviders.length > 0
 
   return (
     <AnimatePresence>
@@ -152,6 +169,25 @@ export function AuthModal({ isOpen, onClose }: Readonly<AuthModalProps>) {
                           Continue with GitHub
                         </button>
                       )}
+                    </div>
+                  )
+                }
+                if (loadFailed) {
+                  return (
+                    <div className="text-center py-4">
+                      <p className="text-muted-foreground text-sm">
+                        Couldn&apos;t reach the sign-in service.
+                      </p>
+                      <p className="text-text-tertiary text-xs mt-1">
+                        The server may be waking up -- this usually takes a few seconds.
+                      </p>
+                      <button
+                        type="button"
+                        onClick={retry}
+                        className="mt-4 inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium text-app-blue bg-app-blue/10 hover:bg-app-blue/20 transition-colors duration-150"
+                      >
+                        Try again
+                      </button>
                     </div>
                   )
                 }

--- a/frontend/src/components/shared/quickInsightsData.ts
+++ b/frontend/src/components/shared/quickInsightsData.ts
@@ -307,7 +307,7 @@ export function buildQuickInsights(
     items.push({ icon: icons.Hourglass, color: 'text-app-indigo', bg: 'bg-app-indigo/10', title: 'Age of Money', value: `${p.ageOfMoney} days`, subtitle: ageOfMoneyLabel(p.ageOfMoney) })
   }
   if (p.daysOfBuffering != null) {
-    items.push({ icon: icons.ShieldCheck, color: 'text-app-teal', bg: 'bg-app-teal/10', title: 'Days of Buffering', value: `${p.daysOfBuffering} days`, subtitle: 'At current spending rate' })
+    items.push({ icon: icons.ShieldCheck, color: 'text-app-teal', bg: 'bg-app-teal/10', title: 'Days of Buffering', value: `${p.daysOfBuffering} days`, subtitle: 'Liquid accounts at current spending' })
   }
   if (p.fixedCommitmentsMonthly > 0) {
     items.push(

--- a/frontend/src/hooks/api/useAnalyticsV2.ts
+++ b/frontend/src/hooks/api/useAnalyticsV2.ts
@@ -27,7 +27,10 @@ import type {
   TransferFlow,
 } from '@/services/api/analyticsV2'
 
-// Query keys — filter properties spread directly to avoid object reference mismatches
+// Query keys — filter properties spread directly to avoid object reference mismatches.
+// EVERY param the queryFn sends must appear in the key: staleTime is Infinity,
+// so a param missing from the key means two callers with different values
+// silently share one cache entry (first mount wins).
 export const analyticsV2Keys = {
   all: ['analyticsV2'] as const,
   dailySummaries: (filters?: { start_date?: string; end_date?: string; limit?: number }) =>
@@ -35,18 +38,22 @@ export const analyticsV2Keys = {
   cohortSpending: () => [...analyticsV2Keys.all, 'cohort-spending'] as const,
   investmentHoldings: (filters?: { active_only?: boolean }) =>
     [...analyticsV2Keys.all, 'investment-holdings', filters?.active_only] as const,
-  monthlySummaries: () => [...analyticsV2Keys.all, 'monthly-summaries'] as const,
-  categoryTrends: (filters?: { category?: string; subcategory?: string }) =>
-    [...analyticsV2Keys.all, 'category-trends', filters?.category, filters?.subcategory] as const,
-  transferFlows: () => [...analyticsV2Keys.all, 'transfer-flows'] as const,
-  recurringTransactions: (filters?: { active_only?: boolean; min_confidence?: number }) =>
-    [...analyticsV2Keys.all, 'recurring-transactions', filters?.active_only, filters?.min_confidence] as const,
-  merchantIntelligence: (filters?: { min_transactions?: number; recurring_only?: boolean }) =>
-    [...analyticsV2Keys.all, 'merchant-intelligence', filters?.min_transactions, filters?.recurring_only] as const,
-  netWorth: () => [...analyticsV2Keys.all, 'net-worth'] as const,
-  fySummaries: () => [...analyticsV2Keys.all, 'fy-summaries'] as const,
-  anomalies: (filters?: { type?: string; severity?: string; include_reviewed?: boolean }) =>
-    [...analyticsV2Keys.all, 'anomalies', filters?.type, filters?.severity, filters?.include_reviewed] as const,
+  monthlySummaries: (filters?: { limit?: number; offset?: number }) =>
+    [...analyticsV2Keys.all, 'monthly-summaries', filters?.limit, filters?.offset] as const,
+  categoryTrends: (filters?: { category?: string; subcategory?: string; limit?: number; offset?: number }) =>
+    [...analyticsV2Keys.all, 'category-trends', filters?.category, filters?.subcategory, filters?.limit, filters?.offset] as const,
+  transferFlows: (filters?: { limit?: number; offset?: number }) =>
+    [...analyticsV2Keys.all, 'transfer-flows', filters?.limit, filters?.offset] as const,
+  recurringTransactions: (filters?: { active_only?: boolean; min_confidence?: number; limit?: number; offset?: number }) =>
+    [...analyticsV2Keys.all, 'recurring-transactions', filters?.active_only, filters?.min_confidence, filters?.limit, filters?.offset] as const,
+  merchantIntelligence: (filters?: { min_transactions?: number; recurring_only?: boolean; limit?: number; offset?: number }) =>
+    [...analyticsV2Keys.all, 'merchant-intelligence', filters?.min_transactions, filters?.recurring_only, filters?.limit, filters?.offset] as const,
+  netWorth: (filters?: { limit?: number; offset?: number }) =>
+    [...analyticsV2Keys.all, 'net-worth', filters?.limit, filters?.offset] as const,
+  fySummaries: (filters?: { limit?: number; offset?: number }) =>
+    [...analyticsV2Keys.all, 'fy-summaries', filters?.limit, filters?.offset] as const,
+  anomalies: (filters?: { type?: string; severity?: string; include_reviewed?: boolean; limit?: number; offset?: number }) =>
+    [...analyticsV2Keys.all, 'anomalies', filters?.type, filters?.severity, filters?.include_reviewed, filters?.limit, filters?.offset] as const,
   budgets: (filters?: { active_only?: boolean }) =>
     [...analyticsV2Keys.all, 'budgets', filters?.active_only] as const,
   goals: (filters?: { goal_type?: string; include_achieved?: boolean }) =>
@@ -85,7 +92,7 @@ export function useInvestmentHoldings(params?: { active_only?: boolean }) {
 // Monthly Summaries
 export function useMonthlySummaries(params?: { limit?: number; offset?: number }) {
   return useQuery<MonthlySummary[], Error>({
-    queryKey: analyticsV2Keys.monthlySummaries(),
+    queryKey: analyticsV2Keys.monthlySummaries(params),
     queryFn: () => analyticsV2Service.getMonthlySummaries(params),
     staleTime: STABLE_STALE_TIME,
   })
@@ -99,7 +106,7 @@ export function useCategoryTrends(params?: {
   offset?: number
 }) {
   return useQuery<CategoryTrend[], Error>({
-    queryKey: analyticsV2Keys.categoryTrends({ category: params?.category, subcategory: params?.subcategory }),
+    queryKey: analyticsV2Keys.categoryTrends(params),
     queryFn: () => analyticsV2Service.getCategoryTrends(params),
     staleTime: STABLE_STALE_TIME,
   })
@@ -108,7 +115,7 @@ export function useCategoryTrends(params?: {
 // Transfer Flows
 export function useTransferFlows(params?: { limit?: number; offset?: number }) {
   return useQuery<TransferFlow[], Error>({
-    queryKey: analyticsV2Keys.transferFlows(),
+    queryKey: analyticsV2Keys.transferFlows(params),
     queryFn: () => analyticsV2Service.getTransferFlows(params),
     staleTime: STABLE_STALE_TIME,
   })
@@ -122,10 +129,7 @@ export function useRecurringTransactions(params?: {
   offset?: number
 }) {
   return useQuery<RecurringTransaction[], Error>({
-    queryKey: analyticsV2Keys.recurringTransactions({
-      active_only: params?.active_only,
-      min_confidence: params?.min_confidence,
-    }),
+    queryKey: analyticsV2Keys.recurringTransactions(params),
     queryFn: () => analyticsV2Service.getRecurringTransactions(params),
     staleTime: STABLE_STALE_TIME,
   })
@@ -186,10 +190,7 @@ export function useMerchantIntelligence(params?: {
   offset?: number
 }) {
   return useQuery<MerchantIntelligence[], Error>({
-    queryKey: analyticsV2Keys.merchantIntelligence({
-      min_transactions: params?.min_transactions,
-      recurring_only: params?.recurring_only,
-    }),
+    queryKey: analyticsV2Keys.merchantIntelligence(params),
     queryFn: () => analyticsV2Service.getMerchantIntelligence(params),
     staleTime: STABLE_STALE_TIME,
   })
@@ -198,7 +199,7 @@ export function useMerchantIntelligence(params?: {
 // Net Worth Snapshots
 export function useNetWorthSnapshots(params?: { limit?: number; offset?: number }) {
   return useQuery<NetWorthSnapshot[], Error>({
-    queryKey: analyticsV2Keys.netWorth(),
+    queryKey: analyticsV2Keys.netWorth(params),
     queryFn: () => analyticsV2Service.getNetWorthSnapshots(params),
     staleTime: STABLE_STALE_TIME,
   })
@@ -207,7 +208,7 @@ export function useNetWorthSnapshots(params?: { limit?: number; offset?: number 
 // Fiscal Year Summaries
 export function useFYSummaries(params?: { limit?: number; offset?: number }) {
   return useQuery<FYSummary[], Error>({
-    queryKey: analyticsV2Keys.fySummaries(),
+    queryKey: analyticsV2Keys.fySummaries(params),
     queryFn: () => analyticsV2Service.getFYSummaries(params),
     staleTime: STABLE_STALE_TIME,
   })
@@ -222,11 +223,7 @@ export function useAnomalies(params?: {
   offset?: number
 }) {
   return useQuery<Anomaly[], Error>({
-    queryKey: analyticsV2Keys.anomalies({
-      type: params?.type,
-      severity: params?.severity,
-      include_reviewed: params?.include_reviewed,
-    }),
+    queryKey: analyticsV2Keys.anomalies(params),
     queryFn: () => analyticsV2Service.getAnomalies(params),
     staleTime: STABLE_STALE_TIME,
   })

--- a/frontend/src/lib/__tests__/gstCalculator.test.ts
+++ b/frontend/src/lib/__tests__/gstCalculator.test.ts
@@ -235,6 +235,35 @@ describe('computeGSTAnalysis', () => {
     const furniture = result.categoryBreakdown.find((c) => c.category === 'Furniture')!
     expect(furniture.gstRate).toBe(18)
   })
+
+  it('category spanning the 2025-09-22 cutover sums per-transaction GST, not one collapsed rate', () => {
+    // Luxury: 28% before the cutover, 40% after. FY 2025-26 spans both.
+    const preAmount = 1280 // inclusive of 28% -> GST = 1280*28/128 = 280
+    const postAmount = 1400 // inclusive of 40% -> GST = 1400*40/140 = 400
+    const txns: Transaction[] = [
+      expense({ id: '1', date: '2025-06-15', category: 'Luxury', amount: preAmount }),
+      expense({ id: '2', date: '2025-12-15', category: 'Luxury', amount: postAmount }),
+    ]
+    const result = computeGSTAnalysis(txns, 'FY 2025-26', 4)
+    const luxury = result.categoryBreakdown.find((c) => c.category === 'Luxury')!
+    // Exact per-transaction sum: 280 + 400 = 680. The old collapsed-rate path
+    // rated the whole 2680 at one slab (28% -> 586.25 or 40% -> 765.71).
+    expect(luxury.gstAmount).toBeCloseTo(680, 6)
+    expect(result.totalGST).toBeCloseTo(680, 6)
+    // Effective blended rate: 100*680/(2680-680) = 34%.
+    expect(luxury.gstRate).toBeCloseTo(34, 1)
+  })
+
+  it('single-table category still reports its exact slab rate', () => {
+    const txns: Transaction[] = [
+      expense({ id: '1', date: '2025-12-01', category: 'Luxury', amount: 1400 }),
+      expense({ id: '2', date: '2026-01-01', category: 'Luxury', amount: 2800 }),
+    ]
+    const result = computeGSTAnalysis(txns, 'FY 2025-26', 4)
+    const luxury = result.categoryBreakdown.find((c) => c.category === 'Luxury')!
+    expect(luxury.gstRate).toBe(40) // snapped back to the integer slab
+    expect(luxury.gstAmount).toBeCloseTo((1400 * 40) / 140 + (2800 * 40) / 140, 6)
+  })
 })
 
 describe('getExpenseFYs', () => {

--- a/frontend/src/lib/gstCalculator.ts
+++ b/frontend/src/lib/gstCalculator.ts
@@ -321,7 +321,15 @@ export function computeGSTAnalysis(
 
   // Aggregate by subcategory (more granular GST rates) or category as fallback.
   // Label = subcategory when available, else category.
-  const categoryMap = new Map<string, { spending: number; count: number; rate: number; parent: string }>()
+  // GST is accumulated PER TRANSACTION (each with its own date-correct rate),
+  // not recomputed from the category total with a single rate -- a category
+  // spanning the 2025-09-22 GST 2.0 cutover has transactions under two
+  // different slab tables, and collapsing them to one rate mis-states the FY
+  // total (measured ~3.8% understatement on real data).
+  const categoryMap = new Map<
+    string,
+    { spending: number; count: number; gst: number; parent: string }
+  >()
   const monthMap = new Map<string, { spending: number; gst: number }>()
 
   for (const tx of expenses) {
@@ -331,17 +339,19 @@ export function computeGSTAnalysis(
     // Date-aware: a transaction before 2025-09-22 uses the legacy slab table,
     // on/after uses GST 2.0. customRates (if any) override both.
     const rate = getGSTRate(cat, sub, customRates, tx.date)
+    const txGst = calculateGSTFromInclusive(tx.amount, rate)
 
-    const existing = categoryMap.get(label) ?? { spending: 0, count: 0, rate, parent: cat }
+    const existing = categoryMap.get(label) ?? { spending: 0, count: 0, gst: 0, parent: cat }
     existing.spending += tx.amount
     existing.count += 1
+    existing.gst += txGst
     categoryMap.set(label, existing)
 
     // Monthly aggregation
     const monthKey = tx.date.substring(0, 7) // "YYYY-MM"
     const monthEntry = monthMap.get(monthKey) ?? { spending: 0, gst: 0 }
     monthEntry.spending += tx.amount
-    monthEntry.gst += calculateGSTFromInclusive(tx.amount, rate)
+    monthEntry.gst += txGst
     monthMap.set(monthKey, monthEntry)
   }
 
@@ -351,18 +361,27 @@ export function computeGSTAnalysis(
   let totalGST = 0
 
   for (const [category, data] of categoryMap) {
-    const rate = data.rate
-    const gst = calculateGSTFromInclusive(data.spending, rate)
+    // Effective inclusive rate implied by the exact per-transaction GST:
+    // gst = spending * r / (100 + r)  =>  r = 100 * gst / (spending - gst).
+    // For a category entirely within one slab table this recovers the slab
+    // rate exactly; cross-cutover categories get the true blended rate.
+    const effectiveRate =
+      data.spending - data.gst > 0 ? (100 * data.gst) / (data.spending - data.gst) : 0
+    // Snap to the slab integer when within float noise so slab-keyed UI
+    // colors keep matching; keep one decimal for genuinely blended rates.
+    const snapped = Math.abs(effectiveRate - Math.round(effectiveRate)) < 0.005
+      ? Math.round(effectiveRate)
+      : Math.round(effectiveRate * 10) / 10
     categoryBreakdown.push({
       category,
       parentCategory: data.parent,
       spending: data.spending,
-      gstRate: rate,
-      gstAmount: gst,
+      gstRate: snapped,
+      gstAmount: data.gst,
       transactionCount: data.count,
     })
     totalSpending += data.spending
-    totalGST += gst
+    totalGST += data.gst
   }
 
   // Sort by GST amount descending

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 
+import { useQuery } from '@tanstack/react-query'
 import { motion } from 'framer-motion'
 import { Wallet, CreditCard, Upload } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
@@ -15,10 +16,15 @@ import { FinancialHealthScore } from '@/components/analytics'
 import { formatCurrency, formatCurrencyShort } from '@/lib/formatters'
 import { PageContainer, PageHeader } from '@/components/ui'
 import { useDashboardMetrics } from '@/hooks/useDashboardMetrics'
+import { useAccountBalances } from '@/hooks/api/useAnalytics'
 import { computeAgeOfMoney, computeDaysOfBuffering } from '@/lib/ageOfMoneyCalculator'
 import { usePreferences } from '@/hooks/api/usePreferences'
 import { useRecurringTransactions } from '@/hooks/api/useAnalyticsV2'
+import { accountClassificationsService } from '@/services/api/accountClassifications'
 import { toMonthlyAmount } from '@/pages/subscription-tracker/helpers'
+
+/** Account types whose balances count as spendable for runway math. */
+const LIQUID_CLASSIFICATIONS = new Set(['Cash', 'Bank Accounts', 'Other Wallets'])
 
 export default function DashboardPage() {
   const navigate = useNavigate()
@@ -31,7 +37,7 @@ export default function DashboardPage() {
     currentFY, setCurrentFY,
     fiscalYearStartMonth,
     dataDateRange, dateRange,
-    filteredTotals, filteredTransactions, isLoading,
+    filteredTransactions, isLoading,
     incomeBreakdown, cashbacksTotal,
     incomeChartData, incomeColorStyles,
     expenseChartData, expenseColorStyles,
@@ -54,18 +60,33 @@ export default function DashboardPage() {
     () => filteredTransactions?.length ? computeAgeOfMoney(filteredTransactions) : null,
     [filteredTransactions],
   )
+  // Days of Buffering runs on LIQUID balances only (cash / bank / wallets).
+  // Feeding lifetime income-minus-expense here counted investments (PPF, MF,
+  // stocks) as spendable and inflated the runway (~754 days vs the real
+  // cash position on audit data). Balances come from account_balances and
+  // are filtered by the user's account classifications.
+  const { data: balanceData } = useAccountBalances()
+  const { data: accountClassifications } = useQuery({
+    queryKey: ['account-classifications'],
+    queryFn: () => accountClassificationsService.getAllClassifications(),
+    staleTime: Infinity,
+  })
   const daysOfBuffering = useMemo(() => {
-    if (!filteredTransactions?.length || !filteredTotals) return null
-    // Coerce to Number: totals can arrive as strings (backend Decimal serialized
-    // as a string), and `string - number` / Math.abs(string) yields NaN, which
-    // rendered "NaN days". Number() of a numeric string is safe; non-numeric
-    // falls through to the null guard below.
-    const income = Number(filteredTotals.total_income ?? 0)
-    const expenses = Number(filteredTotals.total_expenses ?? 0)
-    if (!Number.isFinite(income) || !Number.isFinite(expenses)) return null
-    const liquidBalance = income - Math.abs(expenses)
+    if (!filteredTransactions?.length || !balanceData?.accounts || !accountClassifications) {
+      return null
+    }
+    let liquidBalance = 0
+    for (const [name, acc] of Object.entries(balanceData.accounts)) {
+      const cls = accountClassifications[name]
+      // Unclassified accounts are excluded rather than guessed -- counting an
+      // unlabeled brokerage as cash would silently re-inflate the runway.
+      if (cls && LIQUID_CLASSIFICATIONS.has(cls)) {
+        const bal = Number(acc.balance)
+        if (Number.isFinite(bal)) liquidBalance += bal
+      }
+    }
     return computeDaysOfBuffering(liquidBalance, filteredTransactions)
-  }, [filteredTransactions, filteredTotals])
+  }, [filteredTransactions, balanceData, accountClassifications])
 
   const incomeTotal = useMemo(() => incomeChartData.reduce((sum, d) => sum + d.value, 0), [incomeChartData])
   const expenseTotal = useMemo(() => expenseChartData.reduce((sum, d) => sum + d.value, 0), [expenseChartData])

--- a/frontend/src/pages/investment-analytics/components/PortfolioMetrics.tsx
+++ b/frontend/src/pages/investment-analytics/components/PortfolioMetrics.tsx
@@ -59,10 +59,13 @@ export function PortfolioMetrics(props: Readonly<PortfolioMetricsProps>) {
         color={netInvestmentPL >= 0 ? 'green' : 'red'}
         isLoading={isLoading}
       />
+      {/* "Cashflow XIRR": terminal value is book value (contributions net of
+          withdrawals) -- no market-price feed exists, so this measures the
+          cash-in/cash-out rate, not market performance. Label accordingly. */}
       <MetricCard
-        title="Portfolio XIRR"
+        title="Cashflow XIRR"
         value={xirrValue}
-        subtitle={portfolioXIRR === 0 ? 'Needs dated flows' : 'Annualized, all flows'}
+        subtitle={portfolioXIRR === 0 ? 'Needs dated flows' : 'Annualized, book value'}
         icon={LineChart}
         color={portfolioXIRR >= 0 ? 'green' : 'red'}
         isLoading={isLoading}

--- a/frontend/src/pages/investment-analytics/components/PortfolioMetrics.tsx
+++ b/frontend/src/pages/investment-analytics/components/PortfolioMetrics.tsx
@@ -40,6 +40,7 @@ export function PortfolioMetrics(props: Readonly<PortfolioMetricsProps>) {
       <MetricCard
         title="Total Investment Value"
         value={formatCurrency(totalInvestmentValue)}
+        subtitle="Net contributions (book value)"
         icon={TrendingUp}
         color="green"
         isLoading={isLoading}

--- a/frontend/src/pages/net-worth/NetWorthPage.tsx
+++ b/frontend/src/pages/net-worth/NetWorthPage.tsx
@@ -99,7 +99,7 @@ export default function NetWorthPage() {
           setShowStacked={m.setShowStacked}
           showProjection={m.showProjection}
           setShowProjection={m.setShowProjection}
-          monthlyGrowthRate={m.monthlyGrowthRate}
+          monthlyGrowth={m.monthlyGrowth}
           anchor={m.anchor}
           milestoneRows={m.milestoneRows}
         />
@@ -121,7 +121,7 @@ export default function NetWorthPage() {
           <MilestonesTable
             rows={m.milestoneRows}
             currentNetWorth={m.currentNetWorth}
-            monthlyGrowthRate={m.monthlyGrowthRate}
+            monthlyGrowth={m.monthlyGrowth}
           />
         </motion.div>
 

--- a/frontend/src/pages/net-worth/NetWorthPage.tsx
+++ b/frontend/src/pages/net-worth/NetWorthPage.tsx
@@ -25,7 +25,7 @@ export default function NetWorthPage() {
   if (m.isError && !m.isLoading) {
     return (
       <PageContainer className="space-y-6">
-        <PageHeader title="Net Worth" subtitle="Track your total assets and liabilities" />
+        <PageHeader title="Net Worth" subtitle="Assets and liabilities from your transactions (book value, not live market prices)" />
         <ErrorState
           variant="card"
           message="We couldn't load your net worth data. Please try again."
@@ -38,7 +38,7 @@ export default function NetWorthPage() {
     <PageContainer className="space-y-6">
         <PageHeader
           title="Net Worth"
-          subtitle="Track your total assets and liabilities"
+          subtitle="Assets and liabilities from your transactions (book value, not live market prices)"
           action={<AnalyticsTimeFilter {...m.timeFilterProps} />}
         />
 

--- a/frontend/src/pages/net-worth/__tests__/netWorthProjection.test.ts
+++ b/frontend/src/pages/net-worth/__tests__/netWorthProjection.test.ts
@@ -3,15 +3,12 @@ import { describe, expect, it } from 'vitest'
 import {
   DEFAULT_MILESTONES,
   buildMilestoneRows,
-  buildMilestoneRowsCompound,
   computeAvgMonthlyGrowth,
-  computeMonthlyGrowthRate,
-  computeMonthlyGrowthStats,
+  computeLinearGrowthStats,
   downsampleToMonthly,
   type MilestoneRow,
   projectNetWorth,
-  projectNetWorthCompound,
-  projectNetWorthCompoundBand,
+  projectNetWorthLinearBand,
 } from '../netWorthProjection'
 
 function requireRow(rows: readonly MilestoneRow[], label: string): MilestoneRow {
@@ -220,204 +217,114 @@ describe('projectNetWorth', () => {
     expect(pts[1].date).toBe('2024-03-01')
     expect(pts[2].date).toBe('2024-04-01')
   })
-})
 
-describe('computeMonthlyGrowthRate (compound, geometric mean)', () => {
-  it('returns 0 with fewer than two monthly data points', () => {
-    expect(computeMonthlyGrowthRate([])).toBe(0)
-    expect(computeMonthlyGrowthRate([{ date: '2024-01-01', netWorth: 100 }])).toBe(0)
-  })
-
-  it('returns 0 when start value is non-positive', () => {
-    expect(
-      computeMonthlyGrowthRate([
-        { date: '2024-01-31', netWorth: 0 },
-        { date: '2024-02-29', netWorth: 100_000 },
-      ]),
-    ).toBe(0)
-    expect(
-      computeMonthlyGrowthRate([
-        { date: '2024-01-31', netWorth: -5_000 },
-        { date: '2024-02-29', netWorth: 100_000 },
-      ]),
-    ).toBe(0)
-  })
-
-  it('recovers a known monthly rate over a synthetic series', () => {
-    // 100_000 -> 161_051 over 12 months is exactly 4%/month compound
-    // (1.04^12 = ~1.60103... so close enough; we use an explicit generator)
-    const series: Array<{ date: string; netWorth: number }> = []
-    let v = 100_000
-    for (let m = 0; m <= 12; m++) {
-      const month = String(m + 1).padStart(2, '0')
-      const endOfMonth = m < 9 ? `2024-${month}-28` : `2025-${String(m - 11).padStart(2, '0')}-28`
-      series.push({ date: m < 12 ? `2024-${month}-28` : endOfMonth, netWorth: v })
-      v *= 1.04
-    }
-    const rate = computeMonthlyGrowthRate(series, 12)
-    expect(rate).toBeCloseTo(0.04, 4)
-  })
-
-  it('rate of 0 when net worth is flat', () => {
-    const series = [
-      { date: '2024-01-31', netWorth: 500_000 },
-      { date: '2024-02-29', netWorth: 500_000 },
-      { date: '2024-03-31', netWorth: 500_000 },
-    ]
-    expect(computeMonthlyGrowthRate(series)).toBe(0)
-  })
-})
-
-describe('projectNetWorthCompound', () => {
-  it('returns empty for zero horizon', () => {
-    expect(
-      projectNetWorthCompound({ date: '2024-01-01', netWorth: 100_000 }, 0.01, 0),
-    ).toEqual([])
-  })
-
-  it('grows geometrically at the given rate', () => {
-    const pts = projectNetWorthCompound({ date: '2024-01-01', netWorth: 100_000 }, 0.05, 3)
-    expect(pts).toHaveLength(3)
-    expect(pts[0].netWorth).toBeCloseTo(105_000, 0)
-    expect(pts[1].netWorth).toBeCloseTo(110_250, 0)
-    expect(pts[2].netWorth).toBeCloseTo(115_762.5, 0)
-    expect(pts[0].date).toBe('2024-02-01')
-    expect(pts[2].date).toBe('2024-04-01')
-  })
-
-  it('outpaces linear projection for longer horizons (the actual user-facing win)', () => {
+  it('does not compound: a cumulative-flow series grows linearly, not geometrically', () => {
+    // Regression guard for the ₹28 Cr bug: the projection must be linear in
+    // the anchor value, not exponential. 60 months at 50k/mo from 50L is 80L,
+    // NOT 50L * rate^60.
     const anchor = { date: '2024-01-01', netWorth: 5_000_000 }
-    const monthlyRate = 0.01 // ~12.68%/year
-    // Equivalent ABSOLUTE gain at anchor for linear comparison
-    const monthlyAbsolute = anchor.netWorth * monthlyRate // ₹50k/month at anchor
-    const linearPt = projectNetWorth(anchor, monthlyAbsolute, 60).at(-1)!
-    const compoundPt = projectNetWorthCompound(anchor, monthlyRate, 60).at(-1)!
-    // Linear says 5M + 50k*60 = 8M. Compound says 5M * 1.01^60 = ~9.08M.
-    // Compound must be meaningfully larger so our milestone ETAs are sooner.
-    expect(compoundPt.netWorth).toBeGreaterThan(linearPt.netWorth * 1.1)
+    const pts = projectNetWorth(anchor, 50_000, 60)
+    expect(pts.at(-1)!.netWorth).toBe(5_000_000 + 50_000 * 60) // exactly 8M
   })
 })
 
-describe('computeMonthlyGrowthStats', () => {
+describe('computeLinearGrowthStats', () => {
   it('returns zeros when there is too little data', () => {
-    expect(computeMonthlyGrowthStats([])).toEqual({ rate: 0, logSigma: 0 })
-    expect(computeMonthlyGrowthStats([{ date: '2024-01-31', netWorth: 100 }])).toEqual({
-      rate: 0,
-      logSigma: 0,
+    expect(computeLinearGrowthStats([])).toEqual({ growth: 0, sigma: 0 })
+    expect(computeLinearGrowthStats([{ date: '2024-01-31', netWorth: 100 }])).toEqual({
+      growth: 0,
+      sigma: 0,
     })
     expect(
-      computeMonthlyGrowthStats([
+      computeLinearGrowthStats([
         { date: '2024-01-31', netWorth: 100 },
         { date: '2024-02-29', netWorth: 110 },
       ]),
-    ).toEqual({ rate: 0, logSigma: 0 })
+    ).toEqual({ growth: 0, sigma: 0 })
   })
 
-  it('returns logSigma=0 when the series grows at a constant rate', () => {
-    // 1% per month exactly, no variance.
-    const series: Array<{ date: string; netWorth: number }> = []
-    let v = 100_000
-    for (let m = 0; m <= 6; m++) {
-      const month = String(m + 1).padStart(2, '0')
-      series.push({ date: `2024-${month}-28`, netWorth: v })
-      v *= 1.01
-    }
-    const stats = computeMonthlyGrowthStats(series)
-    expect(stats.rate).toBeCloseTo(0.01, 4)
-    expect(stats.logSigma).toBeCloseTo(0, 6)
-  })
-
-  it('captures variance when monthly returns vary', () => {
-    // Alternating 0% and 2% per month -> mean ~1%/mo, non-zero sigma.
+  it('returns sigma=0 when the series grows by a constant delta', () => {
     const series = [
       { date: '2024-01-28', netWorth: 100_000 },
-      { date: '2024-02-28', netWorth: 100_000 }, // +0%
-      { date: '2024-03-28', netWorth: 102_000 }, // +2%
-      { date: '2024-04-28', netWorth: 102_000 }, // +0%
-      { date: '2024-05-28', netWorth: 104_040 }, // +2%
-      { date: '2024-06-28', netWorth: 104_040 }, // +0%
-      { date: '2024-07-28', netWorth: 106_120.8 }, // +2%
+      { date: '2024-02-28', netWorth: 120_000 },
+      { date: '2024-03-28', netWorth: 140_000 },
+      { date: '2024-04-28', netWorth: 160_000 },
     ]
-    const stats = computeMonthlyGrowthStats(series)
-    // Geometric mean ~1%/mo (alternating 0% and 2%).
-    expect(stats.rate).toBeGreaterThan(0.005)
-    expect(stats.rate).toBeLessThan(0.015)
-    // Sigma should be roughly half the spread of |0% - 2%| in log space ≈ 0.0099.
-    expect(stats.logSigma).toBeGreaterThan(0.005)
-    expect(stats.logSigma).toBeLessThan(0.02)
+    const stats = computeLinearGrowthStats(series)
+    expect(stats.growth).toBe(20_000)
+    expect(stats.sigma).toBe(0)
+  })
+
+  it('captures variance when monthly deltas vary', () => {
+    // Alternating +10k and +30k deltas -> mean 20k, sample stddev ~11.55k.
+    const series = [
+      { date: '2024-01-28', netWorth: 100_000 },
+      { date: '2024-02-28', netWorth: 110_000 }, // +10k
+      { date: '2024-03-28', netWorth: 140_000 }, // +30k
+      { date: '2024-04-28', netWorth: 150_000 }, // +10k
+      { date: '2024-05-28', netWorth: 180_000 }, // +30k
+    ]
+    const stats = computeLinearGrowthStats(series)
+    expect(stats.growth).toBe(20_000)
+    expect(stats.sigma).toBeGreaterThan(10_000)
+    expect(stats.sigma).toBeLessThan(13_000)
+  })
+
+  it('handles negative and zero net worth (no positivity requirement)', () => {
+    // Unlike a geometric rate, the linear model is defined for users who are
+    // currently in debt or recovering from negative net worth.
+    const series = [
+      { date: '2024-01-28', netWorth: -50_000 },
+      { date: '2024-02-28', netWorth: -20_000 }, // +30k
+      { date: '2024-03-28', netWorth: 0 }, // +20k
+      { date: '2024-04-28', netWorth: 25_000 }, // +25k
+    ]
+    const stats = computeLinearGrowthStats(series)
+    expect(stats.growth).toBe(25_000)
+    expect(stats.sigma).toBeGreaterThan(0)
   })
 })
 
-describe('projectNetWorthCompoundBand', () => {
+describe('projectNetWorthLinearBand', () => {
   const anchor = { date: '2024-01-01', netWorth: 1_000_000 }
 
   it('returns empty for non-positive horizon', () => {
-    expect(projectNetWorthCompoundBand(anchor, 0.01, 0.005, 0)).toEqual([])
+    expect(projectNetWorthLinearBand(anchor, 10_000, 5_000, 0)).toEqual([])
   })
 
-  it('collapses upper/lower to mean when logSigma is zero', () => {
-    const pts = projectNetWorthCompoundBand(anchor, 0.01, 0, 12)
+  it('collapses upper/lower to mean when sigma is zero', () => {
+    const pts = projectNetWorthLinearBand(anchor, 10_000, 0, 12)
     expect(pts).toHaveLength(12)
     for (const p of pts) {
-      expect(p.upper).toBeCloseTo(p.mean, 4)
-      expect(p.lower).toBeCloseTo(p.mean, 4)
+      expect(p.upper).toBe(p.mean)
+      expect(p.lower).toBe(p.mean)
     }
-    // Final mean = anchor * 1.01^12 ≈ 1,126,825
-    expect(pts.at(-1)!.mean).toBeCloseTo(1_126_825, 0)
+    // Final mean = anchor + 12 * 10k = 1,120,000
+    expect(pts.at(-1)!.mean).toBe(1_120_000)
   })
 
-  it('upper > mean > lower at every point when logSigma is positive', () => {
-    const pts = projectNetWorthCompoundBand(anchor, 0.01, 0.02, 24)
+  it('upper > mean > lower at every point when sigma is positive', () => {
+    const pts = projectNetWorthLinearBand(anchor, 10_000, 5_000, 24)
     for (const p of pts) {
       expect(p.upper).toBeGreaterThan(p.mean)
       expect(p.lower).toBeLessThan(p.mean)
-      expect(p.lower).toBeGreaterThan(0)
     }
   })
 
-  it('band width grows with sqrt(time) under GBM', () => {
-    // log(upper) - log(lower) = 2 * sigma * sqrt(n) — should scale ~sqrt of time.
-    const pts = projectNetWorthCompoundBand(anchor, 0.01, 0.02, 36)
-    const widthAtMonth1 = Math.log(pts[0].upper) - Math.log(pts[0].lower)
-    const widthAtMonth36 = Math.log(pts[35].upper) - Math.log(pts[35].lower)
-    // sqrt(36) / sqrt(1) = 6 ; allow some slack for rounding.
-    const ratio = widthAtMonth36 / widthAtMonth1
-    expect(ratio).toBeGreaterThan(5.5)
-    expect(ratio).toBeLessThan(6.5)
-  })
-})
-
-describe('buildMilestoneRowsCompound', () => {
-  it('returns all-upcoming with nulls for empty series', () => {
-    const rows = buildMilestoneRowsCompound([], null, 0.01)
-    expect(rows).toHaveLength(DEFAULT_MILESTONES.length)
-    expect(rows.every((r) => r.status === 'upcoming' && r.date === null)).toBe(true)
+  it('band width grows with sqrt(time)', () => {
+    // upper - lower = 2 * sigma * sqrt(n) -- should scale as sqrt of time.
+    const pts = projectNetWorthLinearBand(anchor, 10_000, 5_000, 36)
+    const widthAtMonth1 = pts[0].upper - pts[0].lower
+    const widthAtMonth36 = pts[35].upper - pts[35].lower
+    // sqrt(36) / sqrt(1) = 6
+    expect(widthAtMonth36 / widthAtMonth1).toBeCloseTo(6, 6)
   })
 
-  it('sets upcoming ETA using log-based solver for positive rate', () => {
-    const series = [
-      { date: '2024-01-31', netWorth: 500_000 },
-      { date: '2024-02-29', netWorth: 515_000 }, // ~3%/month-ish
-    ]
-    const anchor = series.at(-1)
-    if (!anchor) throw new Error('anchor required')
-    const rows = buildMilestoneRowsCompound(series, anchor, 0.03)
-
-    const row10L = requireRow(rows, '₹10L')
-    expect(row10L.status).toBe('upcoming')
-    // ln(1_000_000 / 515_000) / ln(1.03) ≈ 22.5 months
-    expect(row10L.distance).toBeGreaterThan(20)
-    expect(row10L.distance).toBeLessThan(25)
-  })
-
-  it('marks all upcoming dates as null when rate is non-positive', () => {
-    const series = [
-      { date: '2024-01-31', netWorth: 500_000 },
-      { date: '2024-02-29', netWorth: 500_000 },
-    ]
-    const rows = buildMilestoneRowsCompound(series, series[1], 0)
-    const upcomingRows = rows.filter((r) => r.status === 'upcoming')
-    expect(upcomingRows.every((r) => r.date === null && r.distance === null)).toBe(true)
+  it('mean follows the linear trend exactly', () => {
+    const pts = projectNetWorthLinearBand(anchor, 25_000, 10_000, 6)
+    pts.forEach((p, idx) => {
+      expect(p.mean).toBe(anchor.netWorth + 25_000 * (idx + 1))
+    })
   })
 })
 

--- a/frontend/src/pages/net-worth/components/MilestonesTable.tsx
+++ b/frontend/src/pages/net-worth/components/MilestonesTable.tsx
@@ -10,8 +10,8 @@ import type { MilestoneRow } from '../netWorthProjection'
 interface MilestonesTableProps {
   readonly rows: readonly MilestoneRow[]
   readonly currentNetWorth: number
-  /** Compound monthly growth rate (decimal). 0.01 = 1 %/month (~12.7 % annualized). */
-  readonly monthlyGrowthRate: number
+  /** Average monthly net-worth change in rupees (linear model over cash flows). */
+  readonly monthlyGrowth: number
 }
 
 /** "3mo" / "1y 2mo" / "2y" */
@@ -141,17 +141,11 @@ function buildColumns(): DataTableColumn<MilestoneRow>[] {
 export default function MilestonesTable({
   rows,
   currentNetWorth,
-  monthlyGrowthRate,
+  monthlyGrowth,
 }: MilestonesTableProps) {
   const stableCount = rows.filter((r) => r.stableSince !== null).length
   const reachedCount = rows.filter((r) => r.status === 'achieved').length
-  const hasGrowth = monthlyGrowthRate > 0
-  // Derive a human-readable annualized % from the compound monthly rate.
-  // ((1 + r)^12 - 1) * 100 -- e.g. 1 %/month -> 12.68 % annualized.
-  const annualizedPercent = hasGrowth ? (((1 + monthlyGrowthRate) ** 12) - 1) * 100 : 0
-  // And the approximate absolute monthly rupee gain at the CURRENT net worth.
-  // Shown alongside the % so the number is concrete, not just academic.
-  const approxMonthlyRupees = hasGrowth ? currentNetWorth * monthlyGrowthRate : 0
+  const hasGrowth = monthlyGrowth > 0
   const columns = buildColumns()
 
   if (rows.length === 0) {
@@ -173,18 +167,13 @@ export default function MilestonesTable({
           <span className="text-foreground font-semibold">{formatCurrency(currentNetWorth)}</span>
         </span>
         <span className="text-muted-foreground">
-          Growth rate:{' '}
+          Avg growth:{' '}
           <span
             className={hasGrowth ? 'text-app-green font-semibold' : 'text-app-red font-semibold'}
           >
-            {hasGrowth ? `+${annualizedPercent.toFixed(1)}%/yr` : 'stalled'}
+            {hasGrowth ? `+${formatCurrency(Math.round(monthlyGrowth))}/mo` : 'stalled'}
           </span>
-          {hasGrowth ? (
-            <span className="text-xs text-text-tertiary">
-              {' '}
-              (~{formatCurrency(Math.round(approxMonthlyRupees))}/mo)
-            </span>
-          ) : (
+          {!hasGrowth && (
             <span className="text-xs text-text-tertiary"> (need positive growth to project)</span>
           )}
         </span>
@@ -219,8 +208,9 @@ export default function MilestonesTable({
         <span className="text-app-green">Stable</span> means your net worth never dropped below
         that threshold after the crossing.{' '}
         <span className="text-app-yellow">Reached</span> means you crossed it but later dipped
-        below. ETAs extrapolate your last 12 months of growth forward at a compound rate -- same
-        way a SIP or PPF/EPF balance actually grows.
+        below. ETAs extrapolate your average monthly saving over the last 12 months. Figures are
+        book value (cash flows in minus out) -- market gains on investments aren't tracked, so
+        treat ETAs as conservative.
       </p>
     </div>
   )

--- a/frontend/src/pages/net-worth/components/NetWorthTrendChart.tsx
+++ b/frontend/src/pages/net-worth/components/NetWorthTrendChart.tsx
@@ -34,7 +34,8 @@ interface NetWorthTrendChartProps {
   setShowStacked: (v: boolean) => void
   showProjection: boolean
   setShowProjection: (v: boolean) => void
-  monthlyGrowthRate: number
+  /** Average monthly net-worth change in rupees (linear model over cash flows). */
+  monthlyGrowth: number
   anchor: NetWorthPoint | null
   /**
    * Upcoming milestones to draw as horizontal threshold lines so users see
@@ -56,7 +57,7 @@ export function NetWorthTrendChart(props: Readonly<NetWorthTrendChartProps>) {
     setShowStacked,
     showProjection,
     setShowProjection,
-    monthlyGrowthRate,
+    monthlyGrowth,
     anchor,
     milestoneRows,
   } = props
@@ -85,12 +86,12 @@ export function NetWorthTrendChart(props: Readonly<NetWorthTrendChartProps>) {
         <div className="flex items-center gap-2 flex-wrap" role="group" aria-label="Net worth chart view options">
           <button
             onClick={() => setShowProjection(!showProjection)}
-            disabled={monthlyGrowthRate <= 0}
+            disabled={monthlyGrowth <= 0}
             aria-pressed={showProjection}
             title={
-              monthlyGrowthRate <= 0
+              monthlyGrowth <= 0
                 ? 'Need positive monthly growth to project'
-                : `Project forward at ${(monthlyGrowthRate * 100).toFixed(2)} %/month compound (~${(((1 + monthlyGrowthRate) ** 12 - 1) * 100).toFixed(1)} % annualized)`
+                : `Project forward at your average monthly saving (book value; market gains not tracked)`
             }
             className={`inline-flex items-center gap-1.5 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors ${
               showProjection
@@ -138,7 +139,7 @@ export function NetWorthTrendChart(props: Readonly<NetWorthTrendChartProps>) {
           )
         }
         const anchorDateIso = anchor?.date ?? new Date().toISOString().substring(0, 10)
-        const showProjectionLine = showProjection && monthlyGrowthRate > 0
+        const showProjectionLine = showProjection && monthlyGrowth > 0
         return (
           <ChartContainer
             height={320}
@@ -269,7 +270,7 @@ export function NetWorthTrendChart(props: Readonly<NetWorthTrendChartProps>) {
                     <>
                       {/* 1-stddev confidence band, drawn before the median line so the
                           line renders on top. The band widens as sqrt(time) under the
-                          GBM model. Empty during historical points (null tuple). */}
+                          random-walk-with-drift model. Empty on historical points. */}
                       <Area
                         type="monotone"
                         dataKey="projectionBand"

--- a/frontend/src/pages/net-worth/netWorthProjection.ts
+++ b/frontend/src/pages/net-worth/netWorthProjection.ts
@@ -57,53 +57,17 @@ export const DEFAULT_MILESTONES: readonly Milestone[] = [
 ] as const
 
 /**
- * Compute the monthly COMPOUND growth rate over the last `lookbackMonths`
- * (as a decimal -- 0.01 means 1 % per month).
- *
- * Uses the geometric mean of month-end net worth over the window:
- *     r = (end / start)^(1 / n) - 1
- *
- * Returns 0 when:
- *   - fewer than 2 month-end points in the window
- *   - start net worth <= 0 (compound growth is undefined from zero / negative)
- *   - end net worth <= 0
- *
- * This is the correct model for an investing/saving user because savings + asset
- * growth both compound. The earlier linear model (`computeAvgMonthlyGrowth`)
- * dramatically underestimates time-to-target for users with returns -- a ₹50L
- * portfolio growing at 12 % annualized reaches ₹1Cr in ~6 years by compound,
- * but ~17 years by linear extrapolation of the recent monthly delta.
- */
-export function computeMonthlyGrowthRate(
-  series: readonly NetWorthPoint[],
-  lookbackMonths = 12,
-): number {
-  if (series.length < 2) return 0
-  const sorted = [...series].sort((a, b) => a.date.localeCompare(b.date))
-
-  const monthlyLast: Record<string, number> = {}
-  for (const point of sorted) {
-    monthlyLast[point.date.substring(0, 7)] = point.netWorth
-  }
-
-  const months = Object.keys(monthlyLast).sort((a, b) => a.localeCompare(b))
-  if (months.length < 2) return 0
-
-  const windowMonths = months.slice(-Math.max(2, lookbackMonths + 1))
-  const lastMonth = windowMonths.at(-1)
-  if (lastMonth === undefined) return 0
-  const start = monthlyLast[windowMonths[0]]
-  const end = monthlyLast[lastMonth]
-  const spanMonths = windowMonths.length - 1
-
-  if (start <= 0 || end <= 0 || spanMonths <= 0) return 0
-
-  return (end / start) ** (1 / spanMonths) - 1
-}
-
-/**
  * Compute average monthly net-worth change over the last ``lookbackMonths``.
  * Returns 0 if there's not enough data.
+ *
+ * This LINEAR model is deliberate: the net-worth series is built from
+ * cumulative cash flows (income - expense), i.e. BOOK VALUE -- there is no
+ * market-price feed. A flow-accumulation series grows by roughly "what you
+ * save each month", not exponentially, so extrapolating it with a compound
+ * rate treats savings as an asset return and explodes (a real-data audit
+ * measured a geometric fit projecting ₹28 Cr in 5 years where the linear
+ * trend gives ~₹0.9 Cr). If a market-value feed ever lands, a compound model
+ * belongs on THAT series -- not on this one.
  */
 export function computeAvgMonthlyGrowth(
   series: readonly NetWorthPoint[],
@@ -154,10 +118,6 @@ export function downsampleToMonthly(
  * Project future monthly net-worth points from ``anchor`` at a constant
  * ABSOLUTE monthly delta (linear extrapolation).
  *
- * Kept for backwards compatibility. Prefer `projectNetWorthCompound` for any
- * new consumer -- linear underestimates time-to-target for users with
- * compound return (equity / MF / PPF / EPF).
- *
  * The anchor's own ``date`` is not included in the output; the first projected
  * point is one month after the anchor.
  */
@@ -182,58 +142,22 @@ export function projectNetWorth(
 }
 
 /**
- * Project future monthly net-worth points from ``anchor`` at a constant
- * COMPOUND monthly rate (geometric growth).
+ * Compute the average monthly net-worth change AND the standard deviation of
+ * the individual monthly deltas over the last ``lookbackMonths``.
  *
- * `monthlyRate` is a decimal (0.01 = 1 % per month). Typical realistic values:
- *   - 0.005-0.015 for a saver-investor in INR assets (6-20 % annual)
- *   - > 0.02 rarely sustainable; clamp at the call site if desired
+ * - ``growth``: same value ``computeAvgMonthlyGrowth`` returns. Rupees/month.
+ * - ``sigma``: sample stddev (n-1 denominator) of the monthly deltas. Used by
+ *   ``projectNetWorthLinearBand`` to widen the band as sqrt(time) -- the
+ *   correct scaling when each month adds an independent savings delta.
  *
- * Unlike the linear `projectNetWorth`, this reflects the actual compounding
- * behaviour of equity / MF / PPF / EPF holdings. For a user with monthly
- * savings contributions *and* market returns, both effects fold into the
- * observed monthly rate -- the geometric-mean lookback captures the blended
- * historical growth directly.
+ * Returns ``{growth: 0, sigma: 0}`` when fewer than 3 month-end points are
+ * available (need at least 2 monthly deltas to have any variance).
  */
-export function projectNetWorthCompound(
-  anchor: NetWorthPoint,
-  monthlyRate: number,
-  horizonMonths = 60,
-): NetWorthPoint[] {
-  if (horizonMonths <= 0) return []
-  const points: NetWorthPoint[] = []
-  const start = new Date(anchor.date)
-  start.setUTCHours(0, 0, 0, 0)
-  for (let i = 1; i <= horizonMonths; i++) {
-    const d = new Date(start)
-    d.setUTCMonth(d.getUTCMonth() + i)
-    points.push({
-      date: d.toISOString().substring(0, 10),
-      netWorth: anchor.netWorth * (1 + monthlyRate) ** i,
-    })
-  }
-  return points
-}
-
-/**
- * Compute the geometric monthly growth rate AND the standard deviation of
- * its log-returns over the last ``lookbackMonths`` of month-end net worth.
- *
- * - ``rate``: same value ``computeMonthlyGrowthRate`` returns. Decimal.
- * - ``logSigma``: stddev of ln(1 + r_i) for the individual monthly growth
- *   rates r_i in the window. Used by ``projectNetWorthCompoundBand`` to
- *   model uncertainty under a geometric Brownian motion (GBM) projection.
- *
- * Returns ``{rate: 0, logSigma: 0}`` when fewer than 3 month-end points are
- * available (need at least 2 monthly rates to have any variance), or when
- * any month-end value is non-positive (compound growth undefined). Sample
- * standard deviation (n-1 denominator) is used.
- */
-export function computeMonthlyGrowthStats(
+export function computeLinearGrowthStats(
   series: readonly NetWorthPoint[],
   lookbackMonths = 12,
-): { rate: number; logSigma: number } {
-  if (series.length < 3) return { rate: 0, logSigma: 0 }
+): { growth: number; sigma: number } {
+  if (series.length < 3) return { growth: 0, sigma: 0 }
   const sorted = [...series].sort((a, b) => a.date.localeCompare(b.date))
 
   const monthlyLast: Record<string, number> = {}
@@ -242,36 +166,19 @@ export function computeMonthlyGrowthStats(
   }
 
   const months = Object.keys(monthlyLast).sort((a, b) => a.localeCompare(b))
-  if (months.length < 3) return { rate: 0, logSigma: 0 }
+  if (months.length < 3) return { growth: 0, sigma: 0 }
 
   const windowMonths = months.slice(-Math.max(3, lookbackMonths + 1))
-  const lastMonth = windowMonths.at(-1)
-  if (lastMonth === undefined) return { rate: 0, logSigma: 0 }
-  const start = monthlyLast[windowMonths[0]]
-  const end = monthlyLast[lastMonth]
-  const spanMonths = windowMonths.length - 1
-
-  if (start <= 0 || end <= 0 || spanMonths <= 0) return { rate: 0, logSigma: 0 }
-
-  // Geometric-mean monthly rate (matches computeMonthlyGrowthRate).
-  const rate = (end / start) ** (1 / spanMonths) - 1
-
-  // Per-month log-returns over the same window.
-  const logReturns: number[] = []
+  const deltas: number[] = []
   for (let i = 1; i < windowMonths.length; i++) {
-    const prev = monthlyLast[windowMonths[i - 1]]
-    const curr = monthlyLast[windowMonths[i]]
-    if (prev <= 0 || curr <= 0) return { rate: 0, logSigma: 0 }
-    logReturns.push(Math.log(curr / prev))
+    deltas.push(monthlyLast[windowMonths[i]] - monthlyLast[windowMonths[i - 1]])
   }
-  if (logReturns.length < 2) return { rate, logSigma: 0 }
+  if (deltas.length < 2) return { growth: 0, sigma: 0 }
 
-  const meanLog = logReturns.reduce((sum, x) => sum + x, 0) / logReturns.length
+  const growth = deltas.reduce((sum, d) => sum + d, 0) / deltas.length
   const variance =
-    logReturns.reduce((sum, x) => sum + (x - meanLog) ** 2, 0) / (logReturns.length - 1)
-  const logSigma = Math.sqrt(variance)
-
-  return { rate, logSigma }
+    deltas.reduce((sum, d) => sum + (d - growth) ** 2, 0) / (deltas.length - 1)
+  return { growth, sigma: Math.sqrt(variance) }
 }
 
 /** A single projected point with a 1-stddev confidence band. */
@@ -283,46 +190,41 @@ export interface NetWorthProjectionBandPoint {
 }
 
 /**
- * Project future monthly net worth with a 1-sigma confidence band under
- * a geometric Brownian motion model.
+ * Project future monthly net worth with a 1-sigma confidence band under a
+ * random-walk-with-drift model (linear trend, additive noise).
  *
  * For month ``n`` after the anchor:
- *   mean  = anchor * (1 + monthlyRate)^n
- *   upper = anchor * exp(n * ln(1 + monthlyRate) + logSigma * sqrt(n))
- *   lower = anchor * exp(n * ln(1 + monthlyRate) - logSigma * sqrt(n))
+ *   mean  = anchor + monthlyGrowth * n
+ *   upper = mean + sigma * sqrt(n)
+ *   lower = mean - sigma * sqrt(n)
  *
  * The sqrt(n) scaling is the correct uncertainty-grows-with-time behaviour
- * for compounding returns: roughly 68 % of plausible trajectories fall
- * within the band, and the band widens further out (the projection is
- * confident next month, less confident in 5 years).
+ * when each month contributes an independent delta: roughly 68 % of plausible
+ * trajectories fall within the band, and the band widens further out (the
+ * projection is confident next month, less confident in 5 years).
  *
- * When ``logSigma <= 0`` the band collapses to the mean (visually a single
- * line, same as ``projectNetWorthCompound``).
+ * When ``sigma <= 0`` the band collapses to the mean (visually a single line).
  */
-export function projectNetWorthCompoundBand(
+export function projectNetWorthLinearBand(
   anchor: NetWorthPoint,
-  monthlyRate: number,
-  logSigma: number,
+  monthlyGrowth: number,
+  sigma: number,
   horizonMonths = 60,
 ): NetWorthProjectionBandPoint[] {
   if (horizonMonths <= 0) return []
   const points: NetWorthProjectionBandPoint[] = []
   const start = new Date(anchor.date)
   start.setUTCHours(0, 0, 0, 0)
-  const lnGrowth = Math.log(1 + monthlyRate)
   for (let i = 1; i <= horizonMonths; i++) {
     const d = new Date(start)
     d.setUTCMonth(d.getUTCMonth() + i)
-    const mean = anchor.netWorth * (1 + monthlyRate) ** i
-    const drift = lnGrowth * i
-    const halfBand = logSigma > 0 ? logSigma * Math.sqrt(i) : 0
-    const upper = anchor.netWorth * Math.exp(drift + halfBand)
-    const lower = anchor.netWorth * Math.exp(drift - halfBand)
+    const mean = anchor.netWorth + monthlyGrowth * i
+    const halfBand = sigma > 0 ? sigma * Math.sqrt(i) : 0
     points.push({
       date: d.toISOString().substring(0, 10),
       mean,
-      upper,
-      lower,
+      upper: mean + halfBand,
+      lower: mean - halfBand,
     })
   }
   return points
@@ -387,24 +289,6 @@ function findStableSince(
   return null
 }
 
-/**
- * Compute how many months from `anchor` until compound growth at `monthlyRate`
- * reaches `target`. Solves `anchor * (1 + r)^n = target` for n:
- *     n = ln(target / anchor) / ln(1 + r)
- *
- * Returns `null` when growth is non-positive or the target is already met.
- */
-function monthsToTargetCompound(
-  anchorValue: number,
-  target: number,
-  monthlyRate: number,
-): number | null {
-  if (target <= anchorValue) return null
-  if (anchorValue <= 0) return null
-  if (monthlyRate <= 0) return null
-  return Math.log(target / anchorValue) / Math.log(1 + monthlyRate)
-}
-
 function buildUpcomingRow(
   m: Milestone,
   anchor: NetWorthPoint,
@@ -414,26 +298,6 @@ function buildUpcomingRow(
     return { ...m, status: 'upcoming', date: null, distance: null, stableSince: null }
   }
   const monthsAway = (m.value - anchor.netWorth) / monthlyGrowth
-  const eta = new Date(anchor.date)
-  eta.setUTCDate(eta.getUTCDate() + Math.round(monthsAway * 30.44))
-  return {
-    ...m,
-    status: 'upcoming',
-    date: eta.toISOString().substring(0, 10),
-    distance: Math.round(monthsAway * 10) / 10,
-    stableSince: null,
-  }
-}
-
-function buildUpcomingRowCompound(
-  m: Milestone,
-  anchor: NetWorthPoint,
-  monthlyRate: number,
-): MilestoneRow {
-  const monthsAway = monthsToTargetCompound(anchor.netWorth, m.value, monthlyRate)
-  if (monthsAway === null) {
-    return { ...m, status: 'upcoming', date: null, distance: null, stableSince: null }
-  }
   const eta = new Date(anchor.date)
   eta.setUTCDate(eta.getUTCDate() + Math.round(monthsAway * 30.44))
   return {
@@ -493,53 +357,5 @@ export function buildMilestoneRows(
   })
 
   // Sort by value so the table reads low-to-high regardless of status.
-  return rows.sort((a, b) => a.value - b.value)
-}
-
-/**
- * Compound-growth equivalent of `buildMilestoneRows`.
- *
- * `monthlyRate` is a decimal (0.01 = 1 % per month). Historic "achieved" rows
- * are identical to the linear version -- only the ETA for upcoming rows is
- * computed using compound growth instead of a fixed monthly delta.
- */
-export function buildMilestoneRowsCompound(
-  series: readonly NetWorthPoint[],
-  anchor: NetWorthPoint | null,
-  monthlyRate: number,
-  milestones: readonly Milestone[] = DEFAULT_MILESTONES,
-): MilestoneRow[] {
-  if (series.length === 0 || anchor === null) {
-    return milestones.map((m) => ({
-      ...m,
-      status: 'upcoming',
-      date: null,
-      distance: null,
-      stableSince: null,
-    }))
-  }
-
-  const achievedDate = scanAchievements(series, milestones)
-  const sorted = [...series].sort((a, b) => a.date.localeCompare(b.date))
-  const startDate = new Date(sorted[0].date)
-
-  const rows: MilestoneRow[] = milestones.map((m) => {
-    const dateStr = achievedDate.get(m.value)
-    if (dateStr !== undefined) {
-      const daysFromStart = Math.max(
-        0,
-        Math.round((new Date(dateStr).getTime() - startDate.getTime()) / 86_400_000),
-      )
-      return {
-        ...m,
-        status: 'achieved',
-        date: dateStr,
-        distance: daysFromStart,
-        stableSince: findStableSince(sorted, m.value, dateStr),
-      }
-    }
-    return buildUpcomingRowCompound(m, anchor, monthlyRate)
-  })
-
   return rows.sort((a, b) => a.value - b.value)
 }

--- a/frontend/src/pages/net-worth/useNetWorth.ts
+++ b/frontend/src/pages/net-worth/useNetWorth.ts
@@ -7,11 +7,10 @@ import { usePreferences } from '@/hooks/api/usePreferences'
 import { accountClassificationsService } from '@/services/api/accountClassifications'
 
 import {
-  computeMonthlyGrowthRate,
-  computeMonthlyGrowthStats,
+  buildMilestoneRows,
+  computeLinearGrowthStats,
   downsampleToMonthly,
-  projectNetWorthCompoundBand,
-  buildMilestoneRowsCompound,
+  projectNetWorthLinearBand,
   type NetWorthPoint,
 } from './netWorthProjection'
 import {
@@ -146,27 +145,27 @@ export function useNetWorth() {
     [chartSeries],
   )
 
-  const monthlyGrowthRate = useMemo(() => computeMonthlyGrowthRate(chartSeries, 12), [chartSeries])
-
-  const monthlyGrowthLogSigma = useMemo(
-    () => computeMonthlyGrowthStats(chartSeries, 12).logSigma,
-    [chartSeries],
-  )
+  // Linear (average monthly delta) growth model. The series is cumulative
+  // cash flow (book value, no market prices), so a compound/geometric fit
+  // would treat savings as an asset return and blow up long-horizon
+  // projections -- see computeAvgMonthlyGrowth docs.
+  const growthStats = useMemo(() => computeLinearGrowthStats(chartSeries, 12), [chartSeries])
+  const monthlyGrowth = growthStats.growth
 
   const milestoneRows = useMemo(
-    () => buildMilestoneRowsCompound(fullSeries, anchor, monthlyGrowthRate),
-    [fullSeries, anchor, monthlyGrowthRate],
+    () => buildMilestoneRows(fullSeries, anchor, monthlyGrowth),
+    [fullSeries, anchor, monthlyGrowth],
   )
 
   const chartData = useMemo(() => {
-    if (!showProjection || monthlyGrowthRate <= 0 || anchor === null) {
+    if (!showProjection || monthlyGrowth <= 0 || anchor === null) {
       return filteredNetWorthData
     }
     const monthlyHistorical = downsampleToMonthly(chartSeries)
-    const band = projectNetWorthCompoundBand(
+    const band = projectNetWorthLinearBand(
       anchor,
-      monthlyGrowthRate,
-      monthlyGrowthLogSigma,
+      monthlyGrowth,
+      growthStats.sigma,
       60,
     )
 
@@ -195,7 +194,7 @@ export function useNetWorth() {
       })),
     ]
     return [...historicalPoints, ...projectedPoints]
-  }, [showProjection, anchor, monthlyGrowthRate, monthlyGrowthLogSigma, chartSeries, filteredNetWorthData])
+  }, [showProjection, anchor, monthlyGrowth, growthStats.sigma, chartSeries, filteredNetWorthData])
 
   const currentNetWorth = anchor?.netWorth ?? 0
 
@@ -261,7 +260,7 @@ export function useNetWorth() {
     setShowStacked,
     showProjection,
     setShowProjection,
-    monthlyGrowthRate,
+    monthlyGrowth,
     anchor,
     milestoneRows,
     currentNetWorth,


### PR DESCRIPTION
Verified-and-fixed wave of correctness bugs. Half the 2-week-old audit backlog turned out already-fixed on re-verification (documented below); this PR fixes the ones still open plus two new bugs surfaced by a fresh hunt.

## Fixes

### 1. Net-worth projection compounded a cash-flow series (HIGH)
`netWorthProjection.ts` fit a **geometric** monthly rate to a cumulative income-minus-expense series and compounded it forward. That series is book value (no market feed), so it grows by ~savings/month, not exponentially -- the audit measured a **28 Cr** 5-year projection where the linear trend gives ~0.9 Cr. Replaced the geometric rate + GBM band with `computeLinearGrowthStats` (avg monthly delta + sample sigma) and `projectNetWorthLinearBand` (random-walk-with-drift, sqrt-time band). Milestone ETAs back to the linear `buildMilestoneRows`; dropped the compound solver. Linear model also handles zero/negative net worth (geometric returned 0 there). Regression test locks the 60-month projection to exact linear growth.

### 2. GST category breakdown collapsed the rate across the 2025-09-22 cutover (MEDIUM)
`computeGSTAnalysis` froze one rate per category, so a category with transactions on both sides of the GST 2.0 cutover was rated under a single slab table (~3.8% understatement on real data). GST now accumulates **per transaction** with each transaction's date-correct rate; the displayed category rate is the effective inclusive rate implied by the exact sum (snaps to the slab integer for single-table categories). Two regression tests (cross-cutover blended + single-table snap).

### 3. Days of Buffering counted investments as spendable cash (MEDIUM)
Dashboard fed lifetime income-minus-expense as the "liquid balance", so PPF/MF/stocks inflated the runway (audit: 754 days vs true cash). Now sums `account_balances` for accounts the user classified as Cash / Bank Accounts / Other Wallets; unclassified excluded rather than guessed.

### 4. analyticsV2 query keys dropped limit/offset (MEDIUM, new find)
Eight `useAnalyticsV2` hooks sent `limit`/`offset` to the API but omitted them from the queryKey. With `staleTime: Infinity`, two callers with different limits share one cache entry -- a `limit:5` widget silently poisons the full list. Key factories now include every param the queryFn sends.

### 5. Auth modal showed "not configured" on any fetch failure (MEDIUM, new find)
`AuthModal` collapsed every `getOAuthProviders()` failure to `[]`, rendering "OAuth sign-in is not configured yet" for cold-start timeouts and network blips even when the backend has providers (observed in prod after a deploy while Vercel/Neon were waking). Failures now get a distinct "server may be waking up" state with a Try again button; the not-configured copy only renders when the request **succeeds** with an empty list.

### 6. Book-value labeling (LOW)
XIRR renamed "Cashflow XIRR" (terminal value is contributions, not market value); "Net contributions (book value)" subtitle on Total Investment Value; Net Worth page subtitle and Days of Buffering copy now say the figures are book value / liquid accounts. Label-only, no calc change.

## Already-fixed on re-verification (no change; noted for the reviewer)
Re-checked the full audit list against current code: **lifestyle-inflation divisor**, **net_worth_change same-day prev-snapshot**, **anomaly sort-before-cap**, **anomaly severity grading**, and **day-of-month mode-first heuristic** are all already fixed in `main` with tests. The stale CORS issue #136 was already fixed and is now closed.

## Verification
- Frontend: `tsc -b`, `eslint .`, and `pnpm test` (281 tests) all pass.
- Backend: `pytest` 328 pass.
- New/updated tests: netWorthProjection (linear model + 28 Cr regression guard), gstCalculator (2 cutover cases).

## Reviewer notes
- The net-worth change is the largest (`netWorthProjection.ts` -270 lines): it removes the compound machinery entirely rather than leaving dead code.
- A cross-user-scoping audit of all backend routers + 15 AI tools found **zero** unscoped queries (not a fix, just confirming the data-isolation invariant holds).