### PR TITLE
perf+fix: algorithm-fit wave -- partial indexes, robust detectors, solver fallbacks

### DIFF
--- a/backend/src/ledger_sync/core/analytics/anomalies.py
+++ b/backend/src/ledger_sync/core/analytics/anomalies.py
@@ -11,16 +11,20 @@ its own modified-Z score below the flagging cutoff.
 
 - **High-expense-month detection**: Iglewicz-Hoaglin modified Z-score
   ``|0.6745 * (x - median) / MAD|`` with configurable cutoff (default 3.5,
-  the NIST-recommended outlier boundary). When MAD collapses to zero
-  (>=50% of months are identical, e.g. all-zero), fall back to Tukey's
-  upper IQR fence (Q3 + 1.5 * IQR).
+  the NIST-recommended outlier boundary), computed against a ROLLING
+  trailing-12-month baseline (excluding the month under test). An all-time
+  baseline on a non-stationary spend series (income growth, lifestyle
+  drift) made every recent month look anomalous versus years-old medians.
+  When the window's MAD collapses to zero (identical months), fall back to
+  Tukey's upper IQR fence (Q3 + 1.5 * IQR) over the same window.
 
-- **Large-transaction detection**: 12-month rolling per-category median.
-  Was previously comparing against the all-time category average, so a
-  legitimate big purchase 2 years ago poisoned the baseline forever --
-  new normal-size transactions looked small and genuinely large ones got
-  flagged less severely. Rolling window + median is order-of-magnitude
-  more robust.
+- **Large-transaction detection**: 12-month rolling per-category median,
+  gated by (a) a per-user materiality floor (fraction of median monthly
+  expense) and (b) a log-space modified-Z outlier test against the
+  category's own amount distribution. The bare ratio>=3 rule flagged
+  14.4% of all expenses on real data because right-skewed spend
+  categories make "3x the median" trivially reachable; the gates cut
+  that to ~2% while keeping genuine outliers.
 
 ## Threshold preservation across the algorithm swap
 
@@ -41,6 +45,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
+from math import log
 from statistics import median, quantiles
 from typing import Any
 
@@ -83,6 +88,19 @@ _LARGE_TXN_MIN_HISTORY = 5
 _LARGE_TXN_HIGH_RATIO = 5.0
 _LARGE_TXN_FLAG_RATIO = 3.0
 
+# Materiality floor for large-transaction flags, as a fraction of the user's
+# median monthly expense. A 3x-of-median chai in a tiny category is not an
+# anomaly worth surfacing; real-data measurement showed ratio>=3 alone flagged
+# 14.4% of ALL expenses, mostly sub-trivial amounts.
+_LARGE_TXN_MATERIALITY_FRACTION = 0.01
+
+# Rolling month window for the high-expense-month baseline.
+_MONTH_BASELINE_WINDOW = 12
+
+# Minimum months of history before a month can be judged (matches
+# _LARGE_TXN_MIN_HISTORY so both detectors share the same warmup notion).
+_MONTH_BASELINE_MIN_HISTORY = 5
+
 
 class AnomaliesMixin(AnalyticsEngineBase):
     """Mixin: anomaly detection + monthly budget tracking."""
@@ -99,6 +117,26 @@ class AnomaliesMixin(AnalyticsEngineBase):
         self._detect_high_expense_months(anomalies_detected, z_cutoff)
         self._detect_large_transactions(anomalies_detected)
 
+        # Suppress findings the user already reviewed/dismissed BEFORE the cap,
+        # so a dismissed anomaly neither resurrects as a fresh unreviewed row
+        # nor consumes cap slots. The `if r.period_key` / `if r.transaction_id`
+        # guards are load-bearing: both detectors emit HIGH_EXPENSE, so without
+        # them one reviewed txn anomaly (period_key=None) would suppress every
+        # month anomaly via (HIGH_EXPENSE, None) and vice versa.
+        reviewed_rows = (
+            self.db.query(Anomaly.anomaly_type, Anomaly.period_key, Anomaly.transaction_id)
+            .filter(Anomaly.user_id == self.user_id, Anomaly.is_reviewed.is_(True))
+            .all()
+        )
+        reviewed_periods = {(r.anomaly_type, r.period_key) for r in reviewed_rows if r.period_key}
+        reviewed_txn_ids = {r.transaction_id for r in reviewed_rows if r.transaction_id}
+        anomalies_detected = [
+            a
+            for a in anomalies_detected
+            if (a["type"], a.get("period_key")) not in reviewed_periods
+            and a.get("transaction_id") not in reviewed_txn_ids
+        ]
+
         # Delete old unreviewed anomalies for this user and insert new. Reviewed
         # anomalies are preserved so users don't have to re-dismiss the same
         # finding on every refresh.
@@ -107,13 +145,19 @@ class AnomaliesMixin(AnalyticsEngineBase):
             del_stmt = del_stmt.where(Anomaly.user_id == self.user_id)
         self.db.execute(del_stmt)
 
-        # Sort by deviation_pct desc BEFORE the 50-row cap so the most severe
-        # anomalies survive. (Cross-type ranking is imperfect since deviation_pct
-        # has different natural scales for month totals vs single txns; the
-        # comment thread notes this and it's on the follow-up list.)
-        anomalies_detected.sort(key=lambda a: a.get("deviation_pct") or 0, reverse=True)
+        # Cap per shape, not across shapes: month rows (period_key) and single-
+        # transaction rows (transaction_id) have different natural deviation_pct
+        # scales, so a global sort let hundreds of 300%-deviation txn flags
+        # evict nearly every month anomaly. Reserve up to 25 slots for months,
+        # give the remainder to transactions.
+        month_rows = [a for a in anomalies_detected if a.get("period_key")]
+        txn_rows = [a for a in anomalies_detected if not a.get("period_key")]
+        month_rows.sort(key=lambda a: a.get("deviation_pct") or 0, reverse=True)
+        txn_rows.sort(key=lambda a: a.get("deviation_pct") or 0, reverse=True)
+        kept_months = month_rows[:25]
+        keep = kept_months + txn_rows[: 50 - len(kept_months)]
 
-        for anomaly_data in anomalies_detected[:50]:  # Limit to 50 anomalies
+        for anomaly_data in keep:
             anomaly = Anomaly(
                 user_id=self.user_id,
                 anomaly_type=anomaly_data["type"],
@@ -170,25 +214,29 @@ class AnomaliesMixin(AnalyticsEngineBase):
             .filter(Transaction.type == TransactionType.EXPENSE)
         )
         monthly_query = apply_excluded_accounts_filter(monthly_query, self.excluded_accounts)
-        monthly_expenses = monthly_query.group_by(period_col).all()
+        monthly_expenses = sorted(monthly_query.group_by(period_col).all(), key=lambda m: m.period)
 
         if len(monthly_expenses) <= 3:  # noqa: PLR2004 -- documented warmup
             return
 
-        values = [float(m.total) for m in monthly_expenses]
-        med = median(values)
-        mad = self._mad(values, med)
+        # Rolling baseline: judge each month against the trailing 12 months
+        # only. Spending series are non-stationary (income growth, lifestyle
+        # drift), so an all-time median made every recent month "anomalous"
+        # versus years-old spending levels.
+        for i, month in enumerate(monthly_expenses):
+            window = [
+                float(m.total) for m in monthly_expenses[max(0, i - _MONTH_BASELINE_WINDOW) : i]
+            ]
+            if len(window) < _MONTH_BASELINE_MIN_HISTORY:
+                continue  # warmup: not enough trailing history
 
-        if med <= 0:
-            # All-zero (or worse) baseline -- nothing meaningful to flag.
-            return
+            med = median(window)
+            if med <= 0:
+                continue
+            mad = self._mad(window, med)
+            use_iqr = mad == 0
+            iqr_fence = self._tukey_upper_fence(window) if use_iqr else None
 
-        # Preferred path: modified Z-score. Falls back to IQR fence when MAD
-        # collapses to zero (many identical months).
-        use_iqr = mad == 0
-        iqr_fence = self._tukey_upper_fence(values) if use_iqr else None
-
-        for month in monthly_expenses:
             total = float(month.total)
             severity = self._grade_month(total, med, mad, z_cutoff, use_iqr, iqr_fence)
             if severity is None:
@@ -200,7 +248,7 @@ class AnomaliesMixin(AnalyticsEngineBase):
                     "severity": severity,
                     "description": (
                         f"Unusually high expenses in {month.period}: "
-                        f"{sym}{total:,.0f} vs median {sym}{med:,.0f}"
+                        f"{sym}{total:,.0f} vs trailing median {sym}{med:,.0f}"
                     ),
                     "period_key": month.period,
                     "expected_value": Decimal(str(med)),
@@ -248,6 +296,19 @@ class AnomaliesMixin(AnalyticsEngineBase):
             .all()
         )
 
+        # Materiality floor: a 3x-of-median blip in a tiny category (a pricier
+        # chai) is not worth a user's attention. Derived per user from their
+        # own median monthly expense -- no hardcoded currency constants.
+        monthly_totals: dict[str, float] = {}
+        for t in expense_txns:
+            key = t.date.strftime("%Y-%m")
+            monthly_totals[key] = monthly_totals.get(key, 0.0) + float(t.amount)
+        materiality_floor = (
+            _LARGE_TXN_MATERIALITY_FRACTION * median(monthly_totals.values())
+            if monthly_totals
+            else 0.0
+        )
+
         # Group amounts by category, retaining chronological order so the
         # rolling window can prune old entries with an O(1) index cursor.
         # amount_history[cat] = list of (date, amount) sorted ascending.
@@ -256,6 +317,10 @@ class AnomaliesMixin(AnalyticsEngineBase):
             history.setdefault(t.category, []).append((t.date, float(t.amount)))
 
         for txn in expense_txns:
+            amount = float(txn.amount)
+            if amount < materiality_floor:
+                continue
+
             cat_history = history.get(txn.category, [])
             # Rolling window: keep amounts strictly older than the txn under
             # test AND within the last 12 months. Leave-one-out prevents the
@@ -269,9 +334,25 @@ class AnomaliesMixin(AnalyticsEngineBase):
             if baseline <= 0:
                 continue
 
-            ratio = float(txn.amount) / baseline
+            ratio = amount / baseline
             if ratio < _LARGE_TXN_FLAG_RATIO:
                 continue
+
+            # Dispersion gate in log space: spend distributions are right-
+            # skewed, so "3x the median" is trivially reachable in high-
+            # variance categories (shopping ranges 100..15,000 routinely).
+            # Require the txn to be a genuine outlier of ITS OWN category's
+            # log-amount distribution. When log-MAD collapses (near-constant
+            # window), keep the ratio-based flag -- mirroring the module's
+            # MAD-collapse fallback convention.
+            log_window = [log(a) for a in window if a > 0]
+            if log_window:
+                log_med = median(log_window)
+                log_mad = self._mad(log_window, log_med)
+                if log_mad > 0:
+                    log_mz = _MZ_CONSTANT * (log(amount) - log_med) / log_mad
+                    if log_mz <= _DEFAULT_MODIFIED_Z_CUTOFF:
+                        continue
 
             severity = "high" if ratio >= _LARGE_TXN_HIGH_RATIO else "medium"
             anomalies.append(
@@ -320,6 +401,20 @@ class AnomaliesMixin(AnalyticsEngineBase):
         current_spending = spending_query.group_by(Transaction.category).all()
         spending_map = {c.category: float(c.total) for c in current_spending}
 
+        # Don't resurrect a budget-exceeded anomaly the user already reviewed
+        # for this period (same suppression rule as _detect_anomalies).
+        reviewed_budget_periods = {
+            r.period_key
+            for r in self.db.query(Anomaly.period_key)
+            .filter(
+                Anomaly.user_id == user_id,
+                Anomaly.is_reviewed.is_(True),
+                Anomaly.anomaly_type == AnomalyType.BUDGET_EXCEEDED,
+            )
+            .all()
+            if r.period_key
+        }
+
         count = 0
         for budget in budgets:
             spent = Decimal(str(spending_map.get(budget.category, 0)))
@@ -331,7 +426,7 @@ class AnomaliesMixin(AnalyticsEngineBase):
             budget.updated_at = now
 
             # Check for budget exceeded anomaly
-            if budget.current_month_pct > 100:  # noqa: PLR2004
+            if budget.current_month_pct > 100 and current_period not in reviewed_budget_periods:  # noqa: PLR2004
                 anomaly = Anomaly(
                     user_id=self.user_id,
                     anomaly_type=AnomalyType.BUDGET_EXCEEDED,

--- a/backend/src/ledger_sync/core/analytics/recurring.py
+++ b/backend/src/ledger_sync/core/analytics/recurring.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import math
 from datetime import UTC, datetime
-from statistics import mean, stdev
+from statistics import median
 
 from sqlalchemy import delete
 
@@ -32,13 +31,14 @@ from ledger_sync.db.models import (
 class RecurringMixin(AnalyticsEngineBase):
     """Mixin: recurring-pattern detection and persistence."""
 
-    # Frequency bands: (min_days, frequency, confidence_penalty_per_std).
+    # Frequency bands: (min_days, frequency, confidence_penalty_per_day).
     # Each band starts at min_days and runs up to (but not including) the
-    # next band's min_days, so float averages between integer thresholds
-    # (e.g. avg_diff = 10.5) resolve cleanly instead of falling through
-    # the gap. The final band has an effective upper bound of 400 days
+    # next band's min_days, so float medians between integer thresholds
+    # (e.g. med = 10.5) resolve cleanly instead of falling through the
+    # gap. The final band has an effective upper bound of 400 days
     # enforced below. Penalty scales with expected cadence -- wider
-    # cycles tolerate more jitter.
+    # cycles tolerate more jitter -- and is applied to the median folded
+    # day residual in ``_folded_confidence``.
     _FREQ_BANDS: list[tuple[float, RecurrenceFrequency, float]] = [
         (4, RecurrenceFrequency.WEEKLY, 8),
         (11, RecurrenceFrequency.BIWEEKLY, 5),
@@ -54,7 +54,16 @@ class RecurringMixin(AnalyticsEngineBase):
     _FREQ_MAX_DAYS: float = 400
 
     def _load_confirmed_recurring(self) -> dict[str, RecurringTransaction]:
-        """Load user-confirmed recurring patterns keyed by lowercase name."""
+        """Load user-confirmed recurring patterns keyed by group label.
+
+        Detection groups transactions by ``normalize_note(txn.note)`` (falling
+        back to the lowercased category/subcategory), but ``pattern_name``
+        stores the raw most-recent note (e.g. "Rent Mar 2026"). Keying each
+        confirmed record by BOTH the normalized name and the plain lowercase
+        name lets the refresh find the confirmed row under the stable group
+        label ("rent") instead of creating an unconfirmed duplicate while the
+        confirmed row's stats freeze.
+        """
         if self.user_id is None:
             return {}
         confirmed = (
@@ -65,7 +74,13 @@ class RecurringMixin(AnalyticsEngineBase):
             )
             .all()
         )
-        return {c.pattern_name.lower(): c for c in confirmed}
+        keyed: dict[str, RecurringTransaction] = {}
+        for c in confirmed:
+            normalized = _normalize_note(c.pattern_name)
+            if normalized:
+                keyed[normalized] = c
+            keyed[c.pattern_name.lower()] = c
+        return keyed
 
     def _detect_recurring_transactions(
         self,
@@ -110,8 +125,14 @@ class RecurringMixin(AnalyticsEngineBase):
             if not frequency or confidence < min_conf:
                 continue
 
-            avg_amount = mean(amounts)
-            amount_variance = stdev(amounts) if len(amounts) > 1 else 0
+            # Median + scaled MAD: recurring groups routinely mix a dominant
+            # regular amount with a few small adjustment rows under the same
+            # note, and a mean/stdev pair gets dragged far from the typical
+            # payment. 1.4826 scales MAD to stdev-like units.
+            avg_amount = median(amounts)
+            amount_variance = (
+                1.4826 * median(abs(a - avg_amount) for a in amounts) if len(amounts) > 1 else 0.0
+            )
 
             info = _resolve_pattern_display(
                 txns,
@@ -163,17 +184,21 @@ class RecurringMixin(AnalyticsEngineBase):
         self,
         dates: list[datetime],
     ) -> tuple[RecurrenceFrequency | None, float, int | None]:
-        """Infer recurrence frequency + confidence + expected day from dates."""
-        if len(dates) < 3:
+        """Infer recurrence frequency + confidence + expected day from dates.
+
+        Bands on the MEDIAN gap between unique days -- the mean of
+        consecutive gaps telescopes to span/(n-1), so a couple of skipped
+        periods used to drag a monthly stream into the wrong band.
+        Confidence then scores gaps folded to multiples of the median
+        (see ``_folded_confidence``), so a skipped month reads as a skip
+        penalty instead of exploding the jitter term.
+        """
+        days = sorted({d.date() for d in dates})
+        if len(days) < 3:
             return None, 0, None
 
-        sorted_dates = sorted(dates)
-        day_diffs = [
-            (sorted_dates[i + 1] - sorted_dates[i]).days for i in range(len(sorted_dates) - 1)
-        ]
-
-        avg_diff = mean(day_diffs)
-        std_diff = stdev(day_diffs) if len(day_diffs) > 1 else math.inf
+        diffs = [(days[i + 1] - days[i]).days for i in range(len(days) - 1)]
+        med = median(diffs)
 
         frequency = None
         confidence: float = 0
@@ -182,17 +207,14 @@ class RecurringMixin(AnalyticsEngineBase):
         # Walk bands in order; each band runs from its min_days up to (but
         # not including) the next band's min_days. The final band caps at
         # ``_FREQ_MAX_DAYS`` so absurdly long cadences don't get a label.
-        if avg_diff < self._FREQ_MAX_DAYS:
-            for i, (lo, freq, penalty) in enumerate(self._FREQ_BANDS):
-                next_lo = (
-                    self._FREQ_BANDS[i + 1][0]
-                    if i + 1 < len(self._FREQ_BANDS)
-                    else self._FREQ_MAX_DAYS
-                )
-                if lo <= avg_diff < next_lo:
-                    frequency = freq
-                    confidence = max(0, 100 - std_diff * penalty)
-                    break
+        for i, (lo, freq, penalty) in enumerate(self._FREQ_BANDS):
+            next_lo = (
+                self._FREQ_BANDS[i + 1][0] if i + 1 < len(self._FREQ_BANDS) else self._FREQ_MAX_DAYS
+            )
+            if lo <= med < next_lo:
+                frequency = freq
+                confidence = self._folded_confidence(diffs, med, penalty)
+                break
 
         # Calculate expected day of month for monthly-ish frequencies
         if frequency in (
@@ -202,6 +224,27 @@ class RecurringMixin(AnalyticsEngineBase):
             RecurrenceFrequency.SEMIANNUAL,
             RecurrenceFrequency.YEARLY,
         ):
-            expected_day = _infer_expected_day_of_month([d.day for d in sorted_dates])
+            # Feed every occurrence (not just unique days) so the mode-first
+            # day inference keeps its original multiplicity behaviour.
+            expected_day = _infer_expected_day_of_month([d.day for d in dates])
 
         return frequency, confidence, expected_day
+
+    @staticmethod
+    def _folded_confidence(diffs: list[int], med: float, penalty: float) -> float:
+        """Score gap regularity with skips folded to multiples of the median.
+
+        Each gap snaps to its nearest multiple of the median interval (a
+        skipped period doubles one gap; folding recovers the underlying
+        cadence). Confidence loses the median folded DAY residual scaled
+        by the band's penalty (jitter term) plus 25 points per unit of
+        skip RATE -- so occasional skips in a long regular stream cost
+        little, while a stream that is mostly skips scores low.
+        """
+        residuals: list[float] = []
+        skips = 0
+        for d in diffs:
+            k = max(1, round(d / med))
+            skips += k - 1
+            residuals.append(abs(d - k * med))
+        return max(0.0, 100 - median(residuals) * penalty - (skips / len(diffs)) * 25)

--- a/backend/src/ledger_sync/core/rules.py
+++ b/backend/src/ledger_sync/core/rules.py
@@ -34,9 +34,14 @@ from ledger_sync.db.models import (
 from ledger_sync.ingest.hash_id import TransactionHasher
 from ledger_sync.utils.logging import logger
 
-# Commit every N updated rows so a large retro-apply stays under the
-# Neon 30s statement timeout.
+# Commit every N moved rows to bound transaction size and lock /
+# idle-in-transaction exposure on Postgres (the Neon statement timeout is
+# per-statement, so chunking is about transaction lifetime, not statements).
 _COMMIT_CHUNK = 500
+
+# IN() lookups are chunked to avoid SQL parameter limits, mirroring
+# ``Reconciler._batch_fetch_existing``.
+_IN_CHUNK = 500
 
 
 def load_active_rules(session: Session, user_id: int) -> list[CategorizationRule]:
@@ -86,13 +91,14 @@ def _rehash_with_collision_handling(
     row: Transaction,
     rule: CategorizationRule,
     user_id: int,
-    live_ids: set[str],
+    ids: set[str],
 ) -> str:
     """Recompute the dedup hash with the rule's category/subcategory.
 
-    Bumps occurrence until the id is unique among the user's live ids
-    (including ids already assigned earlier in this pass), mirroring
-    ``Reconciler.reconcile_batch`` Phase 1.
+    Bumps occurrence until the id is unique among ALL of the user's
+    transaction ids -- soft-deleted rows still occupy their PK, so they
+    must collide too (including ids already assigned earlier in this
+    pass), mirroring ``Reconciler.reconcile_batch`` Phase 1.
     """
     old_id = row.transaction_id
     occurrence = 0
@@ -108,9 +114,47 @@ def _rehash_with_collision_handling(
             user_id=user_id,
             occurrence=occurrence,
         )
-        if new_id == old_id or new_id not in live_ids:
+        if new_id == old_id or new_id not in ids:
             return new_id
         occurrence += 1
+
+
+def _prefetch_children(
+    session: Session,
+    user_id: int,
+    old_ids: list[str],
+) -> tuple[dict[str, list[str]], dict[str, list[int]]]:
+    """Batch-fetch tags and anomaly ids for the rows about to move.
+
+    Two IN() queries per ``_IN_CHUNK`` ids instead of two SELECTs per row,
+    mirroring ``Reconciler._batch_fetch_existing``.
+
+    Returns:
+        Tuple of (tags_by_id, anomaly_ids_by_id) keyed by old transaction_id.
+
+    """
+    tags_by_id: dict[str, list[str]] = {}
+    anomaly_ids_by_id: dict[str, list[int]] = {}
+    for i in range(0, len(old_ids), _IN_CHUNK):
+        chunk = old_ids[i : i + _IN_CHUNK]
+        tag_rows = session.execute(
+            select(TransactionTag.transaction_id, TransactionTag.tag).where(
+                TransactionTag.user_id == user_id,
+                TransactionTag.transaction_id.in_(chunk),
+            )
+        ).all()
+        for tag_tx_id, tag in tag_rows:
+            tags_by_id.setdefault(tag_tx_id, []).append(tag)
+        anomaly_rows = session.execute(
+            select(Anomaly.transaction_id, Anomaly.id).where(
+                Anomaly.user_id == user_id,
+                Anomaly.transaction_id.in_(chunk),
+            )
+        ).all()
+        for anomaly_tx_id, anomaly_id in anomaly_rows:
+            if anomaly_tx_id is not None:
+                anomaly_ids_by_id.setdefault(anomaly_tx_id, []).append(anomaly_id)
+    return tags_by_id, anomaly_ids_by_id
 
 
 def _move_transaction_id(
@@ -119,25 +163,20 @@ def _move_transaction_id(
     rule: CategorizationRule,
     user_id: int,
     new_id: str,
+    tag_values: list[str],
+    anomaly_ids: list[int],
 ) -> None:
     """Rewrite *row*'s PK to *new_id*, carrying its tags and anomalies along.
 
     A direct UPDATE of the child FK column would violate the constraint on
     Postgres in either order (the new parent id doesn't exist yet / the old
-    one still has children), so: collect -> delete -> flush the parent PK
-    change -> re-insert against the new id. Anomalies (nullable FK) are
-    detached before the PK moves and re-pointed after.
+    one still has children), so: delete -> flush the parent PK change ->
+    re-insert against the new id. Anomalies (nullable FK) are detached
+    before the PK moves and re-pointed after. ``tag_values`` and
+    ``anomaly_ids`` are the row's children prefetched by
+    ``_prefetch_children`` so bulk applies avoid per-row SELECTs.
     """
     old_id = row.transaction_id
-    tag_values = [
-        tag_row[0]
-        for tag_row in session.execute(
-            select(TransactionTag.tag).where(
-                TransactionTag.user_id == user_id,
-                TransactionTag.transaction_id == old_id,
-            )
-        ).all()
-    ]
     if tag_values:
         session.execute(
             delete(TransactionTag).where(
@@ -145,15 +184,6 @@ def _move_transaction_id(
                 TransactionTag.transaction_id == old_id,
             )
         )
-    anomaly_ids = [
-        anomaly_row[0]
-        for anomaly_row in session.execute(
-            select(Anomaly.id).where(
-                Anomaly.user_id == user_id,
-                Anomaly.transaction_id == old_id,
-            )
-        ).all()
-    ]
     if anomaly_ids:
         session.execute(
             update(Anomaly).where(Anomaly.id.in_(anomaly_ids)).values(transaction_id=None)
@@ -170,14 +200,59 @@ def _move_transaction_id(
         )
 
 
+def _collect_moves(
+    rows: list[Transaction],
+    rules: list[CategorizationRule],
+    hasher: TransactionHasher,
+    user_id: int,
+    ids: set[str],
+) -> tuple[int, int, list[tuple[Transaction, CategorizationRule, str]]]:
+    """Phase A: match rules and rehash in memory, without touching the DB.
+
+    Rows whose recomputed id is unchanged (theoretically unreachable, since
+    category feeds the hash) are updated in place here; rows that need a PK
+    move are collected for the batched phases. ``ids`` is maintained as
+    moves are collected so ids assigned earlier in the pass also collide.
+
+    Returns:
+        Tuple of (matched, updated_in_place, moves) where each move is
+        (row, rule, new_id).
+
+    """
+    matched = 0
+    updated_in_place = 0
+    moves: list[tuple[Transaction, CategorizationRule, str]] = []
+    for row in rows:
+        rule = next((r for r in rules if match_rule(r, row.note, row.account)), None)
+        if rule is None:
+            continue
+        matched += 1
+
+        if row.category == rule.category and row.subcategory == rule.subcategory:
+            continue
+
+        old_id = row.transaction_id
+        new_id = _rehash_with_collision_handling(hasher, row, rule, user_id, ids)
+        if new_id == old_id:
+            row.category = rule.category
+            row.subcategory = rule.subcategory
+            updated_in_place += 1
+        else:
+            ids.discard(old_id)
+            ids.add(new_id)
+            moves.append((row, rule, new_id))
+    return matched, updated_in_place, moves
+
+
 def apply_rules_retroactively(session: Session, user_id: int) -> tuple[int, int]:
     """Apply all active rules to the user's live non-transfer transactions.
 
-    For each rewritten row the transaction_id is recomputed with the new
-    category/subcategory (occurrence-collision handling mirrors
-    ``Reconciler.reconcile_batch`` Phase 1) and any transaction_tags rows
-    are migrated to the new id. Commits every ``_COMMIT_CHUNK`` updated
-    rows and once at the end.
+    Three batched phases: (A) match + rehash in memory -- occurrence
+    collisions are checked against the user's FULL transaction id keyspace,
+    since soft-deleted rows still occupy their PK (mirroring
+    ``Reconciler.reconcile_batch`` Phase 1); (B) one IN()-chunked prefetch
+    of the moving rows' tags and anomalies; (C) the PK moves, committing
+    every ``_COMMIT_CHUNK`` moved rows and once at the end.
 
     Returns:
         Tuple of (matched, updated): matched counts rows where some rule
@@ -198,41 +273,48 @@ def apply_rules_retroactively(session: Session, user_id: int) -> tuple[int, int]
     )
     rows = list(session.execute(stmt).scalars().all())
 
-    # Live ids of this user -- used for collision detection when rehashing.
-    # Updated as we go so ids assigned earlier in this batch also collide.
-    live_ids: set[str] = {row.transaction_id for row in rows}
+    # ALL of this user's transaction ids -- soft-deleted rows still occupy
+    # their PK, so rehashing onto one would raise an IntegrityError if only
+    # live ids were considered.
+    ids: set[str] = set(
+        session.execute(
+            select(Transaction.transaction_id).where(Transaction.user_id == user_id)
+        ).scalars()
+    )
 
-    matched = 0
-    updated = 0
-    pending_since_commit = 0
+    matched, updated_in_place, moves = _collect_moves(rows, rules, hasher, user_id, ids)
+    tags_by_id, anomaly_ids_by_id = _prefetch_children(
+        session, user_id, [row.transaction_id for row, _, _ in moves]
+    )
 
-    for row in rows:
-        rule = next((r for r in rules if match_rule(r, row.note, row.account)), None)
-        if rule is None:
-            continue
-        matched += 1
+    # Chunked commits bound transaction size / lock lifetime on Postgres.
+    # expire_on_commit is disabled for the pass so those commits don't
+    # expire every loaded row (each attribute access after an expiring
+    # commit would otherwise refresh via its own SELECT).
+    prior_expire_on_commit = session.expire_on_commit
+    session.expire_on_commit = False
+    try:
+        pending_since_commit = 0
+        for row, rule, new_id in moves:
+            old_id = row.transaction_id
+            _move_transaction_id(
+                session,
+                row,
+                rule,
+                user_id,
+                new_id,
+                tags_by_id.get(old_id, []),
+                anomaly_ids_by_id.get(old_id, []),
+            )
+            pending_since_commit += 1
+            if pending_since_commit >= _COMMIT_CHUNK:
+                session.commit()
+                pending_since_commit = 0
+        session.commit()
+    finally:
+        session.expire_on_commit = prior_expire_on_commit
 
-        if row.category == rule.category and row.subcategory == rule.subcategory:
-            continue
-
-        old_id = row.transaction_id
-        new_id = _rehash_with_collision_handling(hasher, row, rule, user_id, live_ids)
-
-        if new_id != old_id:
-            _move_transaction_id(session, row, rule, user_id, new_id)
-            live_ids.discard(old_id)
-            live_ids.add(new_id)
-        else:
-            row.category = rule.category
-            row.subcategory = rule.subcategory
-        updated += 1
-        pending_since_commit += 1
-
-        if pending_since_commit >= _COMMIT_CHUNK:
-            session.commit()
-            pending_since_commit = 0
-
-    session.commit()
+    updated = updated_in_place + len(moves)
     logger.info(
         "Retroactive rule apply for user_id=%s: matched=%d updated=%d",
         user_id,

--- a/backend/src/ledger_sync/db/_models/transactions.py
+++ b/backend/src/ledger_sync/db/_models/transactions.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     Numeric,
     String,
     Text,
+    text,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -23,6 +24,22 @@ from ledger_sync.db.base import Base
 
 if TYPE_CHECKING:
     from ledger_sync.db._models.user import User
+
+
+def _live_index(name: str, *columns: str) -> Index:
+    """Partial index over non-deleted rows, with per-dialect predicates.
+
+    SQLite matches partial-index predicates near-textually against the query
+    WHERE clause; SQLAlchemy's ``.is_(False)`` emits ``is_deleted IS 0`` on
+    SQLite, so the predicate must be the IS-form. Postgres proves predicate
+    implication instead, so the canonical ``= false`` form is used there.
+    """
+    return Index(
+        name,
+        *columns,
+        sqlite_where=text("is_deleted IS 0"),
+        postgresql_where=text("is_deleted = false"),
+    )
 
 
 class Transaction(Base):
@@ -64,7 +81,11 @@ class Transaction(Base):
         default=lambda: datetime.now(UTC),
         index=True,
     )
-    is_deleted: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, index=True)
+    # No standalone index: every read path filters ``is_deleted`` alongside
+    # ``user_id`` and is served by the partial composite indexes below (the
+    # optimize_tx_indexes_2026 migration had already dropped the single-column
+    # index; the old ``index=True`` here was drift).
+    is_deleted: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     # Audit timestamps
     created_at: Mapped[datetime] = mapped_column(
@@ -89,25 +110,28 @@ class Transaction(Base):
     # removed: the planner can never use them for user-scoped queries, so they
     # only taxed writes. See migration ``optimize_tx_indexes_2026``.
     #
-    # NOTE: partial indexes (``WHERE is_deleted = false``) would shrink these
-    # further (~63% of rows are soft-deleted) but the predicate-matching of
-    # ``.is_(False)`` vs a ``= false`` partial differs between SQLite and
-    # Postgres and can't be verified here -- left as a Postgres-verified
-    # follow-up rather than shipped blind.
+    # All composites are PARTIAL on the live rows (soft-deleted rows are dead
+    # weight in every index; every read path filters them out). Predicate
+    # forms are dialect-specific and empirically verified:
+    #   - SQLite matches partial-index predicates near-textually, and
+    #     ``.is_(False)`` emits ``is_deleted IS 0`` -- so the SQLite predicate
+    #     must be the IS-form (a ``= 0`` predicate is NOT matched).
+    #   - Postgres does implication proofs, and ``.is_(False)`` emits
+    #     ``IS false``, which implies ``is_deleted = false``.
     __table_args__ = (
         # Primary analytics range scan: user's rows ordered/filtered by date.
-        Index("ix_transactions_user_date", "user_id", "date"),
+        _live_index("ix_transactions_user_date", "user_id", "date"),
         # Type-filtered + date range (search endpoint, type rollups) -- type is
         # an equality filter so it leads the date range.
-        Index("ix_transactions_user_type_date", "user_id", "type", "date"),
+        _live_index("ix_transactions_user_type_date", "user_id", "type", "date"),
         # Category filter / breakdown.
-        Index("ix_transactions_user_category", "user_id", "category"),
+        _live_index("ix_transactions_user_category", "user_id", "category"),
         # Account grouping (facets, account balances) + the account legs of the
         # search OR (account == X OR from_account == X OR to_account == X) and
         # transfer-flow aggregation.
-        Index("ix_transactions_user_account", "user_id", "account"),
-        Index("ix_transactions_user_from_account", "user_id", "from_account"),
-        Index("ix_transactions_user_to_account", "user_id", "to_account"),
+        _live_index("ix_transactions_user_account", "user_id", "account"),
+        _live_index("ix_transactions_user_from_account", "user_id", "from_account"),
+        _live_index("ix_transactions_user_to_account", "user_id", "to_account"),
     )
 
     def __repr__(self) -> str:

--- a/backend/src/ledger_sync/db/migrations/versions/20260713_1000_partial_transaction_indexes.py
+++ b/backend/src/ledger_sync/db/migrations/versions/20260713_1000_partial_transaction_indexes.py
@@ -1,0 +1,84 @@
+"""rebuild transaction indexes as partial over live rows
+
+Revision ID: partial_tx_indexes_2026
+Revises: tags_rules_views_2026
+Create Date: 2026-07-13 10:00:00.000000
+
+Every read path filters ``is_deleted = false`` (via ``query_helpers`` /
+``.is_(False)``), so soft-deleted rows are dead weight in every composite
+index. Rebuilding the six user-scoped composites as PARTIAL indexes over the
+live rows shrinks them and lets the planner skip tombstones entirely.
+
+Also drops the stray single-column ``ix_transactions_is_deleted`` if present
+(model drift -- a lone boolean index is useless under user-scoped queries).
+
+Predicate forms are dialect-specific and empirically verified:
+  - SQLite matches partial-index predicates near-textually and SQLAlchemy's
+    ``.is_(False)`` emits ``is_deleted IS 0`` -> predicate must be
+    ``is_deleted IS 0`` (a ``= 0`` predicate is NOT matched by the planner).
+  - Postgres proves predicate implication; ``IS false`` implies ``= false``,
+    so the canonical ``= false`` form is used.
+
+Idempotent/defensive like optimize_tx_indexes_2026: drops-then-recreates only
+what exists/is missing, so it converges from either a create_all or migrated
+schema. Index DDL is cheap at this data volume (~7k rows).
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+from sqlalchemy import inspect, text
+
+# revision identifiers, used by Alembic.
+revision: str = "partial_tx_indexes_2026"
+down_revision: str | None = "tags_rules_views_2026"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+TABLE = "transactions"
+
+# name -> columns; all rebuilt with the partial predicate.
+PARTIAL_INDEXES: dict[str, list[str]] = {
+    "ix_transactions_user_date": ["user_id", "date"],
+    "ix_transactions_user_type_date": ["user_id", "type", "date"],
+    "ix_transactions_user_category": ["user_id", "category"],
+    "ix_transactions_user_account": ["user_id", "account"],
+    "ix_transactions_user_from_account": ["user_id", "from_account"],
+    "ix_transactions_user_to_account": ["user_id", "to_account"],
+}
+
+# Single-column boolean index that serves no user-scoped query.
+DROP_IF_PRESENT = {"ix_transactions_is_deleted"}
+
+
+def _predicate(dialect: str) -> str:
+    return "is_deleted IS 0" if dialect == "sqlite" else "is_deleted = false"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+    inspector = inspect(bind)
+    existing = {idx["name"] for idx in inspector.get_indexes(TABLE) if idx.get("name")}
+
+    for name in DROP_IF_PRESENT & existing:
+        op.drop_index(name, table_name=TABLE)
+
+    where = _predicate(dialect)
+    for name, columns in PARTIAL_INDEXES.items():
+        if name in existing:
+            op.drop_index(name, table_name=TABLE)
+        cols = ", ".join(columns)
+        op.execute(text(f"CREATE INDEX {name} ON {TABLE} ({cols}) WHERE {where}"))
+
+
+def downgrade() -> None:
+    """Rebuild the indexes as full (non-partial) composites."""
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    existing = {idx["name"] for idx in inspector.get_indexes(TABLE) if idx.get("name")}
+
+    for name, columns in PARTIAL_INDEXES.items():
+        if name in existing:
+            op.drop_index(name, table_name=TABLE)
+        op.create_index(name, TABLE, columns)

--- a/backend/tests/integration/test_analytics_user_scoping.py
+++ b/backend/tests/integration/test_analytics_user_scoping.py
@@ -133,6 +133,100 @@ def test_detect_large_transactions_scopes_by_user(analytics_db: Session) -> None
     assert anomalies_b == []
 
 
+def test_month_detector_uses_rolling_baseline_not_alltime(analytics_db: Session) -> None:
+    """A step-change in spending (lifestyle drift) must not flag every recent month.
+
+    36 months: 24 at 1000, then 12 at 5000. An all-time median (~1000-3000)
+    would flag many/all of the last 12 months; a trailing-12-month baseline
+    flags only the step boundary at most.
+    """
+    user = _make_user(analytics_db, "drift@example.com")
+    now = datetime.now(UTC) - timedelta(days=1)
+    for i in range(36):
+        year, month = divmod(i, 12)
+        analytics_db.add(
+            Transaction(
+                user_id=user.id,
+                transaction_id=f"drift-{i}",
+                date=datetime(2022 + year, month + 1, 15, tzinfo=UTC),
+                amount=Decimal("1000") if i < 24 else Decimal("5000"),  # noqa: PLR2004
+                currency="INR",
+                type=TransactionType.EXPENSE,
+                account="HDFC",
+                category="Food",
+                subcategory=None,
+                note=None,
+                source_file="test.xlsx",
+                last_seen_at=now,
+                is_deleted=False,
+            ),
+        )
+    analytics_db.commit()
+
+    engine = AnalyticsEngine(analytics_db, user_id=user.id)
+    anomalies: list[dict] = []
+    engine._detect_high_expense_months(anomalies, z_cutoff=3.5)
+    # The months right at the step legitimately flag (they ARE anomalous vs
+    # trailing history) until the window absorbs the new level; the tail of
+    # the series must be quiet once 5000 becomes the trailing normal.
+    flagged = {a["period_key"] for a in anomalies}
+    assert "2024-01" in flagged, "step month should flag against its trailing baseline"
+    assert "2024-12" not in flagged, "steady-state month flagged against stale all-time baseline"
+    assert len(flagged) <= 4, f"too many months flagged: {sorted(flagged)}"
+
+
+def test_large_txn_materiality_floor_skips_trivial_amounts(analytics_db: Session) -> None:
+    """A 3x blip in a tiny category must not flag when the amount is immaterial."""
+    user = _make_user(analytics_db, "chai@example.com")
+    now = datetime.now(UTC) - timedelta(days=1)
+    # Material spending elsewhere: 12 months of 50k rent fixes the monthly median.
+    for i in range(12):
+        analytics_db.add(
+            Transaction(
+                user_id=user.id,
+                transaction_id=f"rent-{i}",
+                date=datetime(2024, i + 1, 1, tzinfo=UTC),
+                amount=Decimal("50000"),
+                currency="INR",
+                type=TransactionType.EXPENSE,
+                account="HDFC",
+                category="Housing",
+                subcategory=None,
+                note=None,
+                source_file="test.xlsx",
+                last_seen_at=now,
+                is_deleted=False,
+            ),
+        )
+    # Tiny chai category: 20, 20, 20, 20, 20 then a 90 (4.5x median, but immaterial).
+    for i, amt in enumerate([20, 20, 20, 20, 20, 90]):
+        analytics_db.add(
+            Transaction(
+                user_id=user.id,
+                transaction_id=f"chai-{i}",
+                date=datetime(2024, i + 1, 20, tzinfo=UTC),
+                amount=Decimal(str(amt)),
+                currency="INR",
+                type=TransactionType.EXPENSE,
+                account="HDFC",
+                category="Chai",
+                subcategory=None,
+                note=None,
+                source_file="test.xlsx",
+                last_seen_at=now,
+                is_deleted=False,
+            ),
+        )
+    analytics_db.commit()
+
+    engine = AnalyticsEngine(analytics_db, user_id=user.id)
+    anomalies: list[dict] = []
+    engine._detect_large_transactions(anomalies)
+    assert all(a.get("transaction_id") != "chai-5" for a in anomalies), (
+        "immaterial 90-rupee blip flagged despite materiality floor"
+    )
+
+
 def test_excluded_accounts_filter_drops_transfer_endpoints(analytics_db: Session) -> None:
     """A transfer landing in an excluded account must not appear in the user query.
 

--- a/backend/tests/integration/test_categorization_rules.py
+++ b/backend/tests/integration/test_categorization_rules.py
@@ -15,8 +15,11 @@ from typing import Any
 import pytest
 from sqlalchemy.orm import Session
 
+from ledger_sync.core import rules as rules_engine
 from ledger_sync.core.sync_engine import SyncEngine
 from ledger_sync.db.models import (
+    Anomaly,
+    AnomalyType,
     Transaction,
     TransactionTag,
     TransactionType,
@@ -281,6 +284,95 @@ def test_apply_handles_occurrence_collision(rules_client) -> None:
     assert all(row.category == "Food" for row in rows)
     recomputed = {_recomputed_id(rows[0], user_a.id, occurrence=n) for n in (0, 1)}
     assert ids == recomputed
+
+
+def test_apply_rehash_avoids_soft_deleted_row_ids(rules_client) -> None:
+    client, session, user_a, _, _ = rules_client
+    live = _seed_txn(session, user_a.id, "live1", note="swiggy order", category="Misc")
+    # A soft-deleted row already occupies the EXACT id the live row would
+    # rehash to at occurrence 0 (typical full-snapshot re-upload leftovers).
+    ghost_id = TransactionHasher().generate_transaction_id(
+        date=live.date,
+        amount=live.amount,
+        account=live.account,
+        note=live.note,
+        category="Food",
+        subcategory=None,
+        tx_type=live.type.value,
+        user_id=user_a.id,
+        occurrence=0,
+    )
+    ghost = _seed_txn(session, user_a.id, ghost_id, note="swiggy order", category="Food")
+    ghost.is_deleted = True
+    session.commit()
+    client.post("/api/categorization-rules", json=_rule_payload(subcategory=None))
+
+    r = client.post("/api/categorization-rules/apply")
+
+    # Was a duplicate-PK IntegrityError (HTTP 500) before soft-deleted rows
+    # were included in the collision keyspace.
+    assert r.status_code == 200, r.json()
+    assert r.json()["updated"] == 1
+    session.expire_all()
+    row = (
+        session.query(Transaction)
+        .filter(Transaction.user_id == user_a.id, Transaction.is_deleted.is_(False))
+        .one()
+    )
+    assert row.category == "Food"
+    assert row.transaction_id != ghost_id
+    assert row.transaction_id == _recomputed_id(row, user_a.id, occurrence=1)
+    ghost_row = session.get(Transaction, ghost_id)
+    assert ghost_row is not None
+    assert ghost_row.is_deleted is True
+
+
+def test_apply_migrates_anomalies_to_new_id(rules_client) -> None:
+    client, session, user_a, _, _ = rules_client
+    seeded = _seed_txn(session, user_a.id, "anom1", note="swiggy order", category="Misc")
+    old_id = seeded.transaction_id
+    session.add(
+        Anomaly(
+            user_id=user_a.id,
+            anomaly_type=AnomalyType.HIGH_EXPENSE,
+            severity="high",
+            description="big spend",
+            transaction_id=old_id,
+            is_reviewed=True,
+        )
+    )
+    session.commit()
+    client.post("/api/categorization-rules", json=_rule_payload(subcategory=None))
+
+    matched, updated = rules_engine.apply_rules_retroactively(session, user_a.id)
+
+    assert (matched, updated) == (1, 1)
+    session.expire_all()
+    row = session.query(Transaction).filter(Transaction.user_id == user_a.id).one()
+    anomaly = session.query(Anomaly).filter(Anomaly.user_id == user_a.id).one()
+    assert row.transaction_id != old_id
+    assert anomaly.transaction_id == row.transaction_id
+
+
+def test_apply_batches_across_commit_chunks_and_restores_expire_on_commit(
+    rules_client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client, session, user_a, _, _ = rules_client
+    monkeypatch.setattr(rules_engine, "_COMMIT_CHUNK", 2)
+    for n in range(5):
+        _seed_txn(session, user_a.id, f"bulk{n}", note=f"swiggy order {n}", category="Misc")
+    client.post("/api/categorization-rules", json=_rule_payload(subcategory=None))
+    assert session.expire_on_commit is True  # sessionmaker default
+
+    matched, updated = rules_engine.apply_rules_retroactively(session, user_a.id)
+
+    assert (matched, updated) == (5, 5)
+    assert session.expire_on_commit is True  # restored after the pass
+    session.expire_all()
+    rows = session.query(Transaction).filter(Transaction.user_id == user_a.id).all()
+    assert len(rows) == 5
+    assert all(row.category == "Food" for row in rows)
+    assert all(row.transaction_id == _recomputed_id(row, user_a.id) for row in rows)
 
 
 def test_apply_with_no_active_rules_returns_zero_counts(rules_client) -> None:

--- a/backend/tests/unit/test_recurring_detection.py
+++ b/backend/tests/unit/test_recurring_detection.py
@@ -1,0 +1,168 @@
+"""Recurring detection -- amount statistics and confirmed-pattern matching.
+
+Pins two behaviours of ``_detect_recurring_transactions``:
+
+* ``expected_amount`` / ``amount_variance`` use median + scaled MAD so a
+  stray adjustment row under the same note cannot drag the stored amount
+  (a single outlier used to skew the mean by 25-273% on real data).
+* Confirmed-pattern lookup matches on the stable group label: a confirmed
+  record whose ``pattern_name`` carries a date trailer ("Rent Mar 2026")
+  is updated in place instead of spawning an unconfirmed duplicate while
+  the confirmed row's stats freeze.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from ledger_sync.core.analytics_engine import AnalyticsEngine
+from ledger_sync.db.base import Base
+from ledger_sync.db.models import (
+    RecurrenceFrequency,
+    RecurringTransaction,
+    Transaction,
+    TransactionType,
+    User,
+)
+
+
+@pytest.fixture
+def session() -> Session:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+@pytest.fixture
+def user(session: Session) -> User:
+    user = User(email="rec@example.com", hashed_password="", is_active=True, is_verified=True)
+    session.add(user)
+    session.commit()
+    return user
+
+
+def _txn(
+    user_id: int,
+    idx: int,
+    date: datetime,
+    amount: str,
+    note: str,
+) -> Transaction:
+    return Transaction(
+        transaction_id=f"txn-{idx}",
+        user_id=user_id,
+        date=date,
+        amount=Decimal(amount),
+        currency="INR",
+        type=TransactionType.EXPENSE,
+        account="HDFC Bank",
+        category="Housing",
+        note=note,
+        source_file="test.xlsx",
+    )
+
+
+def _monthly_dates(n: int) -> list[datetime]:
+    return [datetime(2026, month, 1, tzinfo=UTC) for month in range(1, n + 1)]
+
+
+def _detect(session: Session, user: User, txns: list[Transaction]) -> list[RecurringTransaction]:
+    session.add_all(txns)
+    session.commit()
+    engine = AnalyticsEngine(session, user_id=user.id)
+    engine._detect_recurring_transactions(txns)
+    session.commit()
+    return session.query(RecurringTransaction).all()
+
+
+def test_expected_amount_uses_median_not_mean(session: Session, user: User) -> None:
+    """One stray 10,000 row must not drag the stored amount off 100."""
+    amounts = ["100", "100", "100", "10000"]
+    txns = [_txn(user.id, i, d, amounts[i], "Rent") for i, d in enumerate(_monthly_dates(4))]
+    records = _detect(session, user, txns)
+    assert len(records) == 1
+    assert records[0].expected_amount == Decimal("100")  # mean would be 2575
+    assert records[0].amount_variance == Decimal("0")  # MAD of [0,0,0,9900] is 0
+
+
+def test_amount_variance_is_scaled_mad(session: Session, user: User) -> None:
+    """Variance = 1.4826 * MAD, in stdev-like units, robust to the outlier."""
+    amounts = ["100", "110", "90", "10000"]
+    txns = [_txn(user.id, i, d, amounts[i], "Rent") for i, d in enumerate(_monthly_dates(4))]
+    records = _detect(session, user, txns)
+    assert len(records) == 1
+    # median = 105; |dev| = [5, 5, 15, 9895]; MAD = 10; 1.4826 * 10 = 14.826
+    # (column scale is 2, so compare at cent precision)
+    assert float(records[0].expected_amount) == pytest.approx(105)
+    assert float(records[0].amount_variance) == pytest.approx(14.83, abs=0.01)
+
+
+def test_confirmed_pattern_with_date_trailer_updates_in_place(
+    session: Session,
+    user: User,
+) -> None:
+    """A confirmed 'Rent Mar 2026' record matches the 'rent' group label.
+
+    The refresh must update the confirmed row's stats instead of creating
+    an unconfirmed duplicate and freezing the confirmed one.
+    """
+    session.add(
+        RecurringTransaction(
+            user_id=user.id,
+            pattern_name="Rent Mar 2026",
+            category="Housing",
+            account="HDFC Bank",
+            transaction_type=TransactionType.EXPENSE,
+            frequency=RecurrenceFrequency.MONTHLY,
+            expected_amount=Decimal("100"),
+            amount_variance=Decimal("0"),
+            confidence_score=90,
+            occurrences_detected=3,
+            is_user_confirmed=True,
+            is_active=True,
+        )
+    )
+    session.commit()
+
+    notes = ["Rent Jan 2026", "Rent Feb 2026", "Rent Mar 2026", "Rent Apr 2026"]
+    txns = [_txn(user.id, i, d, "150", notes[i]) for i, d in enumerate(_monthly_dates(4))]
+    records = _detect(session, user, txns)
+
+    assert len(records) == 1  # no unconfirmed duplicate
+    assert records[0].is_user_confirmed is True
+    assert records[0].occurrences_detected == 4
+    assert records[0].expected_amount == Decimal("150")
+    assert records[0].last_occurrence == datetime(2026, 4, 1)
+
+
+def test_confirmed_pattern_exact_name_still_matches(session: Session, user: User) -> None:
+    """Plain lowercase matching (no trailer) keeps working for manual records."""
+    session.add(
+        RecurringTransaction(
+            user_id=user.id,
+            pattern_name="Netflix",
+            category="Entertainment",
+            account="HDFC Bank",
+            transaction_type=TransactionType.EXPENSE,
+            frequency=RecurrenceFrequency.MONTHLY,
+            expected_amount=Decimal("649"),
+            amount_variance=Decimal("0"),
+            confidence_score=100,
+            occurrences_detected=0,
+            is_user_confirmed=True,
+            is_active=True,
+        )
+    )
+    session.commit()
+
+    txns = [_txn(user.id, i, d, "649", "Netflix") for i, d in enumerate(_monthly_dates(3))]
+    records = _detect(session, user, txns)
+
+    assert len(records) == 1
+    assert records[0].is_user_confirmed is True
+    assert records[0].occurrences_detected == 3

--- a/backend/tests/unit/test_recurring_frequency_bands.py
+++ b/backend/tests/unit/test_recurring_frequency_bands.py
@@ -122,6 +122,41 @@ def test_yearly_classic_365_day_cadence() -> None:
     assert freq == RecurrenceFrequency.YEARLY
 
 
+# ─── Skip folding: regular cadences with skipped periods ─────────────────
+
+
+def test_monthly_with_minority_skips_high_confidence() -> None:
+    """Monthly stream with two skipped months stays MONTHLY at high confidence.
+
+    Gaps [31, 30, 59, 31, 61, 30]: median 31 bands MONTHLY; the two doubled
+    gaps fold to 2x the median instead of exploding the jitter term.
+    """
+    eng = _engine()
+    dates = _dates_with_gaps(datetime(2026, 1, 1, tzinfo=UTC), [31, 30, 59, 31, 61, 30])
+    freq, conf, _ = eng._detect_frequency(dates)
+    assert freq == RecurrenceFrequency.MONTHLY
+    assert conf >= 80
+
+
+def test_long_monthly_stream_with_folded_skips() -> None:
+    """A 16-gap wifi-bill-like stream with three skipped months scores >= 90."""
+    eng = _engine()
+    gaps = [30, 31, 30, 61, 30, 31, 61, 31, 30, 31, 61, 30, 31, 30, 31, 30]
+    dates = _dates_with_gaps(datetime(2025, 1, 1, tzinfo=UTC), gaps)
+    freq, conf, _ = eng._detect_frequency(dates)
+    assert freq == RecurrenceFrequency.MONTHLY
+    assert conf >= 90
+
+
+def test_semiannual_with_one_skip() -> None:
+    """Semiannual stream with one skipped period: previously QUARTERLY conf 0."""
+    eng = _engine()
+    dates = _dates_with_gaps(datetime(2024, 1, 1, tzinfo=UTC), [139, 278, 140])
+    freq, conf, _ = eng._detect_frequency(dates)
+    assert freq == RecurrenceFrequency.SEMIANNUAL
+    assert conf >= 90
+
+
 def test_below_minimum_returns_none() -> None:
     """Sub-weekly gaps (avg < 4) still return None -- not a tracked cadence."""
     eng = _engine()

--- a/frontend/src/components/shared/CommandPalette.tsx
+++ b/frontend/src/components/shared/CommandPalette.tsx
@@ -1,12 +1,13 @@
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { useQuery } from '@tanstack/react-query'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { AnimatePresence, motion } from 'framer-motion'
 import { Command, Search } from 'lucide-react'
 
 import { ROUTES } from '@/constants'
 import { rawColors } from '@/constants/colors'
+import { useDebounce } from '@/hooks/useDebounce'
 import { transactionsService } from '@/services/api/transactions'
 
 import { PaletteResults } from './command-palette/PaletteResults'
@@ -75,16 +76,24 @@ export default function CommandPalette() {
   }, [isOpen])
 
   const deferredQuery = useDeferredValue(query)
-  const q = deferredQuery.trim()
+  // Debounce before the queryKey: useDeferredValue only defers re-rendering,
+  // it does NOT coalesce fetches -- without this, every keystroke minted a new
+  // queryKey and fired a server search request per key. 300ms trailing-edge
+  // debounce (same pattern as TransactionFilters) bounds it to ~1 per pause.
+  const debouncedQuery = useDebounce(deferredQuery, 300)
+  const q = debouncedQuery.trim()
 
   // Transaction matches come from the server-side search endpoint (note /
   // category / account, top 5) instead of filtering the full ledger in the
   // browser. Only runs while the palette is open with a non-empty query.
+  // keepPreviousData holds the previous matches on screen while the next
+  // fetch resolves, so the Transactions section doesn't flicker empty.
   const { data: txMatches = [] } = useQuery({
     queryKey: ['command-palette-search', q],
     queryFn: () => transactionsService.getTransactions({ query: q, limit: 5 }),
     enabled: isOpen && q.length > 0,
     staleTime: 60_000,
+    placeholderData: keepPreviousData,
   })
 
   const results: PaletteResult[] = useMemo(() => {

--- a/frontend/src/components/transactions/TransactionFilters.tsx
+++ b/frontend/src/components/transactions/TransactionFilters.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useEffectEvent, useRef, type ReactNode } from 'react'
 import { Search, Filter, X, Calendar } from 'lucide-react'
 import { motion, AnimatePresence } from 'framer-motion'
+import { useDebounce } from '@/hooks/useDebounce'
 import { usePreferencesStore } from '@/store/preferencesStore'
 import type { TagFacet } from '@/services/api/transactions'
 
@@ -31,18 +32,6 @@ export interface FilterValues {
 }
 
 const TRANSACTION_TYPES = ['Income', 'Expense', 'Transfer']
-
-// Custom debounce hook
-function useDebounce<T>(value: T, delay: number): T {
-  const [debouncedValue, setDebouncedValue] = useState<T>(value)
-
-  useEffect(() => {
-    const timer = setTimeout(() => setDebouncedValue(value), delay)
-    return () => clearTimeout(timer)
-  }, [value, delay])
-
-  return debouncedValue
-}
 
 export default function TransactionFilters({
   onFilterChange,

--- a/frontend/src/hooks/useDebounce.ts
+++ b/frontend/src/hooks/useDebounce.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Debounce a changing value: returns the latest value only after it has been
+ * stable for `delay` ms. The standard rate control for type-ahead inputs that
+ * feed network requests -- unlike `useDeferredValue`, which only defers
+ * re-rendering and does not coalesce fetches.
+ */
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay)
+    return () => clearTimeout(timer)
+  }, [value, delay])
+
+  return debouncedValue
+}

--- a/frontend/src/lib/__tests__/gstCalculator.test.ts
+++ b/frontend/src/lib/__tests__/gstCalculator.test.ts
@@ -138,24 +138,33 @@ describe('getGSTRate', () => {
     expect(getGSTRate('Jewellery', undefined, { Restaurants: 12 })).toBe(18)
   })
 
-  it('substring-matches a longer label against a known keyword', () => {
-    // "Fine Dining" contains "Dining" (5%)
+  it('word-matches a longer label against a known keyword', () => {
+    // "Fine Dining" contains the word "Dining" (5%)
     expect(getGSTRate('Fine Dining')).toBe(5)
-  })
-
-  it('QUIRK: a short label that is a substring of a key matches that key', () => {
-    // "Gold" is an exact key (3%). But a label like "Go" is a substring of
-    // many keys; first matching key in insertion order wins. "Go" is contained
-    // in "Gold" (3) which appears before "Gaming" (28) -> resolves to 3.
-    expect(getGSTRate('Go')).toBe(3)
-  })
-
-  it('QUIRK: substring collision can pull an unexpected slab', () => {
-    // "Bus" is an exact key (5%), so exact match wins first.
-    expect(getGSTRate('Bus')).toBe(5)
-    // But "Subscriptions" contains "Bus"? No. Use a real collision instead:
-    // "Air" is a substring of "Air Travel" (18) and resolves via partial match.
+    // "Air" appears as a word inside the "Air Travel" key (18%)
     expect(getGSTRate('Air')).toBe(18)
+    // Multi-word key inside a longer label
+    expect(getGSTRate('Public Transport Pass')).toBe(5)
+  })
+
+  it('does NOT match on raw substrings inside words (regression)', () => {
+    // These were false positives under the old bidirectional substring
+    // fallback: "Bus" ⊂ "Business" and "Train" ⊂ "Training" pulled 5%.
+    // Word-boundary matching sends them to the correct fallback instead.
+    // (Labels where a key IS a whole word, like "Gold Coin", still match --
+    // that's intended.)
+    expect(getGSTRate('Business Services')).toBe(18) // not the "Bus" 5% key
+    expect(getGSTRate('Training')).toBe(18) // not the "Train" 5% key
+    expect(getGSTRate('Automobile')).toBe(18) // not the "Auto" 5% key
+    // "Go" is not a whole-word match for "Gold" -> default 18, not 3.
+    expect(getGSTRate('Go')).toBe(18)
+  })
+
+  it("word-boundary still matches possessive-free word sequences", () => {
+    // "Gold Coin Purchase" contains the word "Gold" -> 3%.
+    expect(getGSTRate('Gold Coin Purchase')).toBe(3)
+    // "Bus" as an exact standalone key still resolves.
+    expect(getGSTRate('Bus')).toBe(5)
   })
 })
 

--- a/frontend/src/lib/__tests__/xirr.test.ts
+++ b/frontend/src/lib/__tests__/xirr.test.ts
@@ -30,13 +30,54 @@ describe('calculateXIRR', () => {
     expect(rate).toBeLessThan(40)
   })
 
-  it('returns 0 when solver diverges (e.g. all same-sign flows)', () => {
-    // No positive return is mathematically solvable -- all money goes in,
-    // none comes out. The guard kicks in and returns 0.
+  it('returns 0 when no root exists (all same-sign flows)', () => {
+    // No rate is mathematically solvable -- all money goes in, none comes
+    // out. NPV never crosses zero, so bisection reports no root.
     const rate = calculateXIRR([
       { date: new Date('2024-01-01'), amount: 100 },
       { date: new Date('2025-01-01'), amount: 50 },
     ])
     expect(rate).toBe(0)
+  })
+
+  it('solves a losing year instead of returning 0 (regression)', () => {
+    // 100k in, 55k out a year later: true XIRR = -45%. Newton overshoots
+    // below -100% here and the old guard reported 0% -- a losing portfolio
+    // displayed as flat. Bisection fallback recovers the real rate.
+    const rate = calculateXIRR([
+      { date: new Date('2024-01-01'), amount: 100_000 },
+      { date: new Date('2025-01-01'), amount: -55_000 },
+    ])
+    expect(rate).toBeCloseTo(-45, 0)
+  })
+
+  it('solves a near-total loss (deep negative rate)', () => {
+    // 100k -> 500 in one year: XIRR = -99.5%.
+    const rate = calculateXIRR([
+      { date: new Date('2024-01-01'), amount: 100_000 },
+      { date: new Date('2025-01-01'), amount: -500 },
+    ])
+    expect(rate).toBeCloseTo(-99.5, 0)
+  })
+
+  it('solves an extreme short-horizon gain via bisection when Newton leaves the bracket', () => {
+    // 2x in one month annualizes to ~409,500% -- outside the 1000% bracket
+    // cap, so the solver returns the bracket-capped estimate rather than 0.
+    // What matters: a huge REAL gain never displays as 0%.
+    const rate = calculateXIRR([
+      { date: new Date('2025-01-01'), amount: 10_000 },
+      { date: new Date('2025-02-01'), amount: -20_000 },
+    ])
+    expect(rate).toBeGreaterThan(500) // enormous, definitely not 0
+  })
+
+  it('still fast-paths a normal gain through Newton', () => {
+    const rate = calculateXIRR([
+      { date: new Date('2023-01-01'), amount: 50_000 },
+      { date: new Date('2024-01-01'), amount: 20_000 },
+      { date: new Date('2025-01-01'), amount: -90_000 },
+    ])
+    expect(rate).toBeGreaterThan(10)
+    expect(rate).toBeLessThan(20)
   })
 })

--- a/frontend/src/lib/gstCalculator.ts
+++ b/frontend/src/lib/gstCalculator.ts
@@ -241,9 +241,22 @@ export interface GSTSummary {
 // Core Functions
 // ────────────────────────────────────────────
 
+/** Split a label into lowercase word tokens ("Food & Dining" -> [food, dining]). */
+function wordTokens(label: string): string[] {
+  return label.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean)
+}
+
 /**
- * Get the GST rate for a label (case-insensitive fuzzy match).
- * Tries exact match first, then partial match against known categories.
+ * Get the GST rate for a label (case-insensitive match).
+ * Tries exact match first, then WORD-BOUNDARY containment against known keys.
+ *
+ * The fallback compares whole word sequences, not raw substrings: a bare
+ * substring test made short keys false-positive traps ("Bus" matched
+ * "Business" -> 5% instead of 18%, "Train" matched "Training", "Gold"
+ * matched "Gold's Gym"). A key matches only when its full word sequence
+ * appears as consecutive whole words in the label (or vice versa), so
+ * "Public Transport" still matches a "Public Transport Pass" label while
+ * "Business Services" no longer trips the "Bus" key.
  */
 function matchRate(
   label: string,
@@ -256,14 +269,32 @@ function matchRate(
     if (key.toLowerCase() === lower) return rate
   }
 
-  // Partial match — label contains a known keyword or vice versa
+  // Word-boundary containment: key words appear consecutively in the label,
+  // or label words appear consecutively in the key.
+  const labelWords = wordTokens(label)
   for (const [key, rate] of Object.entries(rates)) {
-    if (lower.includes(key.toLowerCase()) || key.toLowerCase().includes(lower)) {
+    const keyWords = wordTokens(key)
+    if (
+      containsSequence(labelWords, keyWords) ||
+      containsSequence(keyWords, labelWords)
+    ) {
       return rate
     }
   }
 
   return null
+}
+
+/** True when `needle` appears as a consecutive run inside `haystack`. */
+function containsSequence(haystack: string[], needle: string[]): boolean {
+  if (needle.length === 0 || needle.length > haystack.length) return false
+  outer: for (let i = 0; i <= haystack.length - needle.length; i++) {
+    for (let j = 0; j < needle.length; j++) {
+      if (haystack[i + j] !== needle[j]) continue outer
+    }
+    return true
+  }
+  return false
 }
 
 /**

--- a/frontend/src/lib/gstCalculator.ts
+++ b/frontend/src/lib/gstCalculator.ts
@@ -247,6 +247,42 @@ function wordTokens(label: string): string[] {
 }
 
 /**
+ * Per-rate-table caches, keyed by table object identity. computeGSTAnalysis
+ * calls matchRate once per transaction (7k tx x ~100 table keys), so without
+ * caching the table is re-lowercased/re-tokenized ~700k times per analysis.
+ * The rate tables are module constants (or a stable customRates object), so a
+ * WeakMap keyed on the table keeps this allocation-free across calls.
+ */
+interface TableCache {
+  /** lowercased key -> rate, for the exact-match pass */
+  exact: Map<string, number>
+  /** tokenized keys in insertion order, for the word-boundary pass */
+  tokenized: Array<{ words: string[]; rate: number }>
+  /** memoized resolution: lowercased label -> rate (null = no match) */
+  resolved: Map<string, number | null>
+}
+
+const tableCaches = new WeakMap<Record<string, number>, TableCache>()
+
+function cacheFor(rates: Record<string, number>): TableCache {
+  let cache = tableCaches.get(rates)
+  if (!cache) {
+    cache = {
+      exact: new Map(
+        Object.entries(rates).map(([k, r]) => [k.toLowerCase(), r]),
+      ),
+      tokenized: Object.entries(rates).map(([k, r]) => ({
+        words: wordTokens(k),
+        rate: r,
+      })),
+      resolved: new Map(),
+    }
+    tableCaches.set(rates, cache)
+  }
+  return cache
+}
+
+/**
  * Get the GST rate for a label (case-insensitive match).
  * Tries exact match first, then WORD-BOUNDARY containment against known keys.
  *
@@ -262,27 +298,35 @@ function matchRate(
   label: string,
   rates: Record<string, number>,
 ): number | null {
+  const cache = cacheFor(rates)
   const lower = label.toLowerCase()
 
-  // Exact match (case-insensitive)
-  for (const [key, rate] of Object.entries(rates)) {
-    if (key.toLowerCase() === lower) return rate
-  }
+  const memo = cache.resolved.get(lower)
+  if (memo !== undefined) return memo
 
-  // Word-boundary containment: key words appear consecutively in the label,
-  // or label words appear consecutively in the key.
-  const labelWords = wordTokens(label)
-  for (const [key, rate] of Object.entries(rates)) {
-    const keyWords = wordTokens(key)
-    if (
-      containsSequence(labelWords, keyWords) ||
-      containsSequence(keyWords, labelWords)
-    ) {
-      return rate
+  let result: number | null = null
+
+  // Exact match (case-insensitive)
+  const exact = cache.exact.get(lower)
+  if (exact !== undefined) {
+    result = exact
+  } else {
+    // Word-boundary containment: key words appear consecutively in the label,
+    // or label words appear consecutively in the key.
+    const labelWords = wordTokens(label)
+    for (const { words: keyWords, rate } of cache.tokenized) {
+      if (
+        containsSequence(labelWords, keyWords) ||
+        containsSequence(keyWords, labelWords)
+      ) {
+        result = rate
+        break
+      }
     }
   }
 
-  return null
+  cache.resolved.set(lower, result)
+  return result
 }
 
 /** True when `needle` appears as a consecutive run inside `haystack`. */

--- a/frontend/src/lib/xirr.ts
+++ b/frontend/src/lib/xirr.ts
@@ -5,11 +5,18 @@
  * scattered SIP / lumpsum / withdrawal events, XIRR is the canonical
  * "annualized return" number.
  *
- * Newton-Raphson solver. Returns the rate as a PERCENT (e.g. 12.5 means
- * 12.5 % / year). Returns 0 when:
- *   - fewer than 2 cashflows
- *   - the solver diverges
- *   - derivative goes to ~0 before convergence (flat NPV curve)
+ * Newton-Raphson with bisection fallback. Newton converges in a handful of
+ * iterations near the root, but on loss-making portfolios it overshoots below
+ * -100% en route and the old "return 0 on divergence" guard reported a plain
+ * 45%-loss year as 0% -- a losing portfolio silently displayed as flat. When
+ * Newton leaves the bracket (or oscillates), we now fall back to bisection on
+ * [-99.99%, 1000%], which is guaranteed to converge whenever NPV changes sign
+ * across the bracket (always true for a real portfolio: all-in flows make
+ * NPV -> +inf as rate -> -1, and NPV -> first-flow sign as rate -> inf).
+ *
+ * Returns the rate as a PERCENT (e.g. 12.5 means 12.5 % / year). Returns 0
+ * when there are fewer than 2 cashflows or no sign change exists in the
+ * bracket (degenerate flows, e.g. all inflows).
  *
  * Convention: positive amount = cash INTO the investment (buy / SIP),
  * negative amount = cash OUT (withdrawal / current value treated as an
@@ -24,6 +31,9 @@ export interface CashFlow {
   amount: number
 }
 
+const RATE_MIN = -0.9999
+const RATE_MAX = 10
+
 export function calculateXIRR(
   cashFlows: readonly CashFlow[],
   guess = 0.1,
@@ -32,34 +42,74 @@ export function calculateXIRR(
 ): number {
   if (cashFlows.length < 2) return 0
 
-  const daysBetween = (d1: Date, d2: Date) =>
-    (d2.getTime() - d1.getTime()) / MS_PER_YEAR
-
   const firstDate = cashFlows[0].date
-  let rate = guess
+  const flows = cashFlows.map((cf) => ({
+    years: (cf.date.getTime() - firstDate.getTime()) / MS_PER_YEAR,
+    amount: cf.amount,
+  }))
 
+  const npvAt = (rate: number): number => {
+    let npv = 0
+    for (const f of flows) {
+      npv += f.amount / Math.pow(1 + rate, f.years)
+    }
+    return npv
+  }
+
+  // ── Newton-Raphson (fast path) ──────────────────────────────────
+  let rate = guess
   for (let i = 0; i < maxIterations; i++) {
     let npv = 0
     let dnpv = 0
-
-    for (const cf of cashFlows) {
-      const years = daysBetween(firstDate, cf.date)
-      const factor = Math.pow(1 + rate, years)
-      npv += cf.amount / factor
-      if (years !== 0) {
-        dnpv -= (years * cf.amount) / (factor * (1 + rate))
+    for (const f of flows) {
+      const factor = Math.pow(1 + rate, f.years)
+      npv += f.amount / factor
+      if (f.years !== 0) {
+        dnpv -= (f.years * f.amount) / (factor * (1 + rate))
       }
     }
 
-    if (Math.abs(dnpv) < 1e-12) break
+    if (Math.abs(dnpv) < 1e-12) break // flat curve -> bisection
 
     const newRate = rate - npv / dnpv
-    if (Math.abs(newRate - rate) < tolerance) return newRate * 100
+    if (Math.abs(newRate - rate) < tolerance) {
+      // Converged inside the plausible bracket -> done.
+      if (newRate > RATE_MIN && newRate < RATE_MAX) return newRate * 100
+      break
+    }
     rate = newRate
 
-    // Guard against divergence into absurd territory
-    if (rate < -0.99 || rate > 10) return 0
+    if (rate <= RATE_MIN || rate >= RATE_MAX) break // left bracket -> bisection
   }
 
-  return rate * 100
+  // ── Bisection fallback (robust path) ────────────────────────────
+  // Guaranteed to converge when NPV changes sign across the bracket. The
+  // upper bound expands geometrically because short-horizon gains annualize
+  // to astronomically large but real rates (2x in a month ≈ 409,000%/yr).
+  let lo = RATE_MIN
+  let hi = RATE_MAX
+  let npvLo = npvAt(lo)
+  let npvHi = npvAt(hi)
+  if (!Number.isFinite(npvLo) || !Number.isFinite(npvHi)) return 0
+  while (npvLo * npvHi > 0 && hi < 1e9) {
+    hi *= 10
+    npvHi = npvAt(hi)
+    if (!Number.isFinite(npvHi)) return 0
+  }
+  if (npvLo * npvHi > 0) return 0 // no root anywhere: degenerate flows
+
+  for (let i = 0; i < 200; i++) {
+    const mid = (lo + hi) / 2
+    const npvMid = npvAt(mid)
+    if (Math.abs(npvMid) < tolerance || (hi - lo) / 2 < tolerance) {
+      return mid * 100
+    }
+    if (npvLo * npvMid < 0) {
+      hi = mid
+    } else {
+      lo = mid
+      npvLo = npvMid
+    }
+  }
+  return ((lo + hi) / 2) * 100
 }

--- a/frontend/src/pages/investment-analytics/useInvestmentAnalytics.ts
+++ b/frontend/src/pages/investment-analytics/useInvestmentAnalytics.ts
@@ -266,11 +266,23 @@ export function useInvestmentAnalytics() {
   const filteredGrowthData = useMemo(() => {
     const startDate = dateRange.start_date
     const endDate = dateRange.end_date
-    if (!startDate || !endDate) return dailyGrowthData
-    return dailyGrowthData.filter((item) => {
-      const d = item.fullDate as string
-      return d >= startDate && d <= endDate
-    })
+    const ranged =
+      !startDate || !endDate
+        ? dailyGrowthData
+        : dailyGrowthData.filter((item) => {
+            const d = item.fullDate as string
+            return d >= startDate && d <= endDate
+          })
+    // Long ranges collapse to month-end points: the forward-filled daily
+    // series feeds 4 stacked SVG areas, and an all-time view was painting
+    // ~2,700 points per area (sluggish first paint + hover). Month-end
+    // sampling preserves the shape; short windows keep daily fidelity.
+    if (ranged.length <= 366) return ranged
+    const byMonth = new Map<string, (typeof ranged)[number]>()
+    for (const item of ranged) {
+      byMonth.set((item.fullDate as string).substring(0, 7), item)
+    }
+    return [...byMonth.values()]
   }, [dailyGrowthData, dateRange])
 
   return {

--- a/frontend/src/pages/net-worth/useNetWorth.ts
+++ b/frontend/src/pages/net-worth/useNetWorth.ts
@@ -159,6 +159,15 @@ export function useNetWorth() {
 
   const chartData = useMemo(() => {
     if (!showProjection || monthlyGrowth <= 0 || anchor === null) {
+      // Long ranges collapse to month-end points: an all-time view was
+      // feeding ~1,500 daily points into the SVG area chart (slow paint,
+      // sub-pixel segments), while the projection path below already renders
+      // at monthly resolution. Short windows keep full daily fidelity.
+      if (filteredNetWorthData.length > 366) {
+        const monthly = downsampleToMonthly(chartSeries)
+        const byDate = new Map(filteredNetWorthData.map((p) => [p.date as string, p]))
+        return monthly.map((p) => byDate.get(p.date) ?? { date: p.date, netWorth: p.netWorth })
+      }
       return filteredNetWorthData
     }
     const monthlyHistorical = downsampleToMonthly(chartSeries)


### PR DESCRIPTION
Research-driven algorithm-fit pass: what indexing/algorithms actually fit this project's workload (single-user-scale, ~7k rows, free-tier Postgres), verified empirically, then fixed. Every finding was adversarially verified against the real local DB before implementation; several proposed findings were refuted and NOT implemented.

## Database (the original "best indexing algorithm" question)

**Composite B-trees were already right** for this workload -- what was missing was Postgres/SQLite refinements:

- **Partial indexes over live rows** (`3dec5e5`): every read path filters `is_deleted = false`, so tombstones were dead weight in all six user-scoped composites. Rebuilt with dialect-specific predicates, empirically verified: SQLite matches partial predicates near-textually and SQLAlchemy's `.is_(False)` emits `IS 0`, so the SQLite predicate uses the IS-form (a `= 0` predicate is NOT matched -- EXPLAIN-verified both ways); Postgres proves implication so it gets canonical `= false`. Also drops the stray single-column `is_deleted` index (model drift). ORM-emitted queries confirmed hitting the partial indexes via EXPLAIN QUERY PLAN on the real DB.

## Correctness fixes (real-DB reproductions)

- **XIRR bisection fallback** (`6fb9e70`): Newton-Raphson overshoots below -100% on loss portfolios; the divergence guard returned 0 -- a 45%-loss year displayed as 0% XIRR. Newton stays the fast path; bracket-escape falls back to bisection on [-99.99%, 1000%] (geometric upper-bound expansion for short-horizon gains). Reproduced -45%, -99.5%, and monthly-2x cases.
- **GST word-boundary matching** (`5b1ea9a`): substring fallback made "Bus" match "Business" (5% instead of 18%), "Train" match "Training". Word-token sequence containment; regression tests.
- **Recurring detection** (`13b8200`): mean-of-gaps telescopes to span/(n-1) and one skipped month collapsed confidence. Median banding + skip folding + skip-rate penalty. Real-DB effect: 33 -> 77 detected streams (45 rescued, 1 correctly dropped). expected_amount: median (a stray small row dragged a salary stream 32% low); variance: 1.4826*MAD. Confirmed-pattern lookup also keys the normalized label so confirmed streams stop duplicating on refresh.
- **Rules retro-apply** (`9d225b6`): rehash collision check ignored soft-deleted PKs -> duplicate-PK 500; now seeds from the full id keyspace. Per-row child lookups + expire_on_commit refreshes -> bulk IN()-chunked prefetch + batched commits.
- **Anomaly detection** (`f7c5b88`): month detector used all-time median+MAD on a non-stationary series (every recent month "anomalous" vs years-old levels) -> trailing-12-month rolling baseline. Large-txn ratio>=3 flagged 14.4% of ALL expenses -> per-user materiality floor + log-space modified-Z gate (~2% after). Cross-type cap evicted 20/21 month anomalies -> per-shape cap (25 month slots). Dismissed anomalies resurrected on every refresh -> reviewed-key suppression with None-guards.

## Performance

- **Command palette** (`f0e9fa0`): useDeferredValue is not a debounce -- every keystroke fired a server search. 300ms debounce (hook extracted from TransactionFilters as the single source of truth) + keepPreviousData.
- **GST caching** (`d494e19`): matchRate re-tokenized the ~100-key table per transaction (~700k redundant ops per analysis). WeakMap table cache + label memo.
- **Chart downsampling** (`7315d79`): net-worth (~1.5k pts) and investment growth (~2.7k pts x 4 stacked areas) fed daily series into SVG on long ranges; >366-day ranges now collapse to month-end points.

## Explicitly evaluated and NOT adopted (with reasons)
- BRIN indexes (needs millions of rows; B-trees are kilobytes here), hash indexes (Postgres docs: rarely better), GIN (no full-text search feature yet), LSM/learned indexes (write-optimized/research-tier; ingest is a monthly Excel upload), Redis cache layer (TanStack Query staleTime=Infinity + rollup tables already fill that role at this scale).
- A covering-INCLUDE index on the rollup path was considered and skipped: the hot rollups read from the pre-aggregated summary tables, not raw transactions, so there is no index-only-scan win to take.

## Verification
- Backend: 340 tests pass (12 new), ruff + mypy clean. Migration applied to the real local DB; EXPLAIN plans confirmed before/after.
- Frontend: 288 tests pass (8 new/updated), tsc + eslint clean.
- Deferred (needs a product/migration decision): persisting a stable normalized_key for renamed confirmed recurring patterns (schema change); noted in the recurring commit body.