### PR TITLE
fix(analytics): score financial health from real account balances

### DIFF
--- a/frontend/src/components/analytics/FinancialHealthScore.tsx
+++ b/frontend/src/components/analytics/FinancialHealthScore.tsx
@@ -5,10 +5,15 @@ import { Shield } from 'lucide-react'
 
 import { useTransactions } from '@/hooks/api/useTransactions'
 import { usePreferences } from '@/hooks/api/usePreferences'
+import { useAccountBalances } from '@/hooks/api/useAnalytics'
 import { useInvestmentAccountStore } from '@/store/investmentAccountStore'
+import { useAccountClassifications } from '@/hooks/api/useAccountClassifications'
 import StandardRadarChart from '@/components/analytics/StandardRadarChart'
 import { rawColors } from '@/constants/colors'
+import { fadeUpItem, staggerContainer } from '@/constants/animations'
+import { useCountUp } from '@/hooks/useCountUp'
 import type { Transaction } from '@/types'
+import { resolveAccountCategory } from '@/pages/net-worth/netWorthUtils'
 import { computeCFPScore } from '@/lib/financialHealthCalculator'
 
 import type { HealthMetric } from './health/healthScoreUtils'
@@ -19,6 +24,7 @@ import {
   getOverallStatus,
   getSummary,
 } from './health/healthScoreUtils'
+import { computeBalancePosition } from './health/healthScoreBalances'
 import CFPScoreView from './health/CFPScoreView'
 
 // ─── Sub-components ────────────────────────────────────────────────────────
@@ -58,6 +64,7 @@ function ScoreHeader({ title, score, subtitle, color }: Readonly<{
   subtitle: string
   color: string
 }>) {
+  const animatedScore = useCountUp(score)
   return (
     <div className="flex items-center justify-between mb-4">
       <div className="flex items-center gap-2">
@@ -69,7 +76,7 @@ function ScoreHeader({ title, score, subtitle, color }: Readonly<{
           <p className="text-[11px] text-muted-foreground">{subtitle}</p>
         </div>
       </div>
-      <p className={`text-xl font-bold ${color}`}>{Math.round(score)}</p>
+      <p className={`text-xl font-bold tabular-nums ${color}`}>{Math.round(animatedScore)}</p>
     </div>
   )
 }
@@ -99,20 +106,30 @@ function HealthMetricCard({ metric }: Readonly<{ metric: HealthMetric }>) {
   const color = TIER_COLORS[metric.status] ?? rawColors.app.red
 
   return (
-    <div className="p-2.5 rounded-lg border border-border bg-[var(--overlay-1)]">
+    <motion.div
+      variants={fadeUpItem}
+      whileHover={{ y: -2 }}
+      transition={{ type: 'spring', stiffness: 400, damping: 25 }}
+      className="p-2.5 rounded-lg border border-border bg-[var(--overlay-1)]"
+    >
       <div className="flex items-center justify-between mb-1.5">
         <span className="text-xs font-medium text-foreground truncate">{metric.name}</span>
-        <span className="text-xs font-bold" style={{ color }}>{Math.round(metric.score)}</span>
+        <span className="text-xs font-bold tabular-nums" style={{ color }}>{Math.round(metric.score)}</span>
       </div>
       <div className="h-1 bg-muted/30 rounded-full overflow-hidden mb-1.5">
-        <div className="h-full rounded-full transition-all duration-500"
-          style={{ width: `${metric.score}%`, backgroundColor: color }} />
+        <motion.div
+          className="h-full rounded-full"
+          style={{ backgroundColor: color }}
+          initial={{ width: 0 }}
+          animate={{ width: `${metric.score}%` }}
+          transition={{ duration: 0.7, ease: [0.25, 0.46, 0.45, 0.94] }}
+        />
       </div>
       <div className="flex items-center justify-between">
         <p className="text-[11px] text-text-tertiary truncate">{metric.description}</p>
         <p className="text-[10px] text-text-quaternary shrink-0 ml-2">Target: {metric.target}</p>
       </div>
-    </div>
+    </motion.div>
   )
 }
 
@@ -125,6 +142,8 @@ interface FinancialHealthScoreProps {
 export default function FinancialHealthScore({ transactions: propTransactions }: Readonly<FinancialHealthScoreProps>) {
   const { data: fetchedTransactions = [], isLoading: isFetching } = useTransactions()
   const { data: preferences } = usePreferences()
+  const { data: balanceData } = useAccountBalances()
+  const { data: classifications } = useAccountClassifications()
   const transactions = propTransactions ?? fetchedTransactions
   const isLoading = !propTransactions && isFetching
   const isInvestmentAccount = useInvestmentAccountStore((state) => state.isInvestmentAccount)
@@ -147,12 +166,30 @@ export default function FinancialHealthScore({ transactions: propTransactions }:
     return new Set(arr.map((c) => c.toLowerCase()))
   }, [preferences?.fixed_expense_categories])
 
+  const investmentMappings = useMemo(
+    () => preferences?.investment_account_mappings ?? {},
+    [preferences?.investment_account_mappings],
+  )
+
+  // Real balance position (liquid vs investment vs liabilities) from actual
+  // account balances -- the correct basis for emergency-fund / liquidity /
+  // solvency. Null until balances load, in which case scorers fall back to the
+  // cumulative-flow proxy.
+  const balancePosition = useMemo(() => {
+    const accounts = balanceData?.accounts
+    if (!accounts || Object.keys(accounts).length === 0) return null
+    const classMap = classifications ?? {}
+    return computeBalancePosition(accounts, (name) =>
+      resolveAccountCategory(name, classMap, investmentMappings),
+    )
+  }, [balanceData?.accounts, classifications, investmentMappings])
+
   const analysisData = useMemo(() => {
     if (!transactions.length) return null
     const result = computeMonthlyData(transactions, isInvestmentAccount, userFixedCategories.size > 0 ? userFixedCategories : undefined)
     if (!result) return null
-    return computeAnalysis(result.months, result.monthlyData)
-  }, [transactions, isInvestmentAccount, userFixedCategories])
+    return computeAnalysis(result.months, result.monthlyData, balancePosition)
+  }, [transactions, isInvestmentAccount, userFixedCategories, balancePosition])
 
   const cfpCompositeScore = useMemo(() => {
     if (!analysisData) return 0
@@ -168,6 +205,7 @@ export default function FinancialHealthScore({ transactions: propTransactions }:
       cumulativeNetSavings: analysisData.cumulativeNetSavings,
       netInvestments: analysisData.totalInvestmentInflow - analysisData.totalInvestmentOutflow,
       totalDebtOutstanding: analysisData.avgMonthlyDebt * totalMonths,
+      balances: analysisData.balances,
     }).compositeScore
   }, [analysisData])
 
@@ -203,9 +241,14 @@ export default function FinancialHealthScore({ transactions: propTransactions }:
         />
         <RadarVisualization metrics={fhnRadarData} chartColor={rawColors.app.blue} />
         <p className="text-[11px] text-center text-muted-foreground mb-3">{getSummary(overallScore)}</p>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        <motion.div
+          className="grid grid-cols-1 sm:grid-cols-2 gap-2"
+          variants={staggerContainer}
+          initial="hidden"
+          animate="visible"
+        >
           {metrics.map((m) => <HealthMetricCard key={m.name} metric={m} />)}
-        </div>
+        </motion.div>
         <p className="text-[10px] text-center text-muted-foreground/50 mt-3">Financial Health Network framework</p>
       </div>
 

--- a/frontend/src/components/analytics/health/CFPScoreView.tsx
+++ b/frontend/src/components/analytics/health/CFPScoreView.tsx
@@ -1,5 +1,7 @@
 import { memo, useMemo } from 'react'
+import { motion } from 'framer-motion'
 import { rawColors } from '@/constants/colors'
+import { fadeUpItem, staggerContainer } from '@/constants/animations'
 import StandardRadarChart from '@/components/analytics/StandardRadarChart'
 import { computeCFPScore, type CFPRatio } from '@/lib/financialHealthCalculator'
 import type { AnalysisResult } from './healthScoreUtils'
@@ -13,22 +15,30 @@ function getStatusColor(status: 'good' | 'warning' | 'poor'): string {
 function RatioCard({ ratio }: Readonly<{ ratio: CFPRatio }>) {
   const color = getStatusColor(ratio.status)
   return (
-    <div className="p-3 rounded-xl border border-border bg-[var(--overlay-1)]">
+    <motion.div
+      variants={fadeUpItem}
+      whileHover={{ y: -2 }}
+      transition={{ type: 'spring', stiffness: 400, damping: 25 }}
+      className="p-3 rounded-xl border border-border bg-[var(--overlay-1)]"
+    >
       <div className="flex items-center justify-between mb-2">
         <span className="text-sm font-medium text-foreground">{ratio.name}</span>
-        <span className="text-sm font-bold" style={{ color }}>{ratio.formattedValue}</span>
+        <span className="text-sm font-bold tabular-nums" style={{ color }}>{ratio.formattedValue}</span>
       </div>
       <div className="h-1.5 bg-muted/30 rounded-full overflow-hidden mb-2">
-        <div
-          className="h-full rounded-full transition-all duration-500"
-          style={{ width: `${ratio.score}%`, backgroundColor: color }}
+        <motion.div
+          className="h-full rounded-full"
+          style={{ backgroundColor: color }}
+          initial={{ width: 0 }}
+          animate={{ width: `${ratio.score}%` }}
+          transition={{ duration: 0.7, ease: [0.25, 0.46, 0.45, 0.94] }}
         />
       </div>
       <div className="flex items-center justify-between">
         <span className="text-xs text-text-tertiary">{ratio.description}</span>
         <span className="text-xs text-text-quaternary">Target: {ratio.target}</span>
       </div>
-    </div>
+    </motion.div>
   )
 }
 
@@ -54,6 +64,7 @@ const CFPScoreView = memo(function CFPScoreView({ analysisData }: Readonly<CFPSc
       cumulativeNetSavings: analysisData.cumulativeNetSavings,
       netInvestments: analysisData.totalInvestmentInflow - analysisData.totalInvestmentOutflow,
       totalDebtOutstanding: analysisData.avgMonthlyDebt * totalMonths,
+      balances: analysisData.balances,
     })
   }, [analysisData])
 
@@ -80,11 +91,16 @@ const CFPScoreView = memo(function CFPScoreView({ analysisData }: Readonly<CFPSc
       </div>
 
       {/* Ratio Cards */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+      <motion.div
+        className="grid grid-cols-1 sm:grid-cols-2 gap-3"
+        variants={staggerContainer}
+        initial="hidden"
+        animate="visible"
+      >
         {ratios.map((ratio) => (
           <RatioCard key={ratio.name} ratio={ratio} />
         ))}
-      </div>
+      </motion.div>
 
       <p className="text-[10px] text-center text-muted-foreground/50">
         Based on CFP Board / FPSB India financial planning standards

--- a/frontend/src/components/analytics/health/__tests__/healthScore.test.ts
+++ b/frontend/src/components/analytics/health/__tests__/healthScore.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest'
+
+import { computeCFPScore } from '@/lib/financialHealthCalculator'
+
+import { computeBalancePosition } from '../healthScoreBalances'
+import { computeAnalysis, computeMonthlyData } from '../healthScoreAnalysis'
+import { weightedCoefficientOfVariation } from '../healthScoreTypes'
+import type { AccountBalances } from '@/services/api/calculations'
+import type { Transaction } from '@/types'
+
+// ─── weightedCoefficientOfVariation ──────────────────────────────────────────
+
+describe('weightedCoefficientOfVariation', () => {
+  it('returns 0 for empty input', () => {
+    expect(weightedCoefficientOfVariation([])).toBe(0)
+  })
+
+  it('returns ~0 when all values are equal (no dispersion)', () => {
+    expect(weightedCoefficientOfVariation([100, 100, 100, 100])).toBeCloseTo(0, 6)
+  })
+
+  it('penalizes recent volatility more than old volatility (recency weighting)', () => {
+    // Same eight values, opposite order. Oldest-first arrays.
+    const volatileRecent = [50000, 50000, 50000, 50000, 10000, 90000, 10000, 90000]
+    const volatileOld = [10000, 90000, 10000, 90000, 50000, 50000, 50000, 50000]
+    // When the swings are recent they should dominate the reading; when they
+    // are old (and the recent stretch is steady) the CV should be much lower.
+    expect(weightedCoefficientOfVariation(volatileRecent)).toBeGreaterThan(
+      weightedCoefficientOfVariation(volatileOld),
+    )
+  })
+
+  it('discounts old lean months so a now-steady earner is not flagged volatile', () => {
+    // Two early stipend months, then a steady salary (oldest-first).
+    const ramp = [500, 800, 50000, 50000, 50000, 50000, 50000, 50000]
+    const weighted = weightedCoefficientOfVariation(ramp)
+    const mean = ramp.reduce((a, b) => a + b, 0) / ramp.length
+    const variance = ramp.reduce((s, v) => s + (v - mean) ** 2, 0) / ramp.length
+    const unweighted = (Math.sqrt(variance) / mean) * 100
+    // Recency weighting pulls the reading below the unweighted CV...
+    expect(weighted).toBeLessThan(unweighted)
+    // ...and keeps it out of the "volatile" band (>75%), so the score is not floored.
+    expect(weighted).toBeLessThan(75)
+  })
+})
+
+// ─── computeBalancePosition ──────────────────────────────────────────────────
+
+function balances(accounts: Record<string, number>): AccountBalances['accounts'] {
+  return Object.fromEntries(
+    Object.entries(accounts).map(([name, balance]) => [
+      name,
+      { balance, transactions: 1, last_transaction: null },
+    ]),
+  )
+}
+
+const categorize = (name: string): string => {
+  if (name.startsWith('Bank')) return 'Bank Accounts'
+  if (name.startsWith('Cash') || name.startsWith('Wallet')) return 'Cash & Wallets'
+  if (name.startsWith('Invest')) return 'Investments'
+  if (name.startsWith('CC')) return 'Credit Cards'
+  return 'Other'
+}
+
+describe('computeBalancePosition', () => {
+  it('sums bank + cash + wallet balances into liquid assets', () => {
+    const pos = computeBalancePosition(
+      balances({ 'Bank SBI': 280000, 'Cash in hand': 8000, 'Wallet GPay': 2000 }),
+      categorize,
+    )
+    expect(pos.liquidAssets).toBe(290000)
+    expect(pos.investmentAssets).toBe(0)
+    expect(pos.totalLiabilities).toBe(0)
+    expect(pos.netWorth).toBe(290000)
+  })
+
+  it('files investment accounts separately from the liquid buffer', () => {
+    const pos = computeBalancePosition(
+      balances({ 'Bank SBI': 100000, 'Invest MF': 200000, 'Invest EPF': 180000 }),
+      categorize,
+    )
+    expect(pos.liquidAssets).toBe(100000)
+    expect(pos.investmentAssets).toBe(380000)
+    expect(pos.totalAssets).toBe(480000)
+  })
+
+  it('treats any negative balance as a liability regardless of category', () => {
+    const pos = computeBalancePosition(
+      balances({ 'Bank SBI': 100000, 'CC Amazon': -25000 }),
+      categorize,
+    )
+    expect(pos.liquidAssets).toBe(100000)
+    expect(pos.totalLiabilities).toBe(25000)
+    expect(pos.netWorth).toBe(75000)
+  })
+
+  it('skips excluded accounts', () => {
+    const pos = computeBalancePosition(
+      balances({ 'Bank SBI': 100000, 'Bank Old': 50000 }),
+      categorize,
+      (name) => name === 'Bank Old',
+    )
+    expect(pos.liquidAssets).toBe(100000)
+  })
+})
+
+// ─── Emergency fund / liquidity from real balances ───────────────────────────
+
+/** Build N months of a steady salaried earner: 100k income, 40k expense. */
+function steadyLedger(months: number): Transaction[] {
+  const txns: Transaction[] = []
+  for (let i = 0; i < months; i++) {
+    const m = String(i + 1).padStart(2, '0')
+    const date = `2025-${m}-05`
+    txns.push({ id: `inc-${i}`, date, amount: 100000, type: 'Income', category: 'Salary', account: 'Bank SBI' })
+    txns.push({ id: `exp-${i}`, date, amount: 40000, type: 'Expense', category: 'Rent', account: 'Bank SBI' })
+  }
+  return txns
+}
+
+describe('emergency fund uses real liquid balance, not the flow proxy', () => {
+  const noInvestment = () => false
+
+  it('reads months of coverage from real bank balances even when the flow proxy would be 0', () => {
+    const txns = steadyLedger(6)
+    const built = computeMonthlyData(txns, noInvestment)
+    expect(built).not.toBeNull()
+
+    // Real balances: 300k liquid in the bank, avg monthly expense 40k -> 7.5 months.
+    const pos = computeBalancePosition(balances({ 'Bank SBI': 300000 }), categorize)
+    const withBalances = computeAnalysis(built!.months, built!.monthlyData, pos)
+    expect(withBalances.emergencyFundMonths).toBeCloseTo(7.5, 1)
+    expect(withBalances.balances?.liquidAssets).toBe(300000)
+  })
+
+  it('CFP liquidity + emergency ratios reflect real balances', () => {
+    const pos = computeBalancePosition(
+      balances({ 'Bank SBI': 300000, 'Invest MF': 500000, 'CC Amazon': -20000 }),
+      categorize,
+    )
+    const result = computeCFPScore({
+      totalIncome: 600000,
+      totalExpenses: 240000,
+      avgMonthlyIncome: 100000,
+      avgMonthlyExpense: 40000,
+      avgMonthlyEssentialExpense: 30000,
+      avgMonthlyDebt: 0,
+      cumulativeNetSavings: 360000,
+      netInvestments: 500000,
+      totalDebtOutstanding: 0,
+      balances: pos,
+    })
+    const liquidity = result.ratios.find((r) => r.name === 'Liquidity Ratio')!
+    const emergency = result.ratios.find((r) => r.name === 'Emergency Fund')!
+    const solvency = result.ratios.find((r) => r.name === 'Solvency Ratio')!
+    // 300k liquid / 40k monthly = 7.5 months -> strong, non-zero.
+    expect(liquidity.value).toBeCloseTo(7.5, 1)
+    expect(emergency.value).toBeCloseTo(7.5, 1)
+    expect(liquidity.score).toBeGreaterThan(60)
+    // Net worth 780k / total assets 800k = 97.5% solvency.
+    expect(solvency.value).toBeCloseTo(97.5, 1)
+  })
+
+  it('falls back to the flow proxy when no balances are supplied', () => {
+    const result = computeCFPScore({
+      totalIncome: 600000,
+      totalExpenses: 240000,
+      avgMonthlyIncome: 100000,
+      avgMonthlyExpense: 40000,
+      avgMonthlyEssentialExpense: 30000,
+      avgMonthlyDebt: 0,
+      cumulativeNetSavings: 360000,
+      netInvestments: 100000,
+      totalDebtOutstanding: 0,
+    })
+    // proxy liquid = 360k - 100k = 260k; 260k / 40k = 6.5 months.
+    const emergency = result.ratios.find((r) => r.name === 'Emergency Fund')!
+    expect(emergency.value).toBeCloseTo(6.5, 1)
+  })
+})

--- a/frontend/src/components/analytics/health/healthScoreAnalysis.ts
+++ b/frontend/src/components/analytics/health/healthScoreAnalysis.ts
@@ -1,14 +1,14 @@
 import type { Transaction } from '@/types'
 
-import type { AnalysisResult, MonthlyBucket } from './healthScoreTypes'
+import type { AnalysisResult, BalancePosition, MonthlyBucket } from './healthScoreTypes'
 import {
   DEBT_CATEGORIES,
   DISCRETIONARY_CATEGORIES,
   ESSENTIAL_CATEGORIES,
   checkIsInvestmentTransaction,
   checkIsInvestmentWithdrawal,
-  coefficientOfVariation,
   matchesCategoryList,
+  weightedCoefficientOfVariation,
 } from './healthScoreTypes'
 
 export function createEmptyBucket(): MonthlyBucket {
@@ -95,6 +95,7 @@ export function computeMonthlyData(
 export function computeAnalysis(
   months: string[],
   monthlyData: Record<string, MonthlyBucket>,
+  balances: BalancePosition | null = null,
 ): AnalysisResult {
   const buckets = months.map((m) => monthlyData[m])
   const count = months.length
@@ -123,7 +124,12 @@ export function computeAnalysis(
     totalIncome > 0 ? (totalNetInvestment / totalIncome) * 100 : 0
 
   const cumulativeNetSavings = totalIncome - totalExpense
-  const liquidSavings = Math.max(0, cumulativeNetSavings - Math.max(0, totalNetInvestment))
+  // Prefer the real liquid balance (bank + cash + wallets). Only when no
+  // balance feed is available do we fall back to the old cumulative-flow
+  // proxy -- which understates badly for anyone whose lifetime investing
+  // exceeds their lifetime cash surplus (it clamps to 0).
+  const flowProxyLiquid = Math.max(0, cumulativeNetSavings - Math.max(0, totalNetInvestment))
+  const liquidSavings = balances ? balances.liquidAssets : flowProxyLiquid
   const emergencyFundMonths = avgMonthlyExpense > 0 ? liquidSavings / avgMonthlyExpense : 0
 
   const totalDebt = buckets.reduce((s, m) => s + m.debt, 0)
@@ -151,17 +157,19 @@ export function computeAnalysis(
   // last 12 months -- not the full history. Over a multi-year ramp (a student
   // going from ~Rs0 to a salary) the all-time income CV is ~130%, which floors
   // every stability score at 0 even when the last year is rock-steady (CV ~10%).
+  // Within that window we recency-weight (JPMC/RiskMetrics EWMA of deviations)
+  // so a couple of older lean months don't dominate a now-steady reading.
   const VOLATILITY_WINDOW = 12
   const recentBuckets = buckets.slice(-VOLATILITY_WINDOW)
-  const recentSavingsRates = recentBuckets.map((m) =>
-    m.income > 0 ? ((m.income - m.expense) / m.income) * 100 : 0,
-  )
-  const savingsVolatilityCV = coefficientOfVariation(recentSavingsRates.filter((r) => r > 0))
+  const recentSavingsRates = recentBuckets
+    .map((m) => (m.income > 0 ? ((m.income - m.expense) / m.income) * 100 : 0))
+    .filter((r) => r > 0)
+  const savingsVolatilityCV = weightedCoefficientOfVariation(recentSavingsRates)
 
   // Income CV over recent months that actually had income (a pre-earning month
   // of Rs0 isn't "income instability"; it's no income yet).
   const recentIncomes = recentBuckets.map((m) => m.income).filter((v) => v > 0)
-  const incomeCV = coefficientOfVariation(recentIncomes)
+  const incomeCV = weightedCoefficientOfVariation(recentIncomes)
 
   return {
     monthsAnalyzed: count,
@@ -181,5 +189,6 @@ export function computeAnalysis(
     positiveSavingsRatio,
     savingsVolatilityCV,
     incomeCV,
+    balances,
   }
 }

--- a/frontend/src/components/analytics/health/healthScoreBalances.ts
+++ b/frontend/src/components/analytics/health/healthScoreBalances.ts
@@ -1,0 +1,74 @@
+/**
+ * Build the real-balance position (liquid / investment / liabilities) that the
+ * emergency-fund, liquidity, and solvency ratios need.
+ *
+ * Why this exists: the health score used to derive "liquid assets" as
+ * (cumulative income - expenses - net investments), a flow proxy that clamps to
+ * 0 whenever lifetime investing exceeds the lifetime cash surplus -- so a user
+ * with real bank balances read 0 emergency-fund months. Per FHN/CFSI "Have
+ * sufficient liquid savings", the numerator is the CURRENT balance of liquid
+ * deposit accounts (checking/savings, cash, wallets), never a flow.
+ */
+
+import type { AccountBalances } from '@/services/api/calculations'
+
+import type { BalancePosition } from './healthScoreTypes'
+
+/**
+ * Account categories that hold spendable, near-instant money. Fixed deposits
+ * and liquid mutual funds are also emergency-fund eligible (T+1 access), but
+ * this app files those under "Investments", so they land in investmentAssets --
+ * a deliberately conservative liquid figure (understates, never overstates).
+ */
+const LIQUID_CATEGORIES = new Set(['Cash & Wallets', 'Bank Accounts'])
+const INVESTMENT_CATEGORIES = new Set(['Investments'])
+
+/**
+ * Fold real account balances into a liquid / investment / liability position.
+ *
+ * @param accounts  balance-by-account map from `/calculations/account-balances`
+ * @param categorize maps an account name to a display category
+ *   ('Bank Accounts' | 'Cash & Wallets' | 'Investments' | 'Credit Cards' | ...)
+ * @param isExcluded optional predicate to drop accounts the user hid from analytics
+ */
+export function computeBalancePosition(
+  accounts: AccountBalances['accounts'],
+  categorize: (accountName: string) => string,
+  isExcluded?: (accountName: string) => boolean,
+): BalancePosition {
+  let liquidAssets = 0
+  let investmentAssets = 0
+  let totalLiabilities = 0
+
+  for (const [name, entry] of Object.entries(accounts)) {
+    if (isExcluded?.(name)) continue
+    const balance = entry.balance
+    if (balance < 0) {
+      // Any negative balance is a liability (credit-card debt, overdraft, a
+      // loan account carried negative), regardless of its display category.
+      totalLiabilities += -balance
+      continue
+    }
+    if (balance === 0) continue
+
+    const category = categorize(name)
+    if (LIQUID_CATEGORIES.has(category)) {
+      liquidAssets += balance
+    } else if (INVESTMENT_CATEGORIES.has(category)) {
+      investmentAssets += balance
+    } else {
+      // Loans/Lended (money owed TO the user) and anything uncategorized are
+      // real net-worth assets but not part of the liquid emergency buffer.
+      investmentAssets += balance
+    }
+  }
+
+  const totalAssets = liquidAssets + investmentAssets
+  return {
+    liquidAssets,
+    investmentAssets,
+    totalLiabilities,
+    totalAssets,
+    netWorth: totalAssets - totalLiabilities,
+  }
+}

--- a/frontend/src/components/analytics/health/healthScoreScorers.ts
+++ b/frontend/src/components/analytics/health/healthScoreScorers.ts
@@ -78,6 +78,12 @@ export function scoreEmergencyFund(data: AnalysisResult): HealthMetric {
   else if (months >= 1) score = 40 + ((months - 1) / 2) * 29
   else score = clamp(months * 40, 0, 39)
 
+  // Prefer the real liquid balance (bank + cash + wallets); fall back to the
+  // flow proxy only when no balance feed is attached.
+  const liquid = data.balances
+    ? data.balances.liquidAssets
+    : data.cumulativeNetSavings - (data.totalInvestmentInflow - data.totalInvestmentOutflow)
+
   return {
     name: 'Emergency Fund',
     score: Math.round(clamp(score, 0, 100)),
@@ -87,7 +93,7 @@ export function scoreEmergencyFund(data: AnalysisResult): HealthMetric {
     description: `${months.toFixed(1)} months of expenses (liquid)`,
     target: `>= ${target} months`,
     details: [
-      `Liquid savings: ${formatCurrencyCompact(data.cumulativeNetSavings - (data.totalInvestmentInflow - data.totalInvestmentOutflow))}`,
+      `Liquid balance: ${formatCurrencyCompact(liquid)}`,
       `Avg monthly expenses: ${formatCurrencyCompact(data.avgMonthlyExpense)}`,
       months >= target
         ? `Target met: ${target}+ months coverage`
@@ -229,19 +235,24 @@ export function scoreSavingsConsistency(data: AnalysisResult): HealthMetric {
 }
 
 // PLAN 8: Income stability
+// Bands anchored to JPMorgan Chase Institute's monthly-income CV distribution:
+// median ~38%, so <=40% reads as typical/stable; >100% is the extreme tail.
+// cv is recency-weighted (recent months dominate) so a now-steady earner isn't
+// dragged down by long-past lean/student months.
 export function scoreIncomeStability(data: AnalysisResult): HealthMetric {
   const cv = data.incomeCV
   const stableMax = HEALTH_SCORE_RUBRIC.incomeStabilityMaxCV
+  const moderateMax = 75
   let score: number
-  if (cv < 10) score = clamp(90 + (10 - cv), 90, 100)
-  else if (cv <= stableMax) score = 70 + ((stableMax - cv) / (stableMax - 10)) * 19
-  else if (cv <= 50) score = 40 + ((50 - cv) / (50 - stableMax)) * 29
-  else score = clamp(40 - (cv - 50) * 0.8, 0, 39)
+  if (cv < 15) score = clamp(90 + (15 - cv), 90, 100)
+  else if (cv <= stableMax) score = 70 + ((stableMax - cv) / (stableMax - 15)) * 19
+  else if (cv <= moderateMax) score = 40 + ((moderateMax - cv) / (moderateMax - stableMax)) * 29
+  else score = clamp(40 - (cv - moderateMax) * 0.6, 0, 39)
 
   let desc: string
-  if (cv < 10) desc = 'Very stable income'
+  if (cv < 15) desc = 'Very stable income'
   else if (cv <= stableMax) desc = 'Stable income'
-  else if (cv <= 50) desc = 'Moderate variability'
+  else if (cv <= moderateMax) desc = 'Moderate variability'
   else desc = 'Volatile income'
 
   return {
@@ -255,7 +266,7 @@ export function scoreIncomeStability(data: AnalysisResult): HealthMetric {
     details: [
       `Income variability (CV): ${cv.toFixed(1)}%`,
       `Avg monthly income: ${formatCurrencyCompact(data.avgMonthlyIncome)}`,
-      cv <= 25 ? 'Predictable income stream' : 'Consider building a larger buffer',
+      cv <= stableMax ? 'Predictable income stream' : 'Consider building a larger buffer',
     ],
   }
 }

--- a/frontend/src/components/analytics/health/healthScoreTypes.ts
+++ b/frontend/src/components/analytics/health/healthScoreTypes.ts
@@ -25,6 +25,26 @@ export interface MonthlyBucket {
   categories: Record<string, number>
 }
 
+/**
+ * Point-in-time balance picture derived from real account balances (not a
+ * flow proxy). Liquid = current balances of bank/cash/wallet accounts; the
+ * emergency-fund and liquidity ratios divide this by monthly living expenses.
+ * Per FHN/CFSI "Have sufficient liquid savings", the numerator is observed
+ * liquid account balances, never (lifetime income - expenses - investments).
+ */
+export interface BalancePosition {
+  /** Bank + cash + wallet balances (positive only). The emergency buffer. */
+  liquidAssets: number
+  /** Investment/retirement account balances (positive only). Not liquid. */
+  investmentAssets: number
+  /** Sum of negative balances (credit cards, loans) as a positive number. */
+  totalLiabilities: number
+  /** liquidAssets + investmentAssets. */
+  totalAssets: number
+  /** totalAssets - totalLiabilities. */
+  netWorth: number
+}
+
 export interface AnalysisResult {
   monthsAnalyzed: number
   savingsRate: number
@@ -43,6 +63,12 @@ export interface AnalysisResult {
   positiveSavingsRatio: number
   savingsVolatilityCV: number
   incomeCV: number
+  /**
+   * Real balance position from account balances, when available. Null when
+   * the score is computed from transactions alone (e.g. a preview with no
+   * balance feed) -- scorers then fall back to the cumulative-flow proxy.
+   */
+  balances: BalancePosition | null
 }
 
 export const DEBT_CATEGORIES = [
@@ -117,7 +143,10 @@ export const HEALTH_SCORE_RUBRIC = {
   debtToIncomeMaxPct: 36,
   debtTrendGoodPct: -5,
   savingsConsistencyPct: 90,
-  incomeStabilityMaxCV: 25,
+  // Median household monthly-income CV is ~38% (JPMorgan Chase Institute), so
+  // "stable" must sit around/above the median, not below it. A 25% cap flagged
+  // typical earners as volatile. CV > 100% is the genuine extreme tail (~8%).
+  incomeStabilityMaxCV: 40,
 } as const
 
 // ─── Pure helpers ─────────────────────────────────────────────────
@@ -166,6 +195,28 @@ export function coefficientOfVariation(values: number[]): number {
   if (mean === 0) return 0
   const variance = values.reduce((s, v) => s + Math.pow(v - mean, 2), 0) / values.length
   return (Math.sqrt(variance) / Math.abs(mean)) * 100
+}
+
+/**
+ * Recency-weighted coefficient of variation (%). Recent months count more
+ * than old ones, so a now-steady earner isn't flagged "volatile" by long-past
+ * student months of ~Rs0 income. `values` must be oldest-first; weights decay
+ * geometrically by `decay` per step back in time (RiskMetrics-style EWMA of
+ * deviations from the weighted mean, adapted from lambda~0.97 monthly).
+ *
+ * Returns 0 for empty input or a zero weighted mean.
+ */
+export function weightedCoefficientOfVariation(values: number[], decay = 0.9): number {
+  const n = values.length
+  if (n === 0) return 0
+  // Newest gets weight 1, each older step multiplies by `decay`.
+  const weights = values.map((_, i) => Math.pow(decay, n - 1 - i))
+  const wSum = weights.reduce((a, b) => a + b, 0)
+  if (wSum === 0) return 0
+  const wMean = values.reduce((s, v, i) => s + v * weights[i], 0) / wSum
+  if (wMean === 0) return 0
+  const wVar = values.reduce((s, v, i) => s + weights[i] * Math.pow(v - wMean, 2), 0) / wSum
+  return (Math.sqrt(wVar) / Math.abs(wMean)) * 100
 }
 
 // ─── Investment detection ─────────────────────────────────────────

--- a/frontend/src/hooks/api/useAccountClassifications.ts
+++ b/frontend/src/hooks/api/useAccountClassifications.ts
@@ -1,0 +1,24 @@
+/**
+ * Account classifications query hook.
+ *
+ * Returns the user's account -> category map (e.g. "SBI Savings" ->
+ * "Bank Accounts"). Used by the financial health score to tell liquid
+ * balances (bank/cash/wallets) apart from investment and liability accounts.
+ * Cached like the rest of the analytics data (staleTime Infinity; the cache
+ * clears on upload / settings save).
+ */
+
+import { useQuery } from '@tanstack/react-query'
+
+import { accountClassificationsService } from '@/services/api/accountClassifications'
+
+const ACCOUNT_CLASSIFICATIONS_KEY = ['account-classifications', 'all'] as const
+
+export function useAccountClassifications() {
+  return useQuery({
+    queryKey: ACCOUNT_CLASSIFICATIONS_KEY,
+    queryFn: accountClassificationsService.getAllClassifications,
+    staleTime: Infinity,
+    gcTime: 60 * 60 * 1000,
+  })
+}

--- a/frontend/src/hooks/useCountUp.ts
+++ b/frontend/src/hooks/useCountUp.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef, useState } from 'react'
+
+/**
+ * Animate a number from 0 to `value` with an ease-out cubic over `duration` ms.
+ * Returns the current animated value. Re-runs whenever `value` changes, so a
+ * score that updates when new data arrives counts up to the new figure.
+ *
+ * rAF-driven (no interval drift). Motion stays visible by design -- this app
+ * does not gate animation behind prefers-reduced-motion.
+ */
+export function useCountUp(value: number, duration = 900): number {
+  const [display, setDisplay] = useState(0)
+  const frame = useRef(0)
+  const fromRef = useRef(0)
+
+  useEffect(() => {
+    const from = fromRef.current
+    const start = performance.now()
+
+    const tick = (now: number) => {
+      const progress = Math.min((now - start) / duration, 1)
+      const eased = 1 - Math.pow(1 - progress, 3)
+      const current = from + (value - from) * eased
+      setDisplay(current)
+      if (progress < 1) {
+        frame.current = requestAnimationFrame(tick)
+      } else {
+        fromRef.current = value
+      }
+    }
+
+    frame.current = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(frame.current)
+  }, [value, duration])
+
+  return display
+}

--- a/frontend/src/lib/financialHealthCalculator.ts
+++ b/frontend/src/lib/financialHealthCalculator.ts
@@ -113,18 +113,19 @@ function computeLiquidityRatio(liquidAssets: number, monthlyExpenses: number): C
 
 /**
  * 3. Debt Service Ratio = Monthly Debt Payments / Gross Monthly Income
- * Target: <= 36% (banking standard), <= 20% ideal
+ * Target: <= 36% (banking back-end standard). Tiers per CFSI/FHN
+ * "Have a sustainable debt load": green < 36%, yellow 36-43%, red > 43%.
  */
 function computeDebtServiceRatio(monthlyDebt: number, monthlyIncome: number): CFPRatio {
   const value = monthlyIncome > 0 ? (monthlyDebt / monthlyIncome) * 100 : 0
-  const score = mapToScoreInverse(value, [5, 15, 25, 36, 50])
+  const score = mapToScoreInverse(value, [10, 20, 36, 43, 55])
   return {
     name: 'Debt Service Ratio',
     value,
     score: Math.round(clamp(score, 0, 100)),
     target: '<= 36%',
     status: statusFromScore(score),
-    description: describeByThresholdInverse(value, [[20, 'Healthy debt levels'], [36, 'Within banking limits']], 'High debt burden'),
+    description: describeByThresholdInverse(value, [[20, 'Healthy debt levels'], [36, 'Within banking limits'], [43, 'Elevated debt load']], 'High debt burden'),
     formattedValue: `${value.toFixed(1)}%`,
   }
 }
@@ -149,8 +150,9 @@ function computeInvestmentRatio(netInvestments: number, totalIncome: number): CF
 
 /**
  * 5. Solvency Ratio = Net Worth / Total Assets
- * Target: > 50%, approaching 100% as debt is paid off
- * Approximated as (cumulative savings) / (cumulative savings + total debt outstanding)
+ * Target: >= 50% (higher is better, approaching 100% as debt is paid off).
+ * Uses real net worth from account balances when available; otherwise
+ * approximated from cumulative savings minus outstanding debt.
  */
 function computeSolvencyRatio(netWorth: number, totalAssets: number): CFPRatio {
   let value: number
@@ -169,11 +171,12 @@ function computeSolvencyRatio(netWorth: number, totalAssets: number): CFPRatio {
 }
 
 /**
- * 6. Emergency Fund Coverage = Liquid Balance / Monthly Essential Expenses
- * Target: 3-6 months (salaried), 9-12 months (self-employed)
+ * 6. Emergency Fund Coverage = Liquid Balance / Monthly Living Expenses
+ * Target: 3-6 months (FHN/CFSI score against total living expenses).
+ * 6+ months = top tier, 3-5 next, under 1 month = red.
  */
-function computeEmergencyFundCoverage(liquidBalance: number, monthlyEssentials: number): CFPRatio {
-  const value = monthlyEssentials > 0 ? liquidBalance / monthlyEssentials : 0
+function computeEmergencyFundCoverage(liquidBalance: number, monthlyExpenses: number): CFPRatio {
+  const value = monthlyExpenses > 0 ? liquidBalance / monthlyExpenses : 0
   const score = mapToScore(value, [0, 1, 3, 6, 12])
   return {
     name: 'Emergency Fund',
@@ -190,6 +193,20 @@ function computeEmergencyFundCoverage(liquidBalance: number, monthlyEssentials: 
 const WEIGHTS = [20, 15, 20, 15, 15, 15] as const
 
 /**
+ * Real balance position from account balances. When supplied, the liquidity,
+ * solvency, and emergency-fund ratios use observed balances instead of the
+ * cumulative-flow proxy (which reads 0 for anyone whose lifetime investing
+ * exceeds their lifetime cash surplus).
+ */
+export interface BalanceInputs {
+  liquidAssets: number
+  investmentAssets: number
+  totalLiabilities: number
+  totalAssets: number
+  netWorth: number
+}
+
+/**
  * Compute all 6 CFP ratios and a weighted composite score.
  */
 export function computeCFPScore(params: {
@@ -202,33 +219,48 @@ export function computeCFPScore(params: {
   cumulativeNetSavings: number
   netInvestments: number
   totalDebtOutstanding: number
+  /** Real balances; when present, override the flow-based asset proxy. */
+  balances?: BalanceInputs | null
 }): CFPScoreResult {
   const {
     totalIncome,
     totalExpenses,
     avgMonthlyIncome,
     avgMonthlyExpense,
-    avgMonthlyEssentialExpense,
     avgMonthlyDebt,
     cumulativeNetSavings,
     netInvestments,
     totalDebtOutstanding,
+    balances,
   } = params
 
-  // Liquid assets = net savings minus money locked in investments
-  const liquidAssets = Math.max(0, cumulativeNetSavings - Math.max(0, netInvestments))
-  const totalAssets = liquidAssets + Math.max(0, netInvestments)
-  // Net worth must subtract outstanding debt; otherwise solvency is always
-  // 100% (netWorth === totalAssets) and debt has no effect on the score.
-  const netWorth = totalAssets - Math.max(0, totalDebtOutstanding)
+  let liquidAssets: number
+  let totalAssets: number
+  let netWorth: number
+  if (balances) {
+    // Observed balances: liquid = bank/cash/wallets, and net worth already
+    // nets out real liabilities (negative-balance accounts).
+    liquidAssets = balances.liquidAssets
+    totalAssets = balances.totalAssets
+    netWorth = balances.netWorth
+  } else {
+    // Fallback proxy: liquid = net savings minus money locked in investments.
+    liquidAssets = Math.max(0, cumulativeNetSavings - Math.max(0, netInvestments))
+    totalAssets = liquidAssets + Math.max(0, netInvestments)
+    // Net worth must subtract outstanding debt; otherwise solvency is always
+    // 100% (netWorth === totalAssets) and debt has no effect on the score.
+    netWorth = totalAssets - Math.max(0, totalDebtOutstanding)
+  }
 
+  // Emergency fund is scored on total monthly living expenses (FHN/CFSI use
+  // total living expenses, not essential-only).
   const ratios: CFPRatio[] = [
     computeSavingsRate(totalIncome, totalExpenses),
     computeLiquidityRatio(liquidAssets, avgMonthlyExpense),
     computeDebtServiceRatio(avgMonthlyDebt, avgMonthlyIncome),
     computeInvestmentRatio(netInvestments, totalIncome),
     computeSolvencyRatio(netWorth, totalAssets > 0 ? totalAssets : 1),
-    computeEmergencyFundCoverage(liquidAssets, avgMonthlyEssentialExpense),
+    computeEmergencyFundCoverage(liquidAssets, avgMonthlyExpense),
   ]
 
   const compositeScore = Math.round(


### PR DESCRIPTION
## Problem

The dashboard's **FinHealth Score** and **CFP Ratios** cards read wrong. In the reference profile: Emergency Fund = 0 months, Liquidity Ratio = 0 mo, and Income Stability flagged "volatile" (34) despite steady real balances and a steady salary.

Root cause: both cards derived "liquid assets" as a **flow proxy** -- `cumulative income - expenses - net investments` -- and clamped it to 0. For anyone whose lifetime investing exceeds their lifetime cash surplus, that proxy goes negative and clamps to 0, so the emergency-fund and liquidity ratios read 0 even with real money in the bank. The scorecard never looked at actual account balances.

## Fix

Grounded in a verified research pass over CFP Board / FPSB India / Financial Health Network (FHN/CFSI) / JPMorgan Chase Institute standards:

- **Liquid assets = real current balances** of bank + cash + wallet accounts (new `computeBalancePosition`), classified via the same account-category logic net worth uses. Investments are valued separately; liabilities come from negative balances. Falls back to the old flow proxy only when no balance feed is attached (e.g. a preview with transactions only).
- **Emergency fund + liquidity** now divide real liquid balances by monthly living expenses. Per FHN/CFSI the denominator is **total** living expenses, not essential-only (this corrected an initial assumption).
- **Solvency** uses real net worth / total assets (target >= 50%).
- **Income stability**: recency-weighted CV (RiskMetrics-style EWMA of deviations) over the trailing 12 months, so old lean/student months don't drag down a now-steady earner. Bands widened -- median household monthly-income CV is ~38% (JPMorgan Chase Institute), so <=40% now reads as stable; >100% is the genuine extreme tail. The old 25% cap flagged typical earners as volatile.
- **Debt-service tiers** aligned to the banking standard (green <36% / yellow 36-43% / red >43%).
- **Motion polish** (portfolio-react inspiration): count-up on score headers, staggered card reveals, spring-animated bars.

## Verification

- `pnpm run lint` clean, `pnpm run type-check` clean, `pnpm test` 315 passed (11 new).
- Live in demo mode: Emergency Fund now **40.8 months / score 100** (was 0), Liquidity **40.8 mo** "Strong liquidity buffer" (was 0), Solvency **94%**, Income Stability **79** (was 34). The demo profile is an extreme saver, so 40 months is the correct read of its real balances -- the bug was the 0.

## Notes

New unit tests in `healthScore.test.ts` cover the balance position (liquid vs investment vs liability split, excluded accounts), the weighted CV (recency behavior), and the CFP ratios from real balances plus the flow-proxy fallback.
