### PR TITLE
feat: closed-account status - keep history, stop expecting new activity

### DIFF
--- a/backend/src/ledger_sync/api/account_classifications.py
+++ b/backend/src/ledger_sync/api/account_classifications.py
@@ -1,14 +1,23 @@
 """Account classification API endpoints."""
 
+from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
 from sqlalchemy import select
 
 from ledger_sync.api.deps import CurrentUser, DatabaseSession
-from ledger_sync.db.models import AccountClassification, AccountType
+from ledger_sync.db.models import AccountClassification, AccountType, RecurringTransaction
 
 router = APIRouter(prefix="/api/account-classifications", tags=["account-classifications"])
+
+
+class AccountStatusUpdate(BaseModel):
+    """Body for the close/reopen endpoint."""
+
+    account_name: str
+    is_closed: bool
 
 
 @router.get("")
@@ -26,6 +35,75 @@ async def get_all_classifications(
     classifications = db.execute(stmt).scalars().all()
 
     return {clf.account_name: clf.account_type.value for clf in classifications}
+
+
+@router.get("/closed")
+async def get_closed_accounts(
+    current_user: CurrentUser,
+    db: DatabaseSession,
+) -> list[str]:
+    """List account names the user has marked closed."""
+    stmt = select(AccountClassification.account_name).where(
+        AccountClassification.user_id == current_user.id,
+        AccountClassification.is_closed.is_(True),
+    )
+    return list(db.execute(stmt).scalars().all())
+
+
+@router.put("/status")
+async def set_account_status(
+    body: AccountStatusUpdate,
+    current_user: CurrentUser,
+    db: DatabaseSession,
+) -> dict[str, Any]:
+    """Mark an account closed or reopen it.
+
+    Creates the classification row (type Other) if the account was never
+    classified, so unclassified accounts can still be closed.
+    """
+    stmt = select(AccountClassification).where(
+        AccountClassification.account_name == body.account_name,
+        AccountClassification.user_id == current_user.id,
+    )
+    classification = db.execute(stmt).scalar()
+
+    if not classification:
+        classification = AccountClassification(
+            account_name=body.account_name,
+            account_type=AccountType.OTHER_WALLETS,
+            user_id=current_user.id,
+        )
+        db.add(classification)
+
+    classification.is_closed = body.is_closed
+    classification.closed_date = datetime.now(UTC) if body.is_closed else None
+
+    # Apply the forward-looking consequences immediately instead of waiting
+    # for the next analytics refresh: a closed account has no future cash
+    # flows, so its recurring/bill expectations deactivate right away.
+    # Reopening restores user-confirmed patterns; auto-detected ones are
+    # recreated by the next detection pass anyway.
+    recurring_query = db.query(RecurringTransaction).filter(
+        RecurringTransaction.user_id == current_user.id,
+        RecurringTransaction.account == body.account_name,
+    )
+    if body.is_closed:
+        recurring_query.filter(RecurringTransaction.is_active.is_(True)).update(
+            {"is_active": False, "last_updated": datetime.now(UTC)}
+        )
+    else:
+        recurring_query.filter(
+            RecurringTransaction.is_active.is_(False),
+            RecurringTransaction.is_user_confirmed.is_(True),
+        ).update({"is_active": True, "last_updated": datetime.now(UTC)})
+
+    db.commit()
+
+    return {
+        "account_name": classification.account_name,
+        "is_closed": classification.is_closed,
+        "status": "success",
+    }
 
 
 @router.get("/{account_name}")

--- a/backend/src/ledger_sync/core/analytics/anomalies.py
+++ b/backend/src/ledger_sync/core/analytics/anomalies.py
@@ -52,8 +52,13 @@ from typing import Any
 from sqlalchemy import delete, func
 
 from ledger_sync.core.analytics.base import AnalyticsEngineBase
-from ledger_sync.core.query_helpers import apply_excluded_accounts_filter, fmt_year_month
+from ledger_sync.core.query_helpers import (
+    apply_excluded_accounts_filter,
+    closed_accounts_for,
+    fmt_year_month,
+)
 from ledger_sync.db.models import (
+    AccountClassification,
     Anomaly,
     AnomalyType,
     Budget,
@@ -116,6 +121,7 @@ class AnomaliesMixin(AnalyticsEngineBase):
 
         self._detect_high_expense_months(anomalies_detected, z_cutoff)
         self._detect_large_transactions(anomalies_detected)
+        self._detect_closed_account_activity(anomalies_detected)
 
         # Suppress findings the user already reviewed/dismissed BEFORE the cap,
         # so a dismissed anomaly neither resurrects as a fresh unreviewed row
@@ -369,6 +375,58 @@ class AnomaliesMixin(AnalyticsEngineBase):
                     "deviation_pct": ((float(txn.amount) - baseline) / baseline) * 100,
                 },
             )
+
+    def _detect_closed_account_activity(self, anomalies: list[dict[str, Any]]) -> None:
+        """Flag transactions landing on a closed account after its close date.
+
+        Statements routinely trail closures in India by a cycle or two
+        (refunds, final interest, reversal entries), so new activity is
+        imported normally -- this just surfaces it for review instead of
+        silently absorbing it. Only rows dated AFTER the recorded close
+        date count; the account's own history never triggers it.
+        """
+        closed = closed_accounts_for(self.db, self.user_id)
+        if not closed:
+            return
+
+        close_dates: dict[str, datetime] = {
+            row.account_name: row.closed_date
+            for row in self.db.query(AccountClassification)
+            .filter(
+                AccountClassification.user_id == self.user_id,
+                AccountClassification.is_closed.is_(True),
+                AccountClassification.closed_date.is_not(None),
+            )
+            .all()
+            # The SQL filter already excludes NULLs; this narrows for mypy.
+            if row.closed_date is not None
+        }
+        if not close_dates:
+            return
+
+        sym = self._currency_symbol
+        for account, closed_at in close_dates.items():
+            late_txns = (
+                self._user_transaction_query()
+                .filter(Transaction.account == account, Transaction.date > closed_at)
+                .order_by(Transaction.date.desc())
+                .limit(5)
+                .all()
+            )
+            for txn in late_txns:
+                anomalies.append(
+                    {
+                        "type": AnomalyType.CLOSED_ACCOUNT_ACTIVITY,
+                        "severity": "medium",
+                        "description": (
+                            f"Activity on closed account {account}: "
+                            f"{sym}{float(txn.amount):,.0f} ({txn.category}) "
+                            f"on {txn.date.strftime('%d %b %Y')}"
+                        ),
+                        "transaction_id": txn.transaction_id,
+                        "actual_value": Decimal(str(txn.amount)),
+                    },
+                )
 
     # ─── budget tracking (unchanged behavior; kept in this mixin) ─────────
 

--- a/backend/src/ledger_sync/core/analytics/recurring.py
+++ b/backend/src/ledger_sync/core/analytics/recurring.py
@@ -130,68 +130,79 @@ class RecurringMixin(AnalyticsEngineBase):
             if closed and all(t.account in closed for t in txns):
                 continue
 
-            dates = [t.date for t in txns]
-            amounts = [float(t.amount) for t in txns]
-
-            # Detect frequency
-            frequency, confidence, expected_day = self._detect_frequency(dates)
-            if not frequency or confidence < min_conf:
-                continue
-
-            # Median + scaled MAD: recurring groups routinely mix a dominant
-            # regular amount with a few small adjustment rows under the same
-            # note, and a mean/stdev pair gets dragged far from the typical
-            # payment. 1.4826 scales MAD to stdev-like units.
-            avg_amount = median(amounts)
-            amount_variance = (
-                1.4826 * median(abs(a - avg_amount) for a in amounts) if len(amounts) > 1 else 0.0
+            count += self._upsert_recurring_pattern(
+                label, txn_type, txns, confirmed_names, min_conf
             )
-
-            info = _resolve_pattern_display(
-                txns,
-                dates,
-                avg_amount,
-                amount_variance,
-                frequency,
-                confidence,
-                expected_day,
-                txn_type,
-            )
-
-            # If a user-confirmed record matches, update its stats instead
-            if label in confirmed_names:
-                existing = confirmed_names[label]
-                existing.occurrences_detected = info["occurrences"]
-                existing.last_occurrence = info["last_occurrence"]
-                existing.confidence_score = info["confidence"]
-                existing.expected_amount = info["expected_amount"]
-                existing.amount_variance = info["amount_variance"]
-                existing.last_updated = datetime.now(UTC)
-                count += 1
-                continue
-
-            recurring = RecurringTransaction(
-                user_id=self.user_id,
-                pattern_name=info["pattern_name"],
-                category=info["category"],
-                subcategory=info["subcategory"],
-                account=info["account"],
-                transaction_type=TransactionType(info["txn_type"]),
-                frequency=info["frequency"],
-                expected_amount=info["expected_amount"],
-                amount_variance=info["amount_variance"],
-                expected_day=info["expected_day"],
-                confidence_score=info["confidence"],
-                occurrences_detected=info["occurrences"],
-                last_occurrence=info["last_occurrence"],
-                is_active=True,
-                first_detected=datetime.now(UTC),
-                last_updated=datetime.now(UTC),
-            )
-            self.db.add(recurring)
-            count += 1
 
         return count
+
+    def _upsert_recurring_pattern(
+        self,
+        label: str,
+        txn_type: str,
+        txns: list[Transaction],
+        confirmed_names: dict[str, RecurringTransaction],
+        min_conf: float,
+    ) -> int:
+        """Detect one pattern group and persist it; returns 1 if kept, else 0."""
+        dates = [t.date for t in txns]
+        amounts = [float(t.amount) for t in txns]
+
+        frequency, confidence, expected_day = self._detect_frequency(dates)
+        if not frequency or confidence < min_conf:
+            return 0
+
+        # Median + scaled MAD: recurring groups routinely mix a dominant
+        # regular amount with a few small adjustment rows under the same
+        # note, and a mean/stdev pair gets dragged far from the typical
+        # payment. 1.4826 scales MAD to stdev-like units.
+        avg_amount = median(amounts)
+        amount_variance = (
+            1.4826 * median(abs(a - avg_amount) for a in amounts) if len(amounts) > 1 else 0.0
+        )
+
+        info = _resolve_pattern_display(
+            txns,
+            dates,
+            avg_amount,
+            amount_variance,
+            frequency,
+            confidence,
+            expected_day,
+            txn_type,
+        )
+
+        # If a user-confirmed record matches, update its stats instead
+        if label in confirmed_names:
+            existing = confirmed_names[label]
+            existing.occurrences_detected = info["occurrences"]
+            existing.last_occurrence = info["last_occurrence"]
+            existing.confidence_score = info["confidence"]
+            existing.expected_amount = info["expected_amount"]
+            existing.amount_variance = info["amount_variance"]
+            existing.last_updated = datetime.now(UTC)
+            return 1
+
+        recurring = RecurringTransaction(
+            user_id=self.user_id,
+            pattern_name=info["pattern_name"],
+            category=info["category"],
+            subcategory=info["subcategory"],
+            account=info["account"],
+            transaction_type=TransactionType(info["txn_type"]),
+            frequency=info["frequency"],
+            expected_amount=info["expected_amount"],
+            amount_variance=info["amount_variance"],
+            expected_day=info["expected_day"],
+            confidence_score=info["confidence"],
+            occurrences_detected=info["occurrences"],
+            last_occurrence=info["last_occurrence"],
+            is_active=True,
+            first_detected=datetime.now(UTC),
+            last_updated=datetime.now(UTC),
+        )
+        self.db.add(recurring)
+        return 1
 
     def _detect_frequency(
         self,

--- a/backend/src/ledger_sync/core/analytics/recurring.py
+++ b/backend/src/ledger_sync/core/analytics/recurring.py
@@ -20,6 +20,7 @@ from ledger_sync.core._analytics_helpers import (
     resolve_pattern_display as _resolve_pattern_display,
 )
 from ledger_sync.core.analytics.base import AnalyticsEngineBase
+from ledger_sync.core.query_helpers import closed_accounts_for
 from ledger_sync.db.models import (
     RecurrenceFrequency,
     RecurringTransaction,
@@ -112,9 +113,21 @@ class RecurringMixin(AnalyticsEngineBase):
         confirmed_names = self._load_confirmed_recurring()
         min_conf = self.recurring_min_confidence
 
+        # A closed account has no future cash flows: don't create new
+        # recurring expectations on it, and deactivate confirmed ones so
+        # the bill calendar / missed-payment logic stops expecting them.
+        closed = closed_accounts_for(self.db, self.user_id)
+        for existing in confirmed_names.values():
+            if existing.account in closed and existing.is_active:
+                existing.is_active = False
+                existing.last_updated = datetime.now(UTC)
+
         count = 0
         for (label, txn_type), txns in patterns.items():
             if len(txns) < 3:  # Need at least 3 occurrences
+                continue
+
+            if closed and all(t.account in closed for t in txns):
                 continue
 
             dates = [t.date for t in txns]

--- a/backend/src/ledger_sync/core/query_helpers.py
+++ b/backend/src/ledger_sync/core/query_helpers.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import Query, Session
 from sqlalchemy.sql.selectable import Subquery
 
 from ledger_sync.config.settings import settings
-from ledger_sync.db.models import Transaction, TransactionType, User
+from ledger_sync.db.models import AccountClassification, Transaction, TransactionType, User
 
 # ---------------------------------------------------------------------------
 # Database-agnostic date formatting
@@ -166,6 +166,28 @@ def excluded_accounts_for(user: User) -> set[str]:
     if not isinstance(parsed, list):
         return set()
     return {str(a) for a in parsed if a}
+
+
+def closed_accounts_for(session: Session, user_id: int | None) -> set[str]:
+    """Return the names of accounts the user has marked closed.
+
+    Closed accounts keep their history in analytics (unlike
+    ``excluded_accounts``) but stop being treated as alive: recurring/bill
+    expectations are suppressed and pickers omit them. Consumers that only
+    need the forward-looking distinction should use this, not the excluded
+    set.
+    """
+    if user_id is None:
+        return set()
+    rows = (
+        session.query(AccountClassification.account_name)
+        .filter(
+            AccountClassification.user_id == user_id,
+            AccountClassification.is_closed.is_(True),
+        )
+        .all()
+    )
+    return {r[0] for r in rows}
 
 
 def apply_excluded_accounts_filter[QueryT: Query[Any]](query: QueryT, excluded: set[str]) -> QueryT:

--- a/backend/src/ledger_sync/db/_models/enums.py
+++ b/backend/src/ledger_sync/db/_models/enums.py
@@ -26,6 +26,7 @@ class AnomalyType(PyEnum):
     DUPLICATE_SUSPECTED = "duplicate_suspected"
     MISSING_RECURRING = "missing_recurring"
     BUDGET_EXCEEDED = "budget_exceeded"
+    CLOSED_ACCOUNT_ACTIVITY = "closed_account_activity"
 
 
 class RecurrenceFrequency(PyEnum):

--- a/backend/src/ledger_sync/db/_models/transactions.py
+++ b/backend/src/ledger_sync/db/_models/transactions.py
@@ -198,6 +198,12 @@ class AccountClassification(Base):
         default=AccountType.OTHER_WALLETS,
     )
 
+    # Closed accounts keep their history in analytics but stop being treated
+    # as alive: no recurring/bill expectations, no credit-card limit config,
+    # not offered in account pickers. closed_date is informational only.
+    is_closed: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    closed_date: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
     # Metadata
     created_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, default=lambda: datetime.now(UTC)

--- a/backend/src/ledger_sync/db/migrations/versions/20260721_1000_add_closed_account_status.py
+++ b/backend/src/ledger_sync/db/migrations/versions/20260721_1000_add_closed_account_status.py
@@ -1,0 +1,41 @@
+"""add is_closed + closed_date to account_classifications
+
+Revision ID: closed_accounts_2026
+Revises: account_case_fold_2026
+Create Date: 2026-07-21 10:00:00.000000
+
+Closed accounts (a credit card the user cancelled, an old bank account)
+keep their transaction history in analytics, but the app stops treating
+them as alive: recurring/bill expectations are suppressed, credit-card
+limit config is hidden, and account pickers omit them. ``closed_date``
+is informational.
+
+server_default='false' backfills existing rows as open; the ORM default
+covers new rows.
+
+Follows the repo convention of an empty ``downgrade()`` (restore from a
+database backup to roll back).
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "closed_accounts_2026"
+down_revision: str | None = "account_case_fold_2026"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "account_classifications",
+        sa.Column("is_closed", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.add_column(
+        "account_classifications",
+        sa.Column("closed_date", sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """No downgrade -- restore from a database backup."""

--- a/backend/tests/integration/test_closed_accounts.py
+++ b/backend/tests/integration/test_closed_accounts.py
@@ -1,0 +1,179 @@
+"""Closed-account status: API, recurring deactivation, anomaly detection.
+
+A closed account keeps its transaction history in analytics but stops being
+treated as alive -- no recurring/bill expectations, and post-closure activity
+is surfaced as a review anomaly rather than silently absorbed.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+from ledger_sync.core.analytics_engine import AnalyticsEngine
+from ledger_sync.db.models import (
+    AccountClassification,
+    Anomaly,
+    AnomalyType,
+    RecurrenceFrequency,
+    RecurringTransaction,
+    Transaction,
+    TransactionType,
+)
+
+
+def _txn(user_id: int, tx_id: str, account: str, date: datetime, amount: float) -> Transaction:
+    return Transaction(
+        transaction_id=tx_id,
+        user_id=user_id,
+        date=date,
+        amount=Decimal(str(amount)),
+        currency="INR",
+        type=TransactionType.EXPENSE,
+        account=account,
+        category="Food",
+        subcategory=None,
+        note="lunch",
+        source_file="test.xlsx",
+        last_seen_at=datetime.now(UTC),
+        is_deleted=False,
+    )
+
+
+def _recurring(user_id: int, account: str, *, confirmed: bool) -> RecurringTransaction:
+    now = datetime.now(UTC)
+    return RecurringTransaction(
+        user_id=user_id,
+        pattern_name="Netflix",
+        category="Entertainment",
+        subcategory=None,
+        account=account,
+        transaction_type=TransactionType.EXPENSE,
+        frequency=RecurrenceFrequency.MONTHLY,
+        expected_amount=Decimal("649"),
+        amount_variance=Decimal("0"),
+        expected_day=5,
+        confidence_score=90,
+        occurrences_detected=6,
+        last_occurrence=now,
+        is_active=True,
+        is_user_confirmed=confirmed,
+        first_detected=now,
+        last_updated=now,
+    )
+
+
+def test_status_endpoint_closes_and_reopens(two_user_client) -> None:
+    client, session, user_a, _, _ = two_user_client
+
+    r = client.put(
+        "/api/account-classifications/status",
+        json={"account_name": "CC: Old Axis", "is_closed": True},
+    )
+    assert r.status_code == 200
+    assert r.json()["is_closed"] is True
+
+    row = (
+        session.query(AccountClassification)
+        .filter_by(user_id=user_a.id, account_name="CC: Old Axis")
+        .one()
+    )
+    assert row.is_closed is True
+    assert row.closed_date is not None
+    assert client.get("/api/account-classifications/closed").json() == ["CC: Old Axis"]
+
+    r = client.put(
+        "/api/account-classifications/status",
+        json={"account_name": "CC: Old Axis", "is_closed": False},
+    )
+    assert r.json()["is_closed"] is False
+    session.expire_all()
+    assert row.closed_date is None
+    assert client.get("/api/account-classifications/closed").json() == []
+
+
+def test_closing_deactivates_recurring_reopening_restores_confirmed(two_user_client) -> None:
+    client, session, user_a, _, _ = two_user_client
+    confirmed = _recurring(user_a.id, "CC: Old Axis", confirmed=True)
+    auto = _recurring(user_a.id, "CC: Old Axis", confirmed=False)
+    auto.pattern_name = "Spotify"
+    session.add_all([confirmed, auto])
+    session.commit()
+
+    client.put(
+        "/api/account-classifications/status",
+        json={"account_name": "CC: Old Axis", "is_closed": True},
+    )
+    session.expire_all()
+    assert confirmed.is_active is False
+    assert auto.is_active is False
+
+    client.put(
+        "/api/account-classifications/status",
+        json={"account_name": "CC: Old Axis", "is_closed": False},
+    )
+    session.expire_all()
+    assert confirmed.is_active is True  # user-confirmed comes back
+    assert auto.is_active is False  # auto-detected waits for the next detection pass
+
+
+def test_recurring_detection_skips_closed_accounts(two_user_client) -> None:
+    _, session, user_a, _, _ = two_user_client
+    base = datetime(2026, 1, 5, tzinfo=UTC)
+    for i in range(6):
+        session.add(
+            _txn(
+                user_a.id, f"closed_rec_{i:02d}", "CC: Old Axis", base + timedelta(days=30 * i), 649
+            )
+        )
+    session.add(
+        AccountClassification(
+            user_id=user_a.id,
+            account_name="CC: Old Axis",
+            is_closed=True,
+            closed_date=datetime.now(UTC),
+        )
+    )
+    session.commit()
+
+    engine = AnalyticsEngine(session, user_id=user_a.id)
+    engine._detect_recurring_transactions()  # noqa: SLF001
+    session.commit()
+
+    patterns = (
+        session.query(RecurringTransaction).filter_by(user_id=user_a.id, is_active=True).all()
+    )
+    assert patterns == []
+
+
+def test_anomaly_flags_activity_after_close_date_only(two_user_client) -> None:
+    _, session, user_a, _, _ = two_user_client
+    closed_at = datetime(2026, 6, 1, tzinfo=UTC)
+    # history before closure (must NOT flag) + one refund after (must flag)
+    session.add(
+        _txn(user_a.id, "before_close_01", "CC: Old Axis", closed_at - timedelta(days=40), 500)
+    )
+    session.add(
+        _txn(user_a.id, "after_close_01", "CC: Old Axis", closed_at + timedelta(days=20), 1200)
+    )
+    session.add(
+        AccountClassification(
+            user_id=user_a.id,
+            account_name="CC: Old Axis",
+            is_closed=True,
+            closed_date=closed_at,
+        )
+    )
+    session.commit()
+
+    engine = AnalyticsEngine(session, user_id=user_a.id)
+    engine._detect_anomalies()  # noqa: SLF001
+    session.commit()
+
+    flagged = (
+        session.query(Anomaly)
+        .filter_by(user_id=user_a.id, anomaly_type=AnomalyType.CLOSED_ACCOUNT_ACTIVITY)
+        .all()
+    )
+    assert [a.transaction_id for a in flagged] == ["after_close_01"]
+    assert "CC: Old Axis" in flagged[0].description

--- a/frontend/src/hooks/api/useAccountStatus.ts
+++ b/frontend/src/hooks/api/useAccountStatus.ts
@@ -1,0 +1,37 @@
+/**
+ * Closed-account status hooks.
+ *
+ * Closed accounts keep their history in analytics but stop being treated as
+ * alive (no recurring/bill expectations, no card-limit config, omitted from
+ * pickers). The toggle applies immediately -- it has backend side effects
+ * (recurring deactivation) -- so it is not batched behind the Settings Save.
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+import { analyticsV2Keys } from '@/hooks/api/useAnalyticsV2'
+import { accountClassificationsService } from '@/services/api/accountClassifications'
+
+const CLOSED_ACCOUNTS_KEY = ['account-classifications', 'closed'] as const
+
+export function useClosedAccounts() {
+  return useQuery({
+    queryKey: CLOSED_ACCOUNTS_KEY,
+    queryFn: accountClassificationsService.getClosedAccounts,
+    staleTime: Infinity,
+    gcTime: 60 * 60 * 1000,
+  })
+}
+
+export function useSetAccountStatus() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ accountName, isClosed }: { accountName: string; isClosed: boolean }) =>
+      accountClassificationsService.setAccountStatus(accountName, isClosed),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: CLOSED_ACCOUNTS_KEY })
+      // Recurring expectations flip server-side with the status change.
+      queryClient.invalidateQueries({ queryKey: analyticsV2Keys.all })
+    },
+  })
+}

--- a/frontend/src/pages/AnomalyReviewPage.tsx
+++ b/frontend/src/pages/AnomalyReviewPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react'
 
 import { motion, AnimatePresence } from 'framer-motion'
-import { TrendingUp, HelpCircle, ArrowRightLeft, AlertTriangle, AlertCircle, Info, Check, X, ChevronDown, ChevronUp, Settings2, Save, SlidersHorizontal } from 'lucide-react'
+import { TrendingUp, HelpCircle, ArrowRightLeft, AlertTriangle, AlertCircle, Archive, Info, Check, X, ChevronDown, ChevronUp, Settings2, Save, SlidersHorizontal } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { toast } from 'sonner'
 
@@ -25,6 +25,7 @@ const ANOMALY_TYPE_LABELS: Record<Anomaly['anomaly_type'], string> = {
   unusual_category: 'Unusual Category',
   large_transfer: 'Large Transfer',
   budget_exceeded: 'Budget Exceeded',
+  closed_account_activity: 'Closed Account Activity',
 }
 
 const ANOMALY_TYPE_ICONS: Record<Anomaly['anomaly_type'], typeof TrendingUp> = {
@@ -32,6 +33,7 @@ const ANOMALY_TYPE_ICONS: Record<Anomaly['anomaly_type'], typeof TrendingUp> = {
   unusual_category: HelpCircle,
   large_transfer: ArrowRightLeft,
   budget_exceeded: AlertTriangle,
+  closed_account_activity: Archive,
 }
 
 // Distinct icon per severity so the level reads without relying on colour alone.
@@ -251,6 +253,7 @@ export default function AnomalyReviewPage() {
             <option value="unusual_category">Unusual Category</option>
             <option value="large_transfer">Large Transfer</option>
             <option value="budget_exceeded">Budget Exceeded</option>
+            <option value="closed_account_activity">Closed Account Activity</option>
           </select>
 
           <select

--- a/frontend/src/pages/AnomalyReviewPage.tsx
+++ b/frontend/src/pages/AnomalyReviewPage.tsx
@@ -394,6 +394,7 @@ export default function AnomalyReviewPage() {
                   <div className="mt-4 ml-0 sm:ml-11 space-y-2">
                     <div className="flex flex-wrap items-center gap-2">
                       <button
+                        type="button"
                         onClick={() => handleReview(anomaly.id, false)}
                         disabled={reviewMutation.isPending}
                         className="flex items-center gap-1.5 px-3 py-2.5 min-h-11 text-xs rounded-lg bg-app-green/10 text-app-green border border-app-green/20 hover:bg-app-green/20 transition-colors disabled:opacity-50"
@@ -401,6 +402,7 @@ export default function AnomalyReviewPage() {
                         <Check className="w-3 h-3" /> Review
                       </button>
                       <button
+                        type="button"
                         onClick={() => handleReview(anomaly.id, true)}
                         disabled={reviewMutation.isPending}
                         className="flex items-center gap-1.5 px-3 py-2.5 min-h-11 text-xs rounded-lg bg-app-red/10 text-app-red border border-app-red/20 hover:bg-app-red/20 transition-colors disabled:opacity-50"
@@ -408,6 +410,7 @@ export default function AnomalyReviewPage() {
                         <X className="w-3 h-3" /> Dismiss
                       </button>
                       <button
+                        type="button"
                         onClick={() => {
                           setExpandedNoteId(isExpanded ? null : anomaly.id)
                           setNoteText('')

--- a/frontend/src/pages/net-worth/NetWorthPage.tsx
+++ b/frontend/src/pages/net-worth/NetWorthPage.tsx
@@ -9,6 +9,7 @@ import { rawColors } from '@/constants/colors'
 import { PageContainer, PageHeader } from '@/components/ui'
 import ErrorState from '@/components/shared/ErrorState'
 import { formatCurrency, formatPercent } from '@/lib/formatters'
+import { useClosedAccounts } from '@/hooks/api/useAccountStatus'
 
 import MilestonesTable from './components/MilestonesTable'
 import { AccountCategoryTable } from './components/AccountCategoryTable'
@@ -17,6 +18,7 @@ import { useNetWorth } from './useNetWorth'
 
 export default function NetWorthPage() {
   const m = useNetWorth()
+  const { data: closedAccounts = [] } = useClosedAccounts()
 
   // Leverage = liabilities as a share of assets. Reuses the totals already
   // computed in the hook; clamps the assets-zero edge so we never divide by 0.
@@ -143,6 +145,7 @@ export default function NetWorthPage() {
             expandedCategories={m.expandedAssetCategories}
             onToggleCategory={(cat) => m.toggleCategory(m.setExpandedAssetCategories, cat)}
             getAccountType={m.getAccountType}
+            closedAccounts={closedAccounts}
             emptyIcon={PiggyBank}
             emptyTitle="No asset accounts found"
             emptyDescription="Add transactions for accounts with positive balances to see your assets."
@@ -170,6 +173,7 @@ export default function NetWorthPage() {
             expandedCategories={m.expandedLiabilityCategories}
             onToggleCategory={(cat) => m.toggleCategory(m.setExpandedLiabilityCategories, cat)}
             getAccountType={m.getAccountType}
+            closedAccounts={closedAccounts}
             emptyIcon={CreditCard}
             emptyTitle="No liability accounts found"
             emptyDescription="Great news! You don't have any liability accounts with negative balances."

--- a/frontend/src/pages/net-worth/components/AccountCategoryTable.tsx
+++ b/frontend/src/pages/net-worth/components/AccountCategoryTable.tsx
@@ -55,6 +55,9 @@ interface AccountCategoryTableProps {
   readonly expandedCategories: Set<string>
   readonly onToggleCategory: (category: string) => void
   readonly getAccountType: (name: string) => string
+  /** Accounts the user marked closed -- shown with a badge, still listed while
+   *  the balance is nonzero (a closed card with unpaid dues is still a liability). */
+  readonly closedAccounts?: readonly string[]
   readonly emptyIcon: LucideIcon
   readonly emptyTitle: string
   readonly emptyDescription: string
@@ -71,6 +74,7 @@ export function AccountCategoryTable({
   expandedCategories,
   onToggleCategory,
   getAccountType,
+  closedAccounts = [],
   emptyIcon,
   emptyTitle,
   emptyDescription,
@@ -223,7 +227,16 @@ export function AccountCategoryTable({
                         initial={{ opacity: 0 }}
                         animate={{ opacity: 1 }}
                       >
-                        <td className="py-3 pl-10 pr-4 text-foreground font-medium">{accountName}</td>
+                        <td className="py-3 pl-10 pr-4 text-foreground font-medium">
+                          <span className="inline-flex items-center gap-2">
+                            {accountName}
+                            {closedAccounts.includes(accountName) && (
+                              <span className="px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-[var(--overlay-5)] text-muted-foreground">
+                                Closed
+                              </span>
+                            )}
+                          </span>
+                        </td>
                         <td
                           className={`py-3 px-4 text-right font-bold tabular-nums ${balanceColorClass}`}
                         >

--- a/frontend/src/pages/settings/sections/AdvancedSection.tsx
+++ b/frontend/src/pages/settings/sections/AdvancedSection.tsx
@@ -4,9 +4,11 @@
  */
 
 import { Shield } from 'lucide-react'
+import { useClosedAccounts } from '@/hooks/api/useAccountStatus'
 import type { LocalPrefs, LocalPrefKey } from '../types'
 import { Section } from '../sectionPrimitives'
 import AnomalyDetectionSubsection from './AnomalyDetectionSubsection'
+import ClosedAccountsSubsection from './ClosedAccountsSubsection'
 import CreditCardLimitsSubsection from './CreditCardLimitsSubsection'
 import ExcludedAccountsSubsection from './ExcludedAccountsSubsection'
 
@@ -27,20 +29,26 @@ export default function AdvancedSection({
   excludedAccounts,
   updateLocalPref,
 }: Readonly<Props>) {
+  // A closed credit card has no limit to configure.
+  const { data: closedAccounts = [] } = useClosedAccounts()
+  const openCreditCards = creditCardAccounts.filter((card) => !closedAccounts.includes(card))
+
   return (
     <Section
       index={index}
       icon={Shield}
       title="Advanced"
-      description="Anomaly detection, credit card limits, excluded accounts"
+      description="Anomaly detection, credit card limits, closed and excluded accounts"
     >
       <AnomalyDetectionSubsection localPrefs={localPrefs} updateLocalPref={updateLocalPref} />
 
       <CreditCardLimitsSubsection
         localPrefs={localPrefs}
-        creditCardAccounts={creditCardAccounts}
+        creditCardAccounts={openCreditCards}
         updateLocalPref={updateLocalPref}
       />
+
+      <ClosedAccountsSubsection accounts={accounts} />
 
       <ExcludedAccountsSubsection
         accounts={accounts}

--- a/frontend/src/pages/settings/sections/ClosedAccountsSubsection.tsx
+++ b/frontend/src/pages/settings/sections/ClosedAccountsSubsection.tsx
@@ -1,0 +1,98 @@
+/**
+ * Closed Accounts sub-section within Advanced settings.
+ *
+ * Unlike Excluded Accounts (which hides an account from analytics entirely),
+ * closing keeps the history but stops forward-looking behavior: recurring and
+ * bill expectations deactivate, credit-card limit config hides, and pickers
+ * omit the account. Applies immediately (server side effects), not batched
+ * behind the page Save.
+ */
+
+import { Archive } from 'lucide-react'
+import { toast } from 'sonner'
+
+import { useClosedAccounts, useSetAccountStatus } from '@/hooks/api/useAccountStatus'
+import { useDemoGuard } from '@/hooks/useDemoGuard'
+import { Toggle } from '../sectionPrimitives'
+
+interface Props {
+  accounts: string[]
+}
+
+export default function ClosedAccountsSubsection({ accounts }: Readonly<Props>) {
+  const { data: closedAccounts = [] } = useClosedAccounts()
+  const setStatus = useSetAccountStatus()
+  const { guardDemoAction } = useDemoGuard()
+
+  // Closed accounts with a zero balance drop out of the balances-derived
+  // `accounts` list, so union them in -- otherwise a fully settled closed
+  // card would vanish from this list and could never be reopened.
+  const allNames = [...new Set([...accounts, ...closedAccounts])].sort((a, b) =>
+    a.localeCompare(b),
+  )
+
+  const toggle = (account: string, isClosed: boolean) => {
+    if (guardDemoAction('Closing accounts')) return
+    setStatus.mutate(
+      { accountName: account, isClosed },
+      {
+        onSuccess: () => {
+          toast.success(isClosed ? `${account} marked closed` : `${account} reopened`)
+        },
+        onError: () => toast.error('Failed to update account status'),
+      },
+    )
+  }
+
+  return (
+    <div className="pt-4 border-t border-border space-y-3">
+      <h3 className="text-sm font-medium text-foreground flex items-center gap-2">
+        <Archive className="w-4 h-4 text-primary" />
+        Closed Accounts
+        {closedAccounts.length > 0 && (
+          <span className="px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-[var(--overlay-5)] text-muted-foreground">
+            {closedAccounts.length}
+          </span>
+        )}
+      </h3>
+      <p className="text-xs text-muted-foreground">
+        Closed accounts (a cancelled credit card, an old bank account) keep their history in
+        analytics, but no new bills or recurring payments are expected on them and they are
+        hidden from limits and account pickers. Changes apply immediately.
+      </p>
+      {allNames.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No accounts found.</p>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-1">
+          {allNames.map((account) => {
+            const isClosed = closedAccounts.includes(account)
+            return (
+              <div
+                key={account}
+                className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-[var(--overlay-2)] transition-colors"
+              >
+                <span
+                  className={`text-sm truncate flex-1 ${
+                    isClosed ? 'text-muted-foreground line-through' : 'text-foreground'
+                  }`}
+                >
+                  {account}
+                </span>
+                {isClosed && (
+                  <span className="px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-[var(--overlay-5)] text-muted-foreground shrink-0">
+                    Closed
+                  </span>
+                )}
+                <Toggle
+                  checked={isClosed}
+                  onChange={(next) => toggle(account, next)}
+                  id={`closed-${account}`}
+                />
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/services/api/accountClassifications.ts
+++ b/frontend/src/services/api/accountClassifications.ts
@@ -41,4 +41,20 @@ export const accountClassificationsService = {
     )
     return response.data
   },
+
+  getClosedAccounts: async (): Promise<string[]> => {
+    const response = await apiClient.get<string[]>('/api/account-classifications/closed')
+    return response.data
+  },
+
+  setAccountStatus: async (
+    accountName: string,
+    isClosed: boolean
+  ): Promise<{ account_name: string; is_closed: boolean; status: string }> => {
+    const response = await apiClient.put('/api/account-classifications/status', {
+      account_name: accountName,
+      is_closed: isClosed,
+    })
+    return response.data
+  },
 }

--- a/frontend/src/services/api/analyticsV2.ts
+++ b/frontend/src/services/api/analyticsV2.ts
@@ -165,7 +165,12 @@ export interface FYSummary {
 
 export interface Anomaly {
   id: number
-  anomaly_type: 'high_expense' | 'unusual_category' | 'large_transfer' | 'budget_exceeded'
+  anomaly_type:
+    | 'high_expense'
+    | 'unusual_category'
+    | 'large_transfer'
+    | 'budget_exceeded'
+    | 'closed_account_activity'
   severity: 'low' | 'medium' | 'high'
   description: string
   transaction_id: string | null

--- a/frontend/src/services/api/client.ts
+++ b/frontend/src/services/api/client.ts
@@ -108,6 +108,8 @@ const DEMO_ROUTES: ReadonlyArray<readonly [string, DemoResolver]> = [
   ['/transactions/facets', (txs) => generateDemoFacets(txs)],
   ['/transactions/search', (txs, params) => generateDemoSearch(txs, params)],
   ['/saved-views', () => generateDemoSavedViews()],
+  // Closed-accounts list must precede the generic prefix match below.
+  ['/account-classifications/closed', () => []],
   ['/account-classifications', () => generateDemoAccountClassifications()],
   ['/transactions', (txs, params) => txs.slice(0, (params.limit as number) || txs.length)],
 ]


### PR DESCRIPTION
## What

Accounts can now be marked **closed** -- a cancelled credit card, an old bank account. History stays in analytics; the app just stops treating the account as alive.

**Toggle in Settings** (Advanced -> Closed Accounts): per-account switch, applies immediately (not batched behind Save, because it has server side effects). Zero-balance closed accounts stay reopenable -- the list unions closed names with balance-derived accounts.

What closing does:

- **Recurring / bills**: active recurring patterns on the account deactivate immediately, so the bill calendar and missed-payment logic stop expecting them. The detection pass also skips closed accounts, so patterns never come back on refresh. Reopening restores user-confirmed patterns; auto-detected ones return on the next detection pass.
- **Credit Card Limits**: closed cards are hidden from limit config -- no point setting a limit on a cancelled card.
- **Net worth**: closed accounts with a nonzero balance still list (a closed card with unpaid dues is still a liability) with a "Closed" badge; settled ones drop out naturally.
- **Late activity surfaced, not blocked**: statements trail closures in India by a cycle or two (refunds, reversals), so transactions dated after the close date import normally and produce a new "Closed Account Activity" anomaly (capped at 5 per account) for review. The anomaly page gets the new type with its own label, icon, and filter option.

Unlike `excluded_accounts` (which hides an account from analytics entirely), closing only affects forward-looking behavior.

## Implementation

- `AccountClassification` gains `is_closed` + `closed_date` (migration `closed_accounts_2026`, `server_default=false` backfill).
- New endpoints: `GET /api/account-classifications/closed`, `PUT /api/account-classifications/status` (creates the classification row on demand so unclassified accounts can be closed too).
- `closed_accounts_for()` helper in `query_helpers.py` next to `excluded_accounts_for()`.
- New `AnomalyType.CLOSED_ACCOUNT_ACTIVITY` (string values are DB-stored; addition only, no migration needed for the enum).
- Frontend: `useClosedAccounts` / `useSetAccountStatus` TanStack hooks, `ClosedAccountsSubsection` reusing the existing `Toggle` primitive, demo-mode route stub returns an empty list, demo-guard blocks the mutation with a toast.

## Testing

- Backend: 348 pytest (4 new: close/reopen endpoint round-trip, recurring deactivate + confirmed-restore, detection skip, anomaly flags post-close-date rows only), ruff, mypy all green.
- Migration chain verified against a copy of the real dev DB.
- Frontend: tsc, eslint, 304 vitest green. Verified live: subsection renders in Advanced with per-account toggles, demo mode blocks the toggle with the expected toast, both new endpoints registered (401 without auth, not 404).
