### PR TITLE
feat(net-worth): seed milestone ladder with early rungs (50k, 1L, 2L)

### DIFF
--- a/frontend/src/pages/net-worth/__tests__/netWorthProjection.test.ts
+++ b/frontend/src/pages/net-worth/__tests__/netWorthProjection.test.ts
@@ -34,9 +34,10 @@ describe('buildMilestoneRows', () => {
     // No history -> show the first N targets, not the whole ladder.
     expect(rows).toHaveLength(DEFAULT_UPCOMING_WINDOW)
     expect(rows.every((r) => r.status === 'upcoming' && r.date === null)).toBe(true)
-    // Ladder starts at ₹5L and steps by ₹5L in the lakhs range.
-    expect(rows[0].value).toBe(500_000)
-    expect(rows[1].value).toBe(1_000_000)
+    // Ladder starts with early-saver rungs: ₹50k, ₹1L, ₹2L.
+    expect(rows[0].value).toBe(50_000)
+    expect(rows[1].value).toBe(100_000)
+    expect(rows[2].value).toBe(200_000)
   })
 
   it('labels crossings as achieved with dates', () => {
@@ -91,8 +92,9 @@ describe('buildMilestoneRows', () => {
   })
 
   it('keeps ALL achieved rows but caps upcoming to the window', () => {
-    // Anchor at ₹22L (like the real dashboard): many achieved (₹5/10/15/20L),
-    // and a long upcoming ladder that must be trimmed.
+    // Anchor at ₹22L (like the real dashboard): the ₹1L opening point already
+    // clears the ₹50k/₹1L early rungs, and ₹2L/₹5L/₹10L/₹15L/₹20L are crossed
+    // on the way to ₹22L -- all retained -- with a long upcoming ladder trimmed.
     const series = [
       { date: '2022-01-01', netWorth: 100_000 },
       { date: '2026-01-01', netWorth: 2_200_000 },
@@ -101,8 +103,10 @@ describe('buildMilestoneRows', () => {
     const rows = buildMilestoneRows(series, anchor, 113_000)
     const achieved = rows.filter((r) => r.status === 'achieved')
     const upcoming = rows.filter((r) => r.status === 'upcoming')
-    // ₹5L, ₹10L, ₹15L, ₹20L all crossed -> 4 achieved, all retained.
-    expect(achieved.map((r) => r.value)).toEqual([500_000, 1_000_000, 1_500_000, 2_000_000])
+    // Early rungs + ₹5L steps up to ₹20L, all crossed and retained.
+    expect(achieved.map((r) => r.value)).toEqual([
+      50_000, 100_000, 200_000, 500_000, 1_000_000, 1_500_000, 2_000_000,
+    ])
     // Upcoming trimmed to the window (would otherwise run to ₹10Cr).
     expect(upcoming).toHaveLength(DEFAULT_UPCOMING_WINDOW)
     // First upcoming is the next ₹5L step above ₹22L -> ₹25L.
@@ -212,7 +216,10 @@ describe('buildMilestoneRows', () => {
 })
 
 describe('formatMilestoneLabel', () => {
-  it('formats lakhs and crores with clean rounding', () => {
+  it('formats thousands, lakhs and crores with clean rounding', () => {
+    expect(formatMilestoneLabel(50_000)).toBe('₹50k')
+    expect(formatMilestoneLabel(100_000)).toBe('₹1L')
+    expect(formatMilestoneLabel(200_000)).toBe('₹2L')
     expect(formatMilestoneLabel(500_000)).toBe('₹5L')
     expect(formatMilestoneLabel(2_500_000)).toBe('₹25L')
     expect(formatMilestoneLabel(10_000_000)).toBe('₹1Cr')
@@ -222,8 +229,10 @@ describe('formatMilestoneLabel', () => {
 })
 
 describe('DEFAULT_MILESTONES ladder', () => {
-  it('steps by ₹5L in the lakhs range, widening higher up', () => {
+  it('opens with early rungs, steps by ₹5L in the lakhs range, widens higher up', () => {
     const values = DEFAULT_MILESTONES.map((m) => m.value)
+    // Early-saver rungs.
+    expect(values.slice(0, 3)).toEqual([50_000, 100_000, 200_000])
     // Fine steps below ₹1Cr.
     expect(values).toContain(500_000)
     expect(values).toContain(2_500_000) // ₹25L
@@ -231,6 +240,9 @@ describe('DEFAULT_MILESTONES ladder', () => {
     // Coarser above.
     expect(values).toContain(10_000_000) // ₹1Cr
     expect(values).toContain(100_000_000) // ₹10Cr caps the ladder
+    // No ₹3L/₹4L gap-fillers -- jumps straight from ₹2L to ₹5L.
+    expect(values).not.toContain(300_000)
+    expect(values).not.toContain(400_000)
     // Strictly ascending, no dupes.
     expect(values).toEqual([...new Set(values)].sort((a, b) => a - b))
   })

--- a/frontend/src/pages/net-worth/components/MilestonesTable.tsx
+++ b/frontend/src/pages/net-worth/components/MilestonesTable.tsx
@@ -153,7 +153,7 @@ export default function MilestonesTable({
       <EmptyState
         icon={TrendingUp}
         title="No milestones yet"
-        description="Your first milestone (₹5L net worth) will appear here once you reach it."
+        description="Your first milestone (₹50k net worth) will appear here once you reach it."
         variant="compact"
       />
     )

--- a/frontend/src/pages/net-worth/netWorthProjection.ts
+++ b/frontend/src/pages/net-worth/netWorthProjection.ts
@@ -40,11 +40,15 @@ export interface MilestoneRow extends Milestone {
   stableSince: string | null
 }
 
-/** Format a rupee amount as a short Indian milestone label: ₹5L, ₹1.5Cr, ₹10Cr. */
+/** Format a rupee amount as a short Indian milestone label: ₹50k, ₹5L, ₹1.5Cr. */
 export function formatMilestoneLabel(value: number): string {
   if (value >= 10_000_000) {
     const cr = value / 10_000_000
     return `₹${Number.isInteger(cr) ? cr : Number(cr.toFixed(1))}Cr`
+  }
+  // Below ₹1L, thousands read more naturally than a fractional lakh (₹50k, not ₹0.5L).
+  if (value < 100_000) {
+    return `₹${Math.round(value / 1_000)}k`
   }
   const lakh = value / 100_000
   return `₹${Number.isInteger(lakh) ? lakh : Number(lakh.toFixed(1))}L`
@@ -53,9 +57,10 @@ export function formatMilestoneLabel(value: number): string {
 /**
  * Tiered milestone thresholds for an Indian-rupee net-worth context.
  *
- * Step size widens as the values grow so the near-term list stays granular
- * (where a saver actually crosses thresholds) without exploding into hundreds
- * of rows at the top:
+ * Early rungs are close together so a new saver sees frequent wins, then the
+ * step widens as values grow -- granular where thresholds are actually crossed,
+ * without exploding into hundreds of rows at the top:
+ *   - first rungs  : ₹50k, ₹1L, ₹2L (early-saver wins)
  *   - up to ₹1Cr   : every ₹5L   (₹5L, ₹10L, ... ₹95L, ₹1Cr)
  *   - ₹1Cr - ₹5Cr  : every ₹25L
  *   - ₹5Cr and up  : every ₹1Cr
@@ -64,7 +69,7 @@ export function formatMilestoneLabel(value: number): string {
  * next few upcoming) so the far-future rows never render as noise.
  */
 function generateMilestones(): Milestone[] {
-  const values: number[] = []
+  const values: number[] = [50_000, 100_000, 200_000] // early-saver rungs
   for (let v = 500_000; v < 10_000_000; v += 500_000) values.push(v) // ₹5L step to <₹1Cr
   for (let v = 10_000_000; v < 50_000_000; v += 2_500_000) values.push(v) // ₹25L step ₹1Cr-₹5Cr
   for (let v = 50_000_000; v <= 100_000_000; v += 10_000_000) values.push(v) // ₹1Cr step to ₹10Cr


### PR DESCRIPTION
## What
Prepends ₹50k, ₹1L, ₹2L to the net-worth milestone ladder, before the existing ₹5L-multiples progression.

## Why
The tiered ladder (PR #208) started at ₹5L. A new saver would see no milestone at all until ₹5L net worth -- a long, unrewarding wait. Early rungs at ₹50k / ₹1L / ₹2L give frequent early wins, then the ladder jumps straight to ₹5L (no ₹3L/₹4L clutter) and continues in ₹5L steps as before.

Full ladder: **₹50k, ₹1L, ₹2L, ₹5L, ₹10L ... ₹1Cr** (₹5L steps), then ₹25L steps to ₹5Cr, ₹1Cr steps to ₹10Cr. Windowing (achieved history + next 6 upcoming) is unchanged.

## How
- `generateMilestones()` seeds `[50_000, 100_000, 200_000]` before the ₹5L loop.
- `formatMilestoneLabel` now renders sub-₹1L values as thousands (**₹50k**, not "₹0.5L").
- Empty-state copy updated to "first milestone (₹50k ...)".

## Verification
- Verified live in demo mode (user at ₹27.35L): shows ₹50k / ₹1L / ₹2L / ₹5L ... ₹25L as stable, ₹30L+ upcoming. Labels render correctly (₹50k as thousands).
- `netWorthProjection.test.ts` 32 pass (added ₹50k label case, early-rung ladder-shape assertion, updated the ₹22L-anchor achieved set); `tsc -b` + `eslint` clean.

## Reviewer notes
- Branch is cut from current main (post-#208), single commit.
- No signature change to `buildMilestoneRows` -- purely a ladder-content + label-format tweak.