### PR TITLE
feat(net-worth): tiered milestone ladder with windowed upcoming rows

### DIFF
--- a/frontend/src/pages/net-worth/__tests__/netWorthProjection.test.ts
+++ b/frontend/src/pages/net-worth/__tests__/netWorthProjection.test.ts
@@ -2,10 +2,13 @@ import { describe, expect, it } from 'vitest'
 
 import {
   DEFAULT_MILESTONES,
+  DEFAULT_UPCOMING_WINDOW,
   buildMilestoneRows,
   computeAvgMonthlyGrowth,
   computeLinearGrowthStats,
   downsampleToMonthly,
+  formatMilestoneLabel,
+  type Milestone,
   type MilestoneRow,
   projectNetWorth,
   projectNetWorthLinearBand,
@@ -17,11 +20,23 @@ function requireRow(rows: readonly MilestoneRow[], label: string): MilestoneRow 
   return row
 }
 
+// Small explicit ladder including ₹1L, used by crossing/stability tests so
+// they're independent of the default (₹5L-and-up) generated ladder.
+const SMALL_MILESTONES: readonly Milestone[] = [
+  { value: 100_000, label: '₹1L' },
+  { value: 500_000, label: '₹5L' },
+  { value: 1_000_000, label: '₹10L' },
+]
+
 describe('buildMilestoneRows', () => {
-  it('returns all-upcoming with nulls for empty series', () => {
+  it('returns a windowed preview of upcoming targets for an empty series', () => {
     const rows = buildMilestoneRows([], null, 0)
-    expect(rows).toHaveLength(DEFAULT_MILESTONES.length)
+    // No history -> show the first N targets, not the whole ladder.
+    expect(rows).toHaveLength(DEFAULT_UPCOMING_WINDOW)
     expect(rows.every((r) => r.status === 'upcoming' && r.date === null)).toBe(true)
+    // Ladder starts at ₹5L and steps by ₹5L in the lakhs range.
+    expect(rows[0].value).toBe(500_000)
+    expect(rows[1].value).toBe(1_000_000)
   })
 
   it('labels crossings as achieved with dates', () => {
@@ -33,7 +48,7 @@ describe('buildMilestoneRows', () => {
     ]
     const anchor = series.at(-1)
     expect(anchor).toBeDefined()
-    const rows = buildMilestoneRows(series, anchor ?? null, 100_000)
+    const rows = buildMilestoneRows(series, anchor ?? null, 100_000, SMALL_MILESTONES)
     const oneL = requireRow(rows, '₹1L')
     const fiveL = requireRow(rows, '₹5L')
     const tenL = requireRow(rows, '₹10L')
@@ -49,7 +64,7 @@ describe('buildMilestoneRows', () => {
       { date: '2024-12-01', netWorth: 500_000 },
     ]
     const anchor = { date: '2024-12-01', netWorth: 500_000 }
-    const rows = buildMilestoneRows(series, anchor, 50_000)
+    const rows = buildMilestoneRows(series, anchor, 50_000, SMALL_MILESTONES)
     const tenL = requireRow(rows, '₹10L')
     expect(tenL.status).toBe('upcoming')
     expect(tenL.date).not.toBeNull()
@@ -61,7 +76,7 @@ describe('buildMilestoneRows', () => {
 
   it('upcoming rows have null date when growth is non-positive', () => {
     const series = [{ date: '2024-01-01', netWorth: 500_000 }]
-    const rows = buildMilestoneRows(series, series[0], 0)
+    const rows = buildMilestoneRows(series, series[0], 0, SMALL_MILESTONES)
     const tenL = requireRow(rows, '₹10L')
     expect(tenL.status).toBe('upcoming')
     expect(tenL.date).toBeNull()
@@ -75,15 +90,36 @@ describe('buildMilestoneRows', () => {
     expect(values).toEqual([...values].sort((a, b) => a - b))
   })
 
+  it('keeps ALL achieved rows but caps upcoming to the window', () => {
+    // Anchor at ₹22L (like the real dashboard): many achieved (₹5/10/15/20L),
+    // and a long upcoming ladder that must be trimmed.
+    const series = [
+      { date: '2022-01-01', netWorth: 100_000 },
+      { date: '2026-01-01', netWorth: 2_200_000 },
+    ]
+    const anchor = { date: '2026-01-01', netWorth: 2_200_000 }
+    const rows = buildMilestoneRows(series, anchor, 113_000)
+    const achieved = rows.filter((r) => r.status === 'achieved')
+    const upcoming = rows.filter((r) => r.status === 'upcoming')
+    // ₹5L, ₹10L, ₹15L, ₹20L all crossed -> 4 achieved, all retained.
+    expect(achieved.map((r) => r.value)).toEqual([500_000, 1_000_000, 1_500_000, 2_000_000])
+    // Upcoming trimmed to the window (would otherwise run to ₹10Cr).
+    expect(upcoming).toHaveLength(DEFAULT_UPCOMING_WINDOW)
+    // First upcoming is the next ₹5L step above ₹22L -> ₹25L.
+    expect(upcoming[0].value).toBe(2_500_000)
+    // No absurd far-future row survives the window.
+    expect(rows.some((r) => r.value >= 100_000_000)).toBe(false)
+  })
+
   it('records first crossing only (not re-crossings)', () => {
     const series = [
-      { date: '2024-01-01', netWorth: 110_000 },
-      { date: '2024-02-01', netWorth: 90_000 },
-      { date: '2024-03-01', netWorth: 120_000 },
+      { date: '2024-01-01', netWorth: 610_000 },
+      { date: '2024-02-01', netWorth: 490_000 },
+      { date: '2024-03-01', netWorth: 620_000 },
     ]
     const rows = buildMilestoneRows(series, series[2], 0)
-    const oneL = requireRow(rows, '₹1L')
-    expect(oneL.date).toBe('2024-01-01')
+    const fiveL = requireRow(rows, '₹5L')
+    expect(fiveL.date).toBe('2024-01-01')
   })
 
   it('preserves milestones crossed before any view/earning-start cutoff', () => {
@@ -91,20 +127,20 @@ describe('buildMilestoneRows', () => {
     // slice) so historical crossings remain visible even after the user
     // sets an earning-start preference that would otherwise hide them.
     const fullHistory = [
-      { date: '2023-06-01', netWorth: 150_000 }, // crossed ₹1L in 2023
-      { date: '2023-12-01', netWorth: 400_000 },
-      { date: '2024-06-01', netWorth: 700_000 }, // crossed ₹5L in 2024
+      { date: '2023-06-01', netWorth: 550_000 }, // crossed ₹5L in 2023
+      { date: '2023-12-01', netWorth: 900_000 },
+      { date: '2024-06-01', netWorth: 1_100_000 }, // crossed ₹10L in 2024
     ]
-    const anchor = { date: '2024-06-01', netWorth: 700_000 }
+    const anchor = { date: '2024-06-01', netWorth: 1_100_000 }
     const rows = buildMilestoneRows(fullHistory, anchor, 50_000)
-
-    const oneL = requireRow(rows, '₹1L')
-    expect(oneL.status).toBe('achieved')
-    expect(oneL.date).toBe('2023-06-01')
 
     const fiveL = requireRow(rows, '₹5L')
     expect(fiveL.status).toBe('achieved')
-    expect(fiveL.date).toBe('2024-06-01')
+    expect(fiveL.date).toBe('2023-06-01')
+
+    const tenL = requireRow(rows, '₹10L')
+    expect(tenL.status).toBe('achieved')
+    expect(tenL.date).toBe('2024-06-01')
   })
 
   describe('stableSince', () => {
@@ -115,7 +151,7 @@ describe('buildMilestoneRows', () => {
         { date: '2024-03-01', netWorth: 150_000 }, // still above
         { date: '2024-04-01', netWorth: 200_000 }, // still above
       ]
-      const rows = buildMilestoneRows(series, series[3], 0)
+      const rows = buildMilestoneRows(series, series[3], 0, SMALL_MILESTONES)
       const oneL = requireRow(rows, '₹1L')
       expect(oneL.stableSince).toBe('2024-02-01')
       expect(oneL.stableSince).toBe(oneL.date)
@@ -129,7 +165,7 @@ describe('buildMilestoneRows', () => {
         { date: '2024-04-01', netWorth: 130_000 }, // recovered
         { date: '2024-05-01', netWorth: 140_000 }, // stays above
       ]
-      const rows = buildMilestoneRows(series, series[4], 0)
+      const rows = buildMilestoneRows(series, series[4], 0, SMALL_MILESTONES)
       const oneL = requireRow(rows, '₹1L')
       expect(oneL.date).toBe('2024-01-01')
       expect(oneL.stableSince).toBe('2024-04-01')
@@ -140,7 +176,7 @@ describe('buildMilestoneRows', () => {
         { date: '2024-01-01', netWorth: 110_000 }, // crossed
         { date: '2024-02-01', netWorth: 90_000 }, // fell back below
       ]
-      const rows = buildMilestoneRows(series, series[1], 0)
+      const rows = buildMilestoneRows(series, series[1], 0, SMALL_MILESTONES)
       const oneL = requireRow(rows, '₹1L')
       expect(oneL.status).toBe('achieved') // was reached once
       expect(oneL.date).toBe('2024-01-01')
@@ -153,7 +189,7 @@ describe('buildMilestoneRows', () => {
         { date: '2024-12-01', netWorth: 500_000 },
       ]
       const anchor = { date: '2024-12-01', netWorth: 500_000 }
-      const rows = buildMilestoneRows(series, anchor, 50_000)
+      const rows = buildMilestoneRows(series, anchor, 50_000, SMALL_MILESTONES)
       const tenL = requireRow(rows, '₹10L')
       expect(tenL.status).toBe('upcoming')
       expect(tenL.stableSince).toBeNull()
@@ -168,10 +204,35 @@ describe('buildMilestoneRows', () => {
         { date: '2024-05-01', netWorth: 120_000 }, // recovered again
         { date: '2024-06-01', netWorth: 140_000 }, // holds
       ]
-      const rows = buildMilestoneRows(series, series[5], 0)
+      const rows = buildMilestoneRows(series, series[5], 0, SMALL_MILESTONES)
       const oneL = requireRow(rows, '₹1L')
       expect(oneL.stableSince).toBe('2024-05-01')
     })
+  })
+})
+
+describe('formatMilestoneLabel', () => {
+  it('formats lakhs and crores with clean rounding', () => {
+    expect(formatMilestoneLabel(500_000)).toBe('₹5L')
+    expect(formatMilestoneLabel(2_500_000)).toBe('₹25L')
+    expect(formatMilestoneLabel(10_000_000)).toBe('₹1Cr')
+    expect(formatMilestoneLabel(12_500_000)).toBe('₹1.3Cr')
+    expect(formatMilestoneLabel(100_000_000)).toBe('₹10Cr')
+  })
+})
+
+describe('DEFAULT_MILESTONES ladder', () => {
+  it('steps by ₹5L in the lakhs range, widening higher up', () => {
+    const values = DEFAULT_MILESTONES.map((m) => m.value)
+    // Fine steps below ₹1Cr.
+    expect(values).toContain(500_000)
+    expect(values).toContain(2_500_000) // ₹25L
+    expect(values).toContain(9_500_000) // ₹95L
+    // Coarser above.
+    expect(values).toContain(10_000_000) // ₹1Cr
+    expect(values).toContain(100_000_000) // ₹10Cr caps the ladder
+    // Strictly ascending, no dupes.
+    expect(values).toEqual([...new Set(values)].sort((a, b) => a - b))
   })
 })
 

--- a/frontend/src/pages/net-worth/components/MilestonesTable.tsx
+++ b/frontend/src/pages/net-worth/components/MilestonesTable.tsx
@@ -153,7 +153,7 @@ export default function MilestonesTable({
       <EmptyState
         icon={TrendingUp}
         title="No milestones yet"
-        description="Your first milestone (₹1L net worth) will appear here once you reach it."
+        description="Your first milestone (₹5L net worth) will appear here once you reach it."
         variant="compact"
       />
     )
@@ -178,16 +178,15 @@ export default function MilestonesTable({
           )}
         </span>
         <span className="text-muted-foreground">
-          Stable:{' '}
-          <span className="text-app-green font-semibold">
-            {stableCount} / {rows.length}
-          </span>
+          Reached:{' '}
+          <span className="text-foreground font-semibold">{reachedCount}</span>
         </span>
         <span className="text-muted-foreground">
-          Reached:{' '}
-          <span className="text-foreground font-semibold">
-            {reachedCount} / {rows.length}
-          </span>
+          Stable:{' '}
+          <span className="text-app-green font-semibold">{stableCount}</span>
+          {reachedCount > 0 && (
+            <span className="text-xs text-text-tertiary"> of {reachedCount} reached</span>
+          )}
         </span>
       </div>
 

--- a/frontend/src/pages/net-worth/netWorthProjection.ts
+++ b/frontend/src/pages/net-worth/netWorthProjection.ts
@@ -40,21 +40,45 @@ export interface MilestoneRow extends Milestone {
   stableSince: string | null
 }
 
+/** Format a rupee amount as a short Indian milestone label: ₹5L, ₹1.5Cr, ₹10Cr. */
+export function formatMilestoneLabel(value: number): string {
+  if (value >= 10_000_000) {
+    const cr = value / 10_000_000
+    return `₹${Number.isInteger(cr) ? cr : Number(cr.toFixed(1))}Cr`
+  }
+  const lakh = value / 100_000
+  return `₹${Number.isInteger(lakh) ? lakh : Number(lakh.toFixed(1))}L`
+}
+
 /**
- * Default milestones for an Indian-rupee net-worth context.
- * Hand-picked round numbers; could be preference-driven later.
+ * Tiered milestone thresholds for an Indian-rupee net-worth context.
+ *
+ * Step size widens as the values grow so the near-term list stays granular
+ * (where a saver actually crosses thresholds) without exploding into hundreds
+ * of rows at the top:
+ *   - up to ₹1Cr   : every ₹5L   (₹5L, ₹10L, ... ₹95L, ₹1Cr)
+ *   - ₹1Cr - ₹5Cr  : every ₹25L
+ *   - ₹5Cr and up  : every ₹1Cr
+ *
+ * The full ladder runs to ₹10Cr; callers window it (achieved history + the
+ * next few upcoming) so the far-future rows never render as noise.
  */
-export const DEFAULT_MILESTONES: readonly Milestone[] = [
-  { value: 100_000, label: '₹1L' },
-  { value: 500_000, label: '₹5L' },
-  { value: 1_000_000, label: '₹10L' },
-  { value: 2_500_000, label: '₹25L' },
-  { value: 5_000_000, label: '₹50L' },
-  { value: 10_000_000, label: '₹1Cr' },
-  { value: 25_000_000, label: '₹2.5Cr' },
-  { value: 50_000_000, label: '₹5Cr' },
-  { value: 100_000_000, label: '₹10Cr' },
-] as const
+function generateMilestones(): Milestone[] {
+  const values: number[] = []
+  for (let v = 500_000; v < 10_000_000; v += 500_000) values.push(v) // ₹5L step to <₹1Cr
+  for (let v = 10_000_000; v < 50_000_000; v += 2_500_000) values.push(v) // ₹25L step ₹1Cr-₹5Cr
+  for (let v = 50_000_000; v <= 100_000_000; v += 10_000_000) values.push(v) // ₹1Cr step to ₹10Cr
+  return values.map((value) => ({ value, label: formatMilestoneLabel(value) }))
+}
+
+export const DEFAULT_MILESTONES: readonly Milestone[] = generateMilestones()
+
+/**
+ * Default number of upcoming milestones to surface. Achieved milestones are
+ * always kept (they're history); only the FUTURE list is capped so the table
+ * doesn't show a "₹10Cr in 72 years" row.
+ */
+export const DEFAULT_UPCOMING_WINDOW = 6
 
 /**
  * Compute average monthly net-worth change over the last ``lookbackMonths``.
@@ -313,25 +337,32 @@ function buildUpcomingRow(
  * Build a SINGLE unified list of milestones with status + date + distance,
  * consistent with the anchor + growth rate used by the chart overlay.
  *
- * - achieved: rows whose value was ever crossed by the series.
+ * - achieved: rows whose value was ever crossed by the series (ALL kept -- they
+ *   are history).
  * - upcoming: rows whose value is above the anchor's net worth. ETA is
- *   anchor.date + (value - anchor.netWorth) / monthlyGrowth months.
- *   Omitted from the upcoming set when growth <= 0.
+ *   anchor.date + (value - anchor.netWorth) / monthlyGrowth months. Omitted
+ *   from the upcoming set when growth <= 0. Capped to ``upcomingWindow`` so the
+ *   table shows the next few reachable targets, not a "₹10Cr in 72 years" row.
  */
 export function buildMilestoneRows(
   series: readonly NetWorthPoint[],
   anchor: NetWorthPoint | null,
   monthlyGrowth: number,
   milestones: readonly Milestone[] = DEFAULT_MILESTONES,
+  upcomingWindow: number = DEFAULT_UPCOMING_WINDOW,
 ): MilestoneRow[] {
   if (series.length === 0 || anchor === null) {
-    return milestones.map((m) => ({
-      ...m,
-      status: 'upcoming',
-      date: null,
-      distance: null,
-      stableSince: null,
-    }))
+    // No history yet: show the first ``upcomingWindow`` targets as a preview.
+    return [...milestones]
+      .sort((a, b) => a.value - b.value)
+      .slice(0, Math.max(0, upcomingWindow))
+      .map((m) => ({
+        ...m,
+        status: 'upcoming',
+        date: null,
+        distance: null,
+        stableSince: null,
+      }))
   }
 
   const achievedDate = scanAchievements(series, milestones)
@@ -347,7 +378,7 @@ export function buildMilestoneRows(
       )
       return {
         ...m,
-        status: 'achieved',
+        status: 'achieved' as const,
         date: dateStr,
         distance: daysFromStart,
         stableSince: findStableSince(sorted, m.value, dateStr),
@@ -356,6 +387,14 @@ export function buildMilestoneRows(
     return buildUpcomingRow(m, anchor, monthlyGrowth)
   })
 
-  // Sort by value so the table reads low-to-high regardless of status.
-  return rows.sort((a, b) => a.value - b.value)
+  // Keep ALL achieved rows (history); cap the upcoming rows to the nearest
+  // ``upcomingWindow`` so far-future thresholds don't clutter the table.
+  const achieved = rows.filter((r) => r.status === 'achieved')
+  const upcoming = rows
+    .filter((r) => r.status === 'upcoming')
+    .sort((a, b) => a.value - b.value)
+    .slice(0, Math.max(0, upcomingWindow))
+
+  // Sort the combined set by value so the table reads low-to-high.
+  return [...achieved, ...upcoming].sort((a, b) => a.value - b.value)
 }


### PR DESCRIPTION
## What
Replaces the fixed 9-rung net-worth milestone ladder with a tiered, generated ladder plus a windowed view of upcoming targets.

## Why
The old fixed list (₹1L, ₹5L, ₹10L, ₹25L, ₹50L, ₹1Cr, ₹2.5Cr, ₹5Cr, ₹10Cr) had two problems, both visible on real data (~₹22-27L net worth):
- **Lumpy near-term gaps** -- next target after ₹22L was ₹25L (weeks away), then a 2-year jump straight to ₹50L. Nothing in the range where the user is actually moving.
- **Absurd far-future rows** -- "₹10Cr, expected May 2098, in 71y 10mo" and "₹5Cr in 35y" from a linear book-value extrapolation. Pure noise.

## How
- **Tiered generator**: ₹5L steps up to ₹1Cr, ₹25L steps ₹1Cr-₹5Cr, ₹1Cr steps to ₹10Cr -- fine granularity where thresholds are actually crossed, coarse where they aren't.
- **Windowing**: keep ALL achieved milestones (they're history), but cap upcoming to the next `DEFAULT_UPCOMING_WINDOW` (6). No more 35y/72y rows.
- `formatMilestoneLabel(value)` derives ₹5L / ₹1.5Cr / ₹10Cr labels from the numbers.
- Header counts: "Reached: N" / "Stable: N of N reached" (the old `/9` denominator was meaningless once the ladder became open-ended + windowed).
- Empty-series case previews the first 6 targets instead of the whole ladder.

## Verification
- Verified live in demo mode (see below): user at ₹27.35L shows ₹5L-₹25L as achieved/stable, then ₹30L-₹55L upcoming in ₹5L steps (ETAs 2mo-1y11mo), zero far-future rows.
- `tsc -b`, `eslint .` clean; `netWorthProjection.test.ts` 32 pass (added: windowing keeps-all-achieved/caps-upcoming, formatMilestoneLabel, ladder-shape).

## Reviewer notes
- Builds on PR #207 (calc-correctness wave), which is already merged to main -- this branch is rebased on that tip, so it's a clean single commit.
- `buildMilestoneRows` gains an optional `upcomingWindow` param (defaults to 6); existing callers are unaffected.