### PR TITLE
fix: ux batch - net worth forecast, settings save bar, account case folding, byok bedrock, theme modes, nav dedupe

### DIFF
--- a/backend/src/ledger_sync/api/ai_chat.py
+++ b/backend/src/ledger_sync/api/ai_chat.py
@@ -45,7 +45,12 @@ from ledger_sync.api.ai_usage import (
 from ledger_sync.api.deps import CurrentUser, DatabaseSession
 from ledger_sync.api.rate_limit import limiter, user_limiter
 from ledger_sync.config.settings import settings
+from ledger_sync.core.encryption import DecryptionError, decrypt_api_key
 from ledger_sync.db.models import UserPreferences
+
+# Legacy placeholder the frontend used to send for Bedrock configs before
+# per-user bearer tokens were supported. Treated as "no user key".
+_LEGACY_BEDROCK_PLACEHOLDER = "bedrock-uses-aws-credentials"
 
 router = APIRouter(prefix="/api/ai", tags=["ai"])
 
@@ -233,27 +238,44 @@ def bedrock_chat_proxy(
             ]
         }
 
-    # Pre-flight: if no auth mechanism is reachable, give a clear error instead
-    # of letting boto3 surface its misleading "model identifier is invalid"
-    # exception (which is what it says when it can't sign the request).
-    has_bearer = bool(os.environ.get("AWS_BEARER_TOKEN_BEDROCK"))
-    has_sigv4 = bool(os.environ.get("AWS_ACCESS_KEY_ID")) or bool(os.environ.get("AWS_PROFILE"))
-    if not has_bearer and not has_sigv4:
-        raise HTTPException(
-            status_code=503,
-            detail=(
-                "Bedrock is not configured on the server. Set "
-                "LEDGER_SYNC_BEDROCK_API_KEY (or AWS_BEARER_TOKEN_BEDROCK) "
-                "in the backend environment."
-            ),
-        )
+    # BYOK Bedrock: if the user stored their own Bedrock API key (bearer
+    # token), the call is signed with THEIR key -- they pay AWS directly and
+    # the app's shared-key message cap does not apply (their own token caps
+    # do). The legacy placeholder string means "no user key".
+    user_bearer: str | None = None
+    if prefs.ai_mode == "byok" and prefs.ai_provider == "bedrock" and prefs.ai_api_key_encrypted:
+        try:
+            candidate, _needs_reencrypt = decrypt_api_key(prefs.ai_api_key_encrypted)
+        except DecryptionError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail="Stored Bedrock key cannot be decrypted -- re-enter it in Settings.",
+            ) from exc
+        if candidate and candidate != _LEGACY_BEDROCK_PLACEHOLDER:
+            user_bearer = candidate
 
-    # This proxy ALWAYS signs with the server's Bedrock credential (there is
-    # no per-user AWS key path), so every call through it — app_bedrock OR
-    # byok+bedrock — spends the shared server token. Enforce the app-wide daily
-    # message cap regardless of mode so a user cannot bypass cost control by
-    # flipping to byok. BYOK's optional per-user token caps still apply on top.
-    check_app_message_limit(session, current_user.id)
+    if user_bearer is None:
+        # Server-credential path. Pre-flight: if no auth mechanism is
+        # reachable, give a clear error instead of letting boto3 surface its
+        # misleading "model identifier is invalid" exception (which is what
+        # it says when it can't sign the request).
+        has_bearer = bool(os.environ.get("AWS_BEARER_TOKEN_BEDROCK"))
+        has_sigv4 = bool(os.environ.get("AWS_ACCESS_KEY_ID")) or bool(os.environ.get("AWS_PROFILE"))
+        if not has_bearer and not has_sigv4:
+            raise HTTPException(
+                status_code=503,
+                detail=(
+                    "Bedrock is not configured on the server. Set "
+                    "LEDGER_SYNC_BEDROCK_API_KEY (or AWS_BEARER_TOKEN_BEDROCK) "
+                    "in the backend environment, or paste your own Bedrock "
+                    "API key in Settings > AI Assistant."
+                ),
+            )
+        # Shared-key spend: enforce the app-wide daily message cap regardless
+        # of mode so a user cannot bypass cost control by flipping to byok
+        # without bringing a key.
+        check_app_message_limit(session, current_user.id)
+
     if prefs.ai_mode != "app_bedrock":
         check_token_limits(session, current_user.id)
 
@@ -272,7 +294,22 @@ def bedrock_chat_proxy(
     )
 
     try:
-        client = boto3.client("bedrock-runtime", region_name=region, config=bedrock_config)
+        if user_bearer is not None:
+            # Per-user Bedrock API key: skip SigV4 (no server creds needed)
+            # and attach the user's bearer token to the request. Scoped to
+            # this client instance -- never mutates process env, so
+            # concurrent users cannot leak keys into each other's calls.
+            from botocore import UNSIGNED  # type: ignore[import-untyped]
+
+            unsigned_config = bedrock_config.merge(Config(signature_version=UNSIGNED))
+            client = boto3.client("bedrock-runtime", region_name=region, config=unsigned_config)
+
+            def _attach_bearer(request: Any, **_kwargs: Any) -> None:
+                request.headers["Authorization"] = f"Bearer {user_bearer}"
+
+            client.meta.events.register("request-created.bedrock-runtime", _attach_bearer)
+        else:
+            client = boto3.client("bedrock-runtime", region_name=region, config=bedrock_config)
         response = client.converse(**kwargs)
     except Exception as exc:
         # Surface the real boto/AWS error to the client so the UI can display

--- a/backend/src/ledger_sync/core/sync_engine.py
+++ b/backend/src/ledger_sync/core/sync_engine.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 from ledger_sync.core import rules
 from ledger_sync.core.analytics_engine import AnalyticsEngine
 from ledger_sync.core.reconciler import Reconciler, ReconciliationStats
-from ledger_sync.db.models import ImportLog
+from ledger_sync.db.models import ImportLog, Transaction
 from ledger_sync.ingest.csv_loader import CsvLoader
 from ledger_sync.ingest.excel_loader import ExcelLoader
 from ledger_sync.ingest.normalizer import DataNormalizer, NormalizationError
@@ -61,6 +61,44 @@ class SyncEngine:
             raise ValueError(msg)
         return existing_import
 
+    def _canonicalize_account_casing(self, normalized_rows: list[dict[str, Any]]) -> None:
+        """Fold case-variant account names onto one canonical spelling.
+
+        "CC: Axis Google Flex" and "CC: AXIS Google Flex" are the same real
+        account; letting both through creates two accounts everywhere
+        downstream (balances, net worth, classifications). Canonical form is
+        chosen per lowercased key: the spelling already stored in this user's
+        transactions wins (so re-uploads converge on existing data), else the
+        first spelling seen in this batch. Runs BEFORE hashing because the
+        account name feeds the SHA-256 transaction_id.
+
+        Transfer rows keep ``category`` in sync ("Transfer: A → B" embeds the
+        account names) so the displayed label matches the folded accounts.
+        """
+        # Seed with existing spellings from the user's ledger (all three legs).
+        canonical: dict[str, str] = {}
+        if self.user_id is not None:
+            for column in (Transaction.account, Transaction.from_account, Transaction.to_account):
+                stmt = (
+                    select(column)
+                    .where(Transaction.user_id == self.user_id, column.is_not(None))
+                    .distinct()
+                )
+                for (name,) in self.session.execute(stmt):
+                    canonical.setdefault(name.lower(), name)
+
+        def fold(name: str | None) -> str | None:
+            if not name:
+                return name
+            return canonical.setdefault(name.lower(), name)
+
+        for row in normalized_rows:
+            row["account"] = fold(row.get("account"))
+            if row.get("is_transfer", False):
+                row["from_account"] = fold(row.get("from_account"))
+                row["to_account"] = fold(row.get("to_account"))
+                row["category"] = f"Transfer: {row['from_account']} → {row['to_account']}"
+
     def _reconcile_and_log(
         self,
         normalized_rows: list[dict[str, Any]],
@@ -84,6 +122,8 @@ class SyncEngine:
             if active_rules:
                 for row in normalized_rows:
                     rules.apply_rules_to_row(active_rules, row)
+
+        self._canonicalize_account_casing(normalized_rows)
 
         transactions = [r for r in normalized_rows if not r.get("is_transfer", False)]
         transfers = [r for r in normalized_rows if r.get("is_transfer", False)]

--- a/backend/src/ledger_sync/db/migrations/versions/20260715_1000_fold_case_variant_accounts.py
+++ b/backend/src/ledger_sync/db/migrations/versions/20260715_1000_fold_case_variant_accounts.py
@@ -1,0 +1,203 @@
+"""fold case-variant account names onto one canonical spelling
+
+Revision ID: account_case_fold_2026
+Revises: partial_tx_indexes_2026
+Create Date: 2026-07-15 10:00:00.000000
+
+"CC: Axis Google Flex" and "CC: AXIS Google Flex" are the same real
+account, but the app treated them as two: two rows in Settings ->
+Account Classifications, two balances on the net-worth page, split
+analytics. The transaction hash lowercases account names, so re-uploads
+never duplicated rows -- but the stored ``account`` field is not
+updateable, so rows imported before a casing fix kept the old spelling
+forever alongside newer rows with the new spelling.
+
+This migration folds every case-variant group (per user) onto one
+canonical spelling -- the spelling used by the most transaction rows --
+across:
+
+- ``transactions`` (account, from_account, to_account) and the
+  "Transfer: A → B" category label that embeds the account names
+- ``account_classifications`` (duplicate rows merged, most recently
+  updated row wins the classification value)
+- ``scheduled_transactions`` / ``recurring_transactions``
+- ``user_preferences.excluded_accounts`` (JSON array of exact names)
+
+Rollup tables (transfer_flows, investment_holdings, summaries) are
+rebuilt from transactions on the next analytics refresh, so they are
+left untouched. Import-time canonicalization in
+``SyncEngine._canonicalize_account_casing`` keeps future uploads from
+reintroducing variants.
+
+Follows the repo convention of an empty ``downgrade()`` (restore from a
+database backup to roll back).
+"""
+
+import json
+from collections import defaultdict
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "account_case_fold_2026"
+down_revision: str | None = "partial_tx_indexes_2026"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+_ACCOUNT_LEGS = ("account", "from_account", "to_account")
+
+
+def _build_canonical_map(bind: sa.Connection) -> dict[tuple[int, str], str]:
+    """Map (user_id, lowercased name) -> canonical spelling.
+
+    Canonical = the spelling backing the most transaction rows across all
+    three account legs (ties broken by first-seen). Only groups with more
+    than one spelling are returned.
+    """
+    counts: dict[tuple[int, str], dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    for col in _ACCOUNT_LEGS:
+        rows = bind.execute(
+            sa.text(
+                f"SELECT user_id, {col}, COUNT(*) FROM transactions "  # noqa: S608
+                f"WHERE {col} IS NOT NULL GROUP BY user_id, {col}"
+            )
+        )
+        for user_id, name, n in rows:
+            counts[(user_id, name.lower())][name] += n
+
+    return {
+        key: max(spellings.items(), key=lambda kv: kv[1])[0]
+        for key, spellings in counts.items()
+        if len(spellings) > 1
+    }
+
+
+def _fold_transactions(bind: sa.Connection, canonical: dict[tuple[int, str], str]) -> None:
+    for (user_id, low), canon in canonical.items():
+        for col in _ACCOUNT_LEGS:
+            bind.execute(
+                sa.text(
+                    f"UPDATE transactions SET {col} = :canon "  # noqa: S608
+                    f"WHERE user_id = :uid AND LOWER({col}) = :low AND {col} != :canon"
+                ),
+                {"canon": canon, "uid": user_id, "low": low},
+            )
+
+    # Transfer categories embed the account names ("Transfer: A → B");
+    # rebuild any label that drifted from the folded from/to pair.
+    xfers = bind.execute(
+        sa.text(
+            "SELECT transaction_id, from_account, to_account, category FROM transactions "
+            "WHERE type = 'TRANSFER' AND from_account IS NOT NULL AND to_account IS NOT NULL"
+        )
+    ).fetchall()
+    for tx_id, from_account, to_account, category in xfers:
+        expected = f"Transfer: {from_account} → {to_account}"
+        if category != expected:
+            bind.execute(
+                sa.text("UPDATE transactions SET category = :cat WHERE transaction_id = :tid"),
+                {"cat": expected, "tid": tx_id},
+            )
+
+
+def _fold_classifications(bind: sa.Connection, canonical: dict[tuple[int, str], str]) -> None:
+    """Merge duplicate classification rows and align spellings to canonical.
+
+    Ordered newest-first so the keeper (first member) carries the user's
+    latest classification choice. The (user_id, account_name) unique index
+    means duplicates must be deleted before the keeper is renamed.
+    """
+    rows = bind.execute(
+        sa.text(
+            "SELECT id, user_id, account_name FROM account_classifications "
+            "ORDER BY updated_at DESC, id DESC"
+        )
+    ).fetchall()
+
+    groups: dict[tuple[int, str], list] = defaultdict(list)
+    for row in rows:
+        groups[(row.user_id, row.account_name.lower())].append(row)
+
+    for key, members in groups.items():
+        canon = canonical.get(key)
+        keeper = next((m for m in members if m.account_name == canon), members[0])
+        target_name = canon or keeper.account_name
+
+        for member in members:
+            if member.id != keeper.id:
+                bind.execute(
+                    sa.text("DELETE FROM account_classifications WHERE id = :id"),
+                    {"id": member.id},
+                )
+        if keeper.account_name != target_name:
+            bind.execute(
+                sa.text("UPDATE account_classifications SET account_name = :name WHERE id = :id"),
+                {"name": target_name, "id": keeper.id},
+            )
+
+
+def _fold_planning_tables(bind: sa.Connection, canonical: dict[tuple[int, str], str]) -> None:
+    for table in ("scheduled_transactions", "recurring_transactions"):
+        for (user_id, low), canon in canonical.items():
+            bind.execute(
+                sa.text(
+                    f"UPDATE {table} SET account = :canon "  # noqa: S608
+                    f"WHERE user_id = :uid AND LOWER(account) = :low AND account != :canon"
+                ),
+                {"canon": canon, "uid": user_id, "low": low},
+            )
+
+
+def _fold_excluded_accounts(bind: sa.Connection, canonical: dict[tuple[int, str], str]) -> None:
+    prefs = bind.execute(
+        sa.text("SELECT user_id, excluded_accounts FROM user_preferences")
+    ).fetchall()
+    for user_id, raw in prefs:
+        try:
+            names = json.loads(raw or "[]")
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(names, list):
+            continue
+
+        folded: list[str] = []
+        seen: set[str] = set()
+        changed = False
+        for name in names:
+            if not isinstance(name, str):
+                folded.append(name)
+                continue
+            canon = canonical.get((user_id, name.lower()), name)
+            changed = changed or canon != name
+            if canon.lower() in seen:
+                changed = True
+                continue
+            seen.add(canon.lower())
+            folded.append(canon)
+
+        if changed:
+            bind.execute(
+                sa.text(
+                    "UPDATE user_preferences SET excluded_accounts = :val WHERE user_id = :uid"
+                ),
+                {"val": json.dumps(folded), "uid": user_id},
+            )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    canonical = _build_canonical_map(bind)
+
+    if canonical:
+        _fold_transactions(bind, canonical)
+        _fold_planning_tables(bind, canonical)
+        _fold_excluded_accounts(bind, canonical)
+
+    # Classifications can hold case-variants even when transactions are
+    # already consistent (stale rows from before a casing fix), so this
+    # runs unconditionally.
+    _fold_classifications(bind, canonical)
+
+
+def downgrade() -> None:
+    """No downgrade -- restore from a database backup."""

--- a/backend/tests/integration/test_account_case_folding.py
+++ b/backend/tests/integration/test_account_case_folding.py
@@ -1,0 +1,122 @@
+"""Import-time canonicalization of case-variant account names.
+
+"CC: Axis Google Flex" and "CC: AXIS Google Flex" are the same real
+account; SyncEngine._canonicalize_account_casing folds every spelling of a
+lowercased key onto one canonical form before hashing, so downstream
+consumers (balances, net worth, classifications) see a single account.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from ledger_sync.core.sync_engine import SyncEngine
+from ledger_sync.db.models import Transaction, User
+
+
+def _row(**overrides: Any) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "date": "2026-06-01",
+        "amount": 250.0,
+        "currency": "INR",
+        "type": "Expense",
+        "account": "CC: Axis Google Flex",
+        "category": "Food",
+        "subcategory": None,
+        "note": "swiggy order",
+    }
+    row.update(overrides)
+    return row
+
+
+def _accounts(session: Session, user: User) -> set[str]:
+    rows = (
+        session.query(Transaction.account).filter(Transaction.user_id == user.id).distinct().all()
+    )
+    return {r[0] for r in rows}
+
+
+def test_case_variants_within_one_batch_fold_to_first_spelling(two_user_client) -> None:
+    _, session, user_a, _, _ = two_user_client
+    engine = SyncEngine(session, user_id=user_a.id)
+
+    rows = [
+        _row(note="order 1"),
+        _row(account="CC: AXIS Google Flex", note="order 2"),
+        _row(account="cc: axis google flex", note="order 3"),
+    ]
+    stats = engine.import_rows(rows, file_name="june.xlsx", file_hash="hash-1")
+
+    assert stats.inserted == 3
+    assert _accounts(session, user_a) == {"CC: Axis Google Flex"}
+
+
+def test_new_upload_folds_onto_existing_ledger_spelling(two_user_client) -> None:
+    _, session, user_a, _, _ = two_user_client
+    engine = SyncEngine(session, user_id=user_a.id)
+
+    engine.import_rows([_row()], file_name="june.xlsx", file_hash="hash-1")
+    # Second file spells the same account differently -- existing wins.
+    engine.import_rows(
+        [_row(account="CC: AXIS GOOGLE FLEX", note="order 2")],
+        file_name="july.xlsx",
+        file_hash="hash-2",
+    )
+
+    assert _accounts(session, user_a) == {"CC: Axis Google Flex"}
+
+
+def test_transfer_legs_and_category_label_fold_together(two_user_client) -> None:
+    _, session, user_a, _, _ = two_user_client
+    engine = SyncEngine(session, user_id=user_a.id)
+
+    engine.import_rows(
+        [_row(account="Bank: SBI", note="opening")],
+        file_name="june.xlsx",
+        file_hash="hash-1",
+    )
+    engine.import_rows(
+        [
+            {
+                "date": "2026-06-02",
+                "amount": 500.0,
+                "currency": "INR",
+                "type": "Transfer-Out",
+                "account": "bank: sbi",
+                "category": "Wallet: GPay",
+                "subcategory": None,
+                "note": "top-up",
+            }
+        ],
+        file_name="july.xlsx",
+        file_hash="hash-2",
+    )
+
+    xfer = (
+        session.query(Transaction)
+        .filter(Transaction.user_id == user_a.id, Transaction.from_account.is_not(None))
+        .one()
+    )
+    assert xfer.from_account == "Bank: SBI"
+    assert xfer.account == "Bank: SBI"
+    assert xfer.category == "Transfer: Bank: SBI → Wallet: GPay"
+
+
+def test_folding_is_user_scoped(two_user_client) -> None:
+    # "PayTM" is deliberately NOT in BANK_CANONICAL_NAMES: known bank tokens
+    # (Axis, HDFC, ...) are already re-cased by _standardize_account for every
+    # user, which would mask the scoping behaviour under test.
+    _, session, user_a, user_b, _ = two_user_client
+
+    SyncEngine(session, user_id=user_a.id).import_rows(
+        [_row(account="Wallet: PayTM")], file_name="a.xlsx", file_hash="hash-a"
+    )
+    # User B's own spelling must NOT fold onto user A's canonical form.
+    SyncEngine(session, user_id=user_b.id).import_rows(
+        [_row(account="Wallet: PAYTM")], file_name="b.xlsx", file_hash="hash-b"
+    )
+
+    assert _accounts(session, user_a) == {"Wallet: PayTM"}
+    assert _accounts(session, user_b) == {"Wallet: PAYTM"}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,13 +23,15 @@
     <script>
       (function () {
         try {
-          var m = localStorage.getItem('ledger-sync-theme') || 'light';
-          var resolved = m === 'system'
-            ? (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark')
-            : m;
+          var m = localStorage.getItem('ledger-sync-theme');
+          // Explicit choice wins; no value (or the legacy 'system') follows
+          // the OS preference -- the default for new users.
+          var resolved = (m === 'dark' || m === 'light')
+            ? m
+            : (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
           document.documentElement.dataset.theme = resolved;
           // Keep the mobile browser chrome in step with the selected theme.
-          var bar = resolved === 'light' ? '#f7f7f5' : '#101112';
+          var bar = resolved === 'light' ? '#eaf0f7' : '#0a0f16';
           var setMeta = function (name, content) {
             var el = document.querySelector('meta[name="' + name + '"]');
             if (el) el.setAttribute('content', content);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -139,22 +139,16 @@ function NotFoundPage() {
   )
 }
 
-// Keeps the resolved theme in sync when the OS color-scheme changes while the
-// user is in 'system' mode. The initial theme is already applied pre-paint by
-// the inline script in index.html; this re-applies on store mount (covering a
-// localStorage value the inline script also read) and watches OS changes.
+// Re-applies the resolved theme on store mount. The initial theme is already
+// applied pre-paint by the inline script in index.html; modes are now just
+// dark/light (new users default to the OS preference at load time), so there
+// is no live OS watcher anymore.
 function ThemeWatcher() {
-  const mode = useThemeStore((s) => s.mode)
   const syncResolved = useThemeStore((s) => s.syncResolved)
 
   useEffect(() => {
     syncResolved()
-    if (mode !== 'system') return
-    const mq = globalThis.matchMedia('(prefers-color-scheme: light)')
-    const onChange = () => syncResolved()
-    mq.addEventListener('change', onChange)
-    return () => mq.removeEventListener('change', onChange)
-  }, [mode, syncResolved])
+  }, [syncResolved])
 
   return null
 }

--- a/frontend/src/components/layout/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar/Sidebar.tsx
@@ -24,6 +24,7 @@ import {
   dashboardItem,
   navigationSections,
   overviewItem,
+  transactionsItem,
   utilityItems,
 } from './navConfig'
 import SidebarItem from './SidebarItem'
@@ -198,6 +199,12 @@ export default function Sidebar() {
                 to={overviewItem.path}
                 icon={overviewItem.icon}
                 label={overviewItem.label}
+                onNavigate={closeMobile}
+              />
+              <SidebarItem
+                to={transactionsItem.path}
+                icon={transactionsItem.icon}
+                label={transactionsItem.label}
                 onNavigate={closeMobile}
               />
             </div>

--- a/frontend/src/components/layout/Sidebar/ThemeToggle.tsx
+++ b/frontend/src/components/layout/Sidebar/ThemeToggle.tsx
@@ -1,16 +1,16 @@
-import { Sun, Moon, Monitor } from 'lucide-react'
+import { Sun, Moon } from 'lucide-react'
 
 import { useThemeStore } from '@/store/themeStore'
 import type { ThemeMode } from '@/lib/theme'
 
 /**
- * Quick theme cycler for the sidebar utility bar: light -> dark -> system.
- * Shows the icon for the current mode; full Light/Dark/System control lives
- * in Settings > Display. Reads/writes the shared themeStore.
+ * Quick theme toggle for the sidebar utility bar: light <-> dark.
+ * Shows the icon for the current mode. Reads/writes the shared themeStore.
+ * (New users start on their OS preference; the toggle stores an explicit choice.)
  */
-const NEXT: Record<ThemeMode, ThemeMode> = { light: 'dark', dark: 'system', system: 'light' }
-const ICON = { light: Sun, dark: Moon, system: Monitor }
-const LABEL = { light: 'Light', dark: 'Dark', system: 'System' }
+const NEXT: Record<ThemeMode, ThemeMode> = { light: 'dark', dark: 'light' }
+const ICON = { light: Sun, dark: Moon }
+const LABEL = { light: 'Light', dark: 'Dark' }
 
 export default function ThemeToggle() {
   const mode = useThemeStore((s) => s.mode)
@@ -22,7 +22,7 @@ export default function ThemeToggle() {
       type="button"
       onClick={() => setMode(NEXT[mode])}
       className="flex size-11 items-center justify-center rounded-md text-text-tertiary transition-colors duration-150 hover:bg-surface-hover hover:text-foreground lg:size-9"
-      title={`Theme: ${LABEL[mode]} (tap to change)`}
+      title={`Theme: ${LABEL[mode]} (tap to switch to ${LABEL[NEXT[mode]]})`}
       aria-label={`Theme: ${LABEL[mode]}. Tap to switch to ${LABEL[NEXT[mode]]}.`}
     >
       <Icon size={18} />

--- a/frontend/src/components/layout/Sidebar/navConfig.ts
+++ b/frontend/src/components/layout/Sidebar/navConfig.ts
@@ -49,6 +49,15 @@ export const overviewItem: NavItem = {
 }
 
 /**
+ * Transactions is a first-class destination (it's one of the four mobile tabs),
+ * so it sits top-level with Dashboard and Overview rather than alone in a
+ * single-item "Data" group.
+ */
+export const transactionsItem: NavItem = {
+  path: ROUTES.TRANSACTIONS, label: 'Transactions', icon: Receipt,
+}
+
+/**
  * Sections are ordered to follow the natural money decision-flow --
  * "where did it go -> what comes in -> what's left -> grow it -> plan ahead ->
  * what I owe" -- so the sidebar reads like how people think about their money
@@ -104,20 +113,13 @@ export const navigationSections: NavSection[] = [
       { path: ROUTES.GST_ANALYSIS, label: 'Indirect Tax (GST)', icon: Receipt },
     ],
   },
-  {
-    title: 'Data',
-    items: [
-      { path: ROUTES.TRANSACTIONS, label: 'Transactions', icon: Receipt },
-      { path: ROUTES.UPLOAD, label: 'Upload & Sync', icon: Upload },
-      { path: ROUTES.SETTINGS, label: 'Settings', icon: Settings2 },
-    ],
-  },
 ]
 
 /**
- * Bottom utility bar keeps quick access to Upload (the core recurring task, E)
- * and Settings as icons, even though both now also live in the Data section --
- * a power user mid-task shouldn't have to scroll the nav to re-sync.
+ * Bottom utility bar is the single home for Upload & Sync and Settings --
+ * always visible above the profile, no scrolling through the nav groups.
+ * They were previously duplicated in the Data section; the duplication read
+ * as two different destinations, so the list entries were dropped.
  */
 export const utilityItems: NavItem[] = [
   { path: ROUTES.UPLOAD, label: 'Upload & Sync', icon: Upload },

--- a/frontend/src/lib/chatAdapters.ts
+++ b/frontend/src/lib/chatAdapters.ts
@@ -12,6 +12,8 @@
  *   `content` and the adapters wrap it into a single text block.
  */
 
+import { API_BASE_URL } from '@/constants'
+
 // --- Public types ------------------------------------------------------------
 
 export type Block =
@@ -336,7 +338,9 @@ async function callBedrock(params: SendParams): Promise<ChatResponse> {
     messages: params.messages.map(toBedrockWireMessage),
     tools: params.tools,
   }
-  const res = await fetch('/api/ai/bedrock/chat', {
+  // MUST be absolute against the backend host: a relative /api path resolves
+  // to GitHub Pages in production, whose static host answers POST with 405.
+  const res = await fetch(`${API_BASE_URL}/api/ai/bedrock/chat`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/frontend/src/lib/theme.ts
+++ b/frontend/src/lib/theme.ts
@@ -1,39 +1,47 @@
 /**
- * Theme handling. Three modes:
- *  - 'dark'   -> always dark
- *  - 'light'  -> always the default ledger workspace theme
- *  - 'system' -> follow the OS `prefers-color-scheme`
+ * Theme handling. Two modes:
+ *  - 'dark'  -> dark ledger workspace
+ *  - 'light' -> light ledger workspace
+ *
+ * New users default to their OS `prefers-color-scheme`; once they toggle,
+ * the explicit choice persists in localStorage under `ledger-sync-theme`.
  *
  * The resolved theme is written to `data-theme` on <html>; index.css defines
- * `[data-theme='light']` token overrides. The setting persists in localStorage
- * under `ledger-sync-theme`. An inline script in index.html applies it before
- * first paint (no flash); this module keeps it in sync at runtime.
+ * `[data-theme='light']` token overrides. An inline script in index.html
+ * applies it before first paint (no flash); this module keeps it in sync at
+ * runtime.
  */
 
 import { refreshRawColors } from '@/constants/colors'
 
-export type ThemeMode = 'dark' | 'light' | 'system'
+export type ThemeMode = 'dark' | 'light'
 
 export const THEME_STORAGE_KEY = 'ledger-sync-theme'
 
-/** Read the stored mode, defaulting to the light ledger workspace. */
+/** OS-level preference, used as the default for users with no stored choice. */
+export function osPreferredTheme(): ThemeMode {
+  const prefersLight =
+    globalThis.matchMedia?.('(prefers-color-scheme: light)').matches ?? false
+  return prefersLight ? 'light' : 'dark'
+}
+
+/**
+ * Read the stored mode. An explicit stored choice wins; anything else
+ * (no value, or the legacy 'system' value from before that mode was removed)
+ * falls back to the OS preference.
+ */
 export function getStoredThemeMode(): ThemeMode {
   try {
     const v = localStorage.getItem(THEME_STORAGE_KEY)
-    if (v === 'dark' || v === 'light' || v === 'system') return v
+    if (v === 'dark' || v === 'light') return v
   } catch {
     // localStorage may be unavailable (private mode / quota) -- fall through.
   }
-  return 'light'
+  return osPreferredTheme()
 }
 
-/** Resolve a mode to the concrete theme to paint ('dark' | 'light'). */
+/** Resolve a mode to the concrete theme to paint. Identity now that 'system' is gone. */
 export function resolveTheme(mode: ThemeMode): 'dark' | 'light' {
-  if (mode === 'system') {
-    const prefersLight =
-      globalThis.matchMedia?.('(prefers-color-scheme: light)').matches ?? false
-    return prefersLight ? 'light' : 'dark'
-  }
   return mode
 }
 
@@ -70,7 +78,8 @@ export function applyTheme(resolved: 'dark' | 'light', skipTransition = false): 
 
   // Keep the mobile browser chrome (theme-color / color-scheme) tracking the
   // active theme on a live toggle, mirroring the pre-paint script in index.html.
-  const bar = resolved === 'light' ? '#f7f7f5' : '#101112'
+  // Values match the --color-background tokens in index.css.
+  const bar = resolved === 'light' ? '#eaf0f7' : '#0a0f16'
   document.querySelector('meta[name="theme-color"]')?.setAttribute('content', bar)
   document.querySelector('meta[name="color-scheme"]')?.setAttribute('content', resolved)
 

--- a/frontend/src/pages/net-worth/components/AccountCategoryTable.tsx
+++ b/frontend/src/pages/net-worth/components/AccountCategoryTable.tsx
@@ -131,9 +131,6 @@ export function AccountCategoryTable({
               % Allocated
             </th>
             <th className="text-right py-3 px-4 text-sm font-semibold text-muted-foreground">
-              Type
-            </th>
-            <th className="text-right py-3 px-4 text-sm font-semibold text-muted-foreground">
               Transactions
             </th>
           </tr>
@@ -212,9 +209,6 @@ export function AccountCategoryTable({
                           <AllocationCell balance={catBalance} total={total} barColor={barColor} />
                         </td>
                         <td className="py-2 px-4 text-right text-sm font-medium text-muted-foreground/70">
-                          n/a
-                        </td>
-                        <td className="py-2 px-4 text-right text-sm font-medium text-muted-foreground/70">
                           {catTransactions}
                         </td>
                       </tr>,
@@ -241,9 +235,6 @@ export function AccountCategoryTable({
                             total={total}
                             barColor={barColor}
                           />
-                        </td>
-                        <td className="py-3 px-4 text-right text-muted-foreground">
-                          {getAccountType(accountName)}
                         </td>
                         <td className="py-3 px-4 text-right text-muted-foreground">
                           {accountData.transactions}

--- a/frontend/src/pages/net-worth/components/NetWorthTrendChart.tsx
+++ b/frontend/src/pages/net-worth/components/NetWorthTrendChart.tsx
@@ -298,10 +298,11 @@ export function NetWorthTrendChart(props: Readonly<NetWorthTrendChartProps>) {
                   )}
                 </>
               )}
-              {/* Drag-to-zoom on the x-axis. Default window is the most-recent
-                  third of the data so the chart still reads at full fidelity
-                  on first paint; users can drag either traveller to widen or
-                  narrow the view without touching the global time filter. */}
+              {/* Drag-to-zoom on the x-axis. Default window: most-recent third
+                  of the HISTORY. When projecting, chartData appends 60 months
+                  of forecast -- a blind "last third" window would show ONLY
+                  the flat dashed projection with zero historical context, so
+                  anchor the window to start ~12 months before "now" instead. */}
               {chartData.length > 6 && (
                 <Brush
                   {...BRUSH_DEFAULTS}
@@ -309,7 +310,20 @@ export function NetWorthTrendChart(props: Readonly<NetWorthTrendChartProps>) {
                   tickFormatter={(value: string) =>
                     formatDate(value, { month: 'short', year: '2-digit' })
                   }
-                  startIndex={Math.max(0, chartData.length - Math.ceil(chartData.length / 3))}
+                  startIndex={(() => {
+                    if (!showProjectionLine) {
+                      return Math.max(0, chartData.length - Math.ceil(chartData.length / 3))
+                    }
+                    // Last historical point = last row with a non-null netWorth.
+                    let anchorIdx = chartData.length - 1
+                    for (let i = chartData.length - 1; i >= 0; i--) {
+                      if (chartData[i].netWorth != null) {
+                        anchorIdx = i
+                        break
+                      }
+                    }
+                    return Math.max(0, anchorIdx - 12)
+                  })()}
                 />
               )}
             </AreaChart>

--- a/frontend/src/pages/settings/SettingsPage.tsx
+++ b/frontend/src/pages/settings/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion'
+import { AnimatePresence, motion } from 'framer-motion'
 import { Save, RotateCcw } from 'lucide-react'
 import { PageContainer, PageHeader } from '@/components/ui'
 import ConfirmDialog from '@/components/ui/ConfirmDialog'
@@ -227,6 +227,37 @@ export default function SettingsPage() {
           variant="warning"
           onConfirm={s.handleReset}
         />
+
+        {/* Floating save bar: settings sections run several screens deep, so
+            saving must not require scrolling back to the header. Appears only
+            with unsaved changes; sits above the mobile tab bar. */}
+        <AnimatePresence>
+          {s.hasChanges && (
+            <motion.div
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 16 }}
+              transition={{ duration: 0.18 }}
+              className="fixed inset-x-0 z-40 flex justify-center px-4 bottom-[calc(68px+env(safe-area-inset-bottom,0px)+0.75rem)] lg:bottom-[calc(env(safe-area-inset-bottom,0px)+1.25rem)]"
+            >
+              <div className="flex items-center gap-3 rounded-lg border border-[var(--hairline-2)] bg-surface-dropdown/95 px-4 py-2.5 shadow-[var(--glass-shadow-strong)] backdrop-blur-lg">
+                <span className="flex items-center gap-1.5 text-sm text-app-yellow">
+                  <span className="h-2 w-2 animate-pulse rounded-full bg-app-yellow" />
+                  Unsaved changes
+                </span>
+                <motion.button
+                  whileTap={{ scale: 0.97 }}
+                  onClick={s.handleSave}
+                  disabled={s.isSaving}
+                  className="flex items-center gap-2 rounded-md border border-foreground bg-foreground px-4 py-1.5 text-sm font-medium text-background transition-colors hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <Save className="h-4 w-4" />
+                  <span>{s.isSaving ? 'Saving...' : 'Save'}</span>
+                </motion.button>
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
     </PageContainer>
   )
 }

--- a/frontend/src/pages/settings/sections/AIAssistantSection.tsx
+++ b/frontend/src/pages/settings/sections/AIAssistantSection.tsx
@@ -129,7 +129,9 @@ export default function AIAssistantSection({ index }: Readonly<Props>) {
     saveMutation.mutate({
       provider,
       model,
-      api_key: isBedrock(provider) ? 'bedrock-uses-aws-credentials' : apiKey,
+      // Bedrock: the user's API key (bearer token) when provided; the legacy
+      // placeholder keeps the shared server credential path.
+      api_key: isBedrock(provider) && !apiKey ? 'bedrock-uses-aws-credentials' : apiKey,
       region: isBedrock(provider) ? region : undefined,
     })
   }

--- a/frontend/src/pages/settings/sections/DisplayPreferencesSection.tsx
+++ b/frontend/src/pages/settings/sections/DisplayPreferencesSection.tsx
@@ -5,7 +5,7 @@
  * from the CURRENCIES metadata map.
  */
 
-import { Settings2, Sun, Moon, Monitor, type LucideIcon } from 'lucide-react'
+import { Settings2, Sun, Moon, type LucideIcon } from 'lucide-react'
 import { CURRENCIES, getCurrencyMeta } from '@/constants/currencies'
 import { useThemeStore } from '@/store/themeStore'
 import type { ThemeMode } from '@/lib/theme'
@@ -25,7 +25,6 @@ const currencyList = Object.values(CURRENCIES)
 const THEME_OPTIONS: { value: ThemeMode; label: string; Icon: LucideIcon }[] = [
   { value: 'light', label: 'Light', Icon: Sun },
   { value: 'dark', label: 'Dark', Icon: Moon },
-  { value: 'system', label: 'System', Icon: Monitor },
 ]
 
 export default function DisplayPreferencesSection({
@@ -159,7 +158,7 @@ export default function DisplayPreferencesSection({
               </label>
             ))}
           </div>
-          <FieldHint>System follows your device's light/dark setting.</FieldHint>
+          <FieldHint>New users start on their device's light/dark preference.</FieldHint>
         </div>
       </div>
     </Section>

--- a/frontend/src/pages/settings/sections/ai/ByokConfigForm.tsx
+++ b/frontend/src/pages/settings/sections/ai/ByokConfigForm.tsx
@@ -37,7 +37,11 @@ export function ByokConfigForm(props: Readonly<ByokConfigFormProps>) {
     setTestStatus,
   } = props
   const providerModels = MODELS[provider] ?? []
-  const needsApiKey = provider && !isBedrock(provider)
+  // Every provider takes a key now: OpenAI/Anthropic keys are used browser-
+  // direct; a Bedrock API key (bearer token) is stored encrypted and used by
+  // the server proxy to sign calls with YOUR AWS account instead of the
+  // app's shared credential.
+  const needsApiKey = Boolean(provider)
 
   return (
     <>
@@ -64,7 +68,7 @@ export function ByokConfigForm(props: Readonly<ByokConfigFormProps>) {
         </select>
         <FieldHint>
           {isBedrock(provider)
-            ? 'Bedrock uses server-side AWS credentials (env vars or ~/.aws/credentials).'
+            ? 'Paste a Bedrock API key (bearer token from the AWS console). Calls are proxied through the server and signed with YOUR key -- leave empty to use the shared app credential.'
             : 'Your API key is encrypted and stored securely. LLM calls go directly from your browser to the provider.'}
         </FieldHint>
       </div>

--- a/frontend/src/pages/settings/sections/ai/aiConstants.ts
+++ b/frontend/src/pages/settings/sections/ai/aiConstants.ts
@@ -20,12 +20,24 @@ export const MODELS: Record<string, { value: string; label: string }[]> = {
     { value: 'claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5' },
   ],
   bedrock: [
+    // Anthropic Claude (US cross-region inference profiles)
+    { value: 'us.anthropic.claude-fable-5', label: 'Claude Fable 5 (Bedrock)' },
+    { value: 'us.anthropic.claude-sonnet-5', label: 'Claude Sonnet 5 (Bedrock)' },
+    { value: 'us.anthropic.claude-opus-4-8', label: 'Claude Opus 4.8 (Bedrock)' },
     { value: 'us.anthropic.claude-opus-4-7', label: 'Claude Opus 4.7 (Bedrock)' },
     { value: 'us.anthropic.claude-sonnet-4-6', label: 'Claude Sonnet 4.6 (Bedrock)' },
     {
       value: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
       label: 'Claude Haiku 4.5 (Bedrock)',
     },
+    // Amazon Nova
+    { value: 'us.amazon.nova-pro-v1:0', label: 'Amazon Nova Pro (Bedrock)' },
+    { value: 'us.amazon.nova-lite-v1:0', label: 'Amazon Nova Lite (Bedrock)' },
+    { value: 'us.amazon.nova-micro-v1:0', label: 'Amazon Nova Micro (Bedrock)' },
+    // Meta Llama
+    { value: 'us.meta.llama3-3-70b-instruct-v1:0', label: 'Llama 3.3 70B (Bedrock)' },
+    // DeepSeek
+    { value: 'us.deepseek.r1-v1:0', label: 'DeepSeek R1 (Bedrock)' },
   ],
 }
 

--- a/frontend/src/store/themeStore.ts
+++ b/frontend/src/store/themeStore.ts
@@ -1,11 +1,10 @@
 /**
  * Theme store -- single source of truth for the active theme mode.
  *
- * Holds the user's chosen `mode` ('dark' | 'light' | 'system') and the
- * `resolved` concrete theme ('dark' | 'light'). Setting the mode persists it
- * and applies `data-theme` to <html> via the theme lib. A `ThemeWatcher`
- * (mounted in App) keeps `resolved` in sync when the OS preference changes
- * while in 'system' mode.
+ * Holds the user's chosen `mode` ('dark' | 'light') and the `resolved`
+ * concrete theme. Setting the mode persists it and applies `data-theme` to
+ * <html> via the theme lib. New users default to the OS preference (resolved
+ * once at load); the toggle stores an explicit choice.
  */
 
 import { create } from 'zustand'


### PR DESCRIPTION
## What

Batch of 8 UX and bug fixes from live usage screenshots.

**Net worth**
- Forecast view was unusable: the default brush window landed entirely inside the 60-month projection tail, showing only a flat dashed line with zero history. The window now anchors to the last historical point minus 12 months, so you see recent history, the "Now" marker, the median projection, and the confidence band together.
- Dropped the redundant Type column from the Assets/Liabilities tables. The grouped category headers already carry that information.

**Settings**
- Floating save bar. The page runs several screens deep; saving no longer requires scrolling back to the header. The bar appears only with unsaved changes, mirrors the header Save/Unsaved state, and sits above the mobile tab bar.

**Accounts**
- Case-variant account names ("CC: Axis Google Flex" vs "CC: AXIS Google Flex") no longer split into two accounts. Import now folds every spelling of the same lowercased name onto one canonical form (existing ledger spelling wins), including transfer legs and the "Transfer: A -> B" label. A data migration folds existing variants across transactions, classifications (duplicate rows merged), scheduled/recurring transactions, and the excluded-accounts preference. Rollups rebuild on the next analytics refresh.

**Theme**
- Appearance is now Dark/Light only; the System option is gone. New users start on their device's OS preference (resolved once pre-paint in index.html). Legacy stored "system" values fall through to the OS preference.

**AI assistant**
- Fixed the production "Bedrock error 405": the chat proxy fetch used a relative `/api` path, which resolved to the GitHub Pages static host. Now absolute against `API_BASE_URL`.
- BYOK Bedrock is now a real BYOK path: the settings form shows an API key field for Bedrock (bearer token from the AWS console), the backend decrypts the user key and signs the Bedrock call with it via an UNSIGNED-config client and a per-request Authorization header. Leaving the key empty keeps the shared app credential (with the existing daily message cap). User-key calls skip the shared-key cap.
- Expanded the Bedrock model list: Fable 5, Sonnet 5, Opus 4.8, Nova Pro/Lite/Micro, Llama 3.3 70B, DeepSeek R1, alongside the existing Claude options.

**Navigation**
- Upload & Sync and Settings appeared twice in the sidebar (Data group + utility icons above the profile). The utility icons are now their single home; Transactions moved to a top-level entry with Dashboard and Overview, and the one-item Data group is gone.

## Testing

- Backend: 344 pytest passing, ruff clean, mypy clean. New integration tests cover batch folding, existing-spelling wins, transfer leg + label folding, and user scoping.
- Migration verified against a copy of the real dev DB seeded with the exact screenshot scenario (two classification rows, variant transactions): folds to one account, one classification row, zero drifted transfer labels.
- Frontend: tsc, eslint, 304 vitest passing. Verified live in the browser: forecast chart shows history + projection band, Type column gone, floating save bar appears above the mobile tab bar on change, sidebar shows single Upload/Settings entries.
