### PR TITLE
feat(cash-flow): drill-down sankey with breadcrumb navigation

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,7 @@
     "react-dom": "^19.2.7",
     "react-dropzone": "^15.0.0",
     "react-router-dom": "^7.18.0",
-    "recharts": "^3.9.0",
+    "recharts": "^3.10.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: ^7.18.0
         version: 7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       recharts:
-        specifier: ^3.9.0
-        version: 3.9.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.3)(react@19.2.7)(redux@5.0.1)
+        specifier: ^3.10.0
+        version: 3.10.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.3)(react@19.2.7)(redux@5.0.1)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -59,7 +59,7 @@ importers:
         version: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz
       zustand:
         specifier: ^5.0.14
-        version: 5.0.14(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
+        version: 5.0.14(@types/react@19.2.17)(immer@11.1.15)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -1856,8 +1856,8 @@ packages:
     resolution: {integrity: sha512-CxN9N56HYfd2m/acc/NOFrZQsN9kU4eh+2kk6A707Kz1krH8tKmfrs5RnftB8WNX80T0NS7vSQsDOlg23diR2g==}
     engines: {node: '>= 0.4'}
 
-  es-toolkit@1.48.1:
-    resolution: {integrity: sha512-wfnXlwd5I75eXRtdD2vuEs50xHHESECDsGD7yiQnfFVNoa5522NwXEbmgo98LfiukSQHs+mBM7/YG3qKJB9/mQ==}
+  es-toolkit@1.49.0:
+    resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -2148,11 +2148,8 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
-  immer@10.2.0:
-    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
-
-  immer@11.1.8:
-    resolution: {integrity: sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==}
+  immer@11.1.15:
+    resolution: {integrity: sha512-VrNANlmnWQnh5COXIIOQXM9oOJw7naGKlBT74ZOOR6lpVXc3gFEu9FJLDFcpCJ2j+NWr8TIwtWD//T6ZX6TKiQ==}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -2723,8 +2720,8 @@ packages:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
-  recharts@3.9.0:
-    resolution: {integrity: sha512-dCEcE9y20c8H2tkVeByrAXhhnBJk6/QLbxKmn+dJUptOfc5NMjwRh1jo0vZPRLD+5dMrHrP+hPEsfbGBMfnf5Q==}
+  recharts@3.10.0:
+    resolution: {integrity: sha512-wulMvfncpIlmu2uFtRU/mE5/+NiVtASXkw2KdwJTdHs3WsASX0WxZlX+rpKgyn5BDbIhkPtCpUKkB9XNK5KE0w==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -3338,7 +3335,7 @@ packages:
     resolution: {integrity: sha512-/bIYdBLAVsNR3v7gYGaV4pQW3M3kEPx5E8vDxGvxo6khTrGtSSCS7QiFKv9ogzBgZiy0OXLP9zO28U/1nF1mfw==}
 
   xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz:
-    resolution: {tarball: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz, integrity: sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA==}
+    resolution: {integrity: sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA==, tarball: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz}
     version: 0.20.3
     engines: {node: '>=0.8'}
     hasBin: true
@@ -4295,7 +4292,7 @@ snapshots:
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@standard-schema/utils': 0.3.0
-      immer: 11.1.8
+      immer: 11.1.15
       redux: 5.0.1
       redux-thunk: 3.1.0(redux@5.0.1)
       reselect: 5.2.0
@@ -5275,7 +5272,7 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
-  es-toolkit@1.48.1: {}
+  es-toolkit@1.49.0: {}
 
   escalade@3.2.0: {}
 
@@ -5612,9 +5609,7 @@ snapshots:
 
   ignore@7.0.5: {}
 
-  immer@10.2.0: {}
-
-  immer@11.1.8: {}
+  immer@11.1.15: {}
 
   imurmurhash@0.1.4: {}
 
@@ -6138,14 +6133,14 @@ snapshots:
 
   react@19.2.7: {}
 
-  recharts@3.9.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.3)(react@19.2.7)(redux@5.0.1):
+  recharts@3.10.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@19.2.3)(react@19.2.7)(redux@5.0.1):
     dependencies:
       '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1))(react@19.2.7)
       clsx: 2.1.1
       decimal.js-light: 2.5.1
-      es-toolkit: 1.48.1
+      es-toolkit: 1.49.0
       eventemitter3: 5.0.4
-      immer: 10.2.0
+      immer: 11.1.15
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       react-is: 19.2.3
@@ -6933,9 +6928,9 @@ snapshots:
 
   zod@4.4.3: {}
 
-  zustand@5.0.14(@types/react@19.2.17)(immer@11.1.8)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)):
+  zustand@5.0.14(@types/react@19.2.17)(immer@11.1.15)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)):
     optionalDependencies:
       '@types/react': 19.2.17
-      immer: 11.1.8
+      immer: 11.1.15
       react: 19.2.7
       use-sync-external-store: 1.6.0(react@19.2.7)

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -14,3 +14,6 @@ onlyBuiltDependencies:
 
 allowBuilds:
   sharp: true
+
+minimumReleaseAgeExclude:
+  - recharts@3.10.0

--- a/frontend/src/components/shared/MetricCard.tsx
+++ b/frontend/src/components/shared/MetricCard.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 
+import { motion } from 'framer-motion'
 import { ArrowDownRight, ArrowUpRight } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { Link } from 'react-router-dom'
@@ -63,7 +64,9 @@ export default function MetricCard({
   const ChangeIcon = isPositive ? ArrowUpRight : ArrowDownRight
 
   const content = (
-    <div
+    <motion.div
+      whileHover={{ y: -3 }}
+      transition={{ type: 'spring', stiffness: 400, damping: 25 }}
       className={cn(
         'metric-card ledger-panel group relative min-h-28 overflow-hidden p-4 text-left transition-colors duration-150',
         isInteractive && 'hover:border-[var(--hairline-4)] hover:bg-[var(--overlay-1)]',
@@ -124,7 +127,7 @@ export default function MetricCard({
           )}
         </div>
       </div>
-    </div>
+    </motion.div>
   )
 
   if (href) {

--- a/frontend/src/components/ui/PageContainer.tsx
+++ b/frontend/src/components/ui/PageContainer.tsx
@@ -1,5 +1,8 @@
 import type { ReactNode } from 'react'
 
+import { motion } from 'framer-motion'
+
+import { PAGE_ENTER } from '@/constants/animations'
 import { cn } from '@/lib/cn'
 
 /**
@@ -26,6 +29,9 @@ import { cn } from '@/lib/cn'
  * `maxWidth` defaults to `7xl` (the analytics-page norm). Pages that read best
  * narrower -- Settings / Upload -- pass `5xl` so they can adopt this scaffold
  * without widening their content column.
+ *
+ * The inner wrapper carries the shared page-entrance motion (PAGE_ENTER), so
+ * every page fades up on navigation without per-page wiring.
  */
 type MaxWidth = '7xl' | '5xl' | '4xl'
 
@@ -46,9 +52,12 @@ interface PageContainerProps {
 export default function PageContainer({ children, className, maxWidth = '7xl' }: PageContainerProps) {
   return (
     <div className="min-h-full px-[max(1rem,env(safe-area-inset-left))] py-5 md:px-[max(1.5rem,env(safe-area-inset-left))] md:py-6 lg:px-[max(2rem,env(safe-area-inset-left))]">
-      <div className={cn(MAX_WIDTH_CLASSES[maxWidth], 'mx-auto space-y-5 md:space-y-6', className)}>
+      <motion.div
+        {...PAGE_ENTER}
+        className={cn(MAX_WIDTH_CLASSES[maxWidth], 'mx-auto space-y-5 md:space-y-6', className)}
+      >
         {children}
-      </div>
+      </motion.div>
     </div>
   )
 }

--- a/frontend/src/components/ui/PageHeader.tsx
+++ b/frontend/src/components/ui/PageHeader.tsx
@@ -1,5 +1,9 @@
 import { memo, type ReactNode } from 'react'
 
+import { motion } from 'framer-motion'
+
+import { HEADER_ENTER } from '@/constants/animations'
+
 interface PageHeaderProps {
   title: string
   subtitle?: string
@@ -13,14 +17,14 @@ const PageHeader = memo(function PageHeader({
 }: Readonly<PageHeaderProps>) {
   return (
     <header className="flex flex-col gap-3 border-b border-[var(--hairline-1)] pb-5 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
-      <div className="min-w-0">
+      <motion.div {...HEADER_ENTER} className="min-w-0">
         <h1 className="text-page-title text-balance text-foreground">{title}</h1>
         {subtitle && (
           <p className="mt-1 max-w-2xl text-pretty text-sm leading-5 text-muted-foreground">
             {subtitle}
           </p>
         )}
-      </div>
+      </motion.div>
       {action && (
         <div className="flex min-w-0 w-full flex-wrap items-center gap-2 sm:w-auto sm:shrink-0">
           {action}

--- a/frontend/src/constants/animations.ts
+++ b/frontend/src/constants/animations.ts
@@ -80,3 +80,57 @@ export const cardHover = {
   y: -4,
   transition: { type: 'spring' as const, stiffness: 400, damping: 25 },
 }
+
+/** MetricCard / stat-tile hover: subtle lift with a quick spring. */
+export const HOVER_LIFT = {
+  whileHover: { y: -3 },
+  transition: { type: 'spring' as const, stiffness: 400, damping: 25 },
+} as const
+
+// ---------------------------------------------------------------------------
+// Page-level presets (adapted from brand/portfolio-react's motion vocabulary)
+// ---------------------------------------------------------------------------
+
+/** Whole-page content entrance: one quiet fade-up on navigation. Applied by
+ * PageContainer so every page gets it without per-page wiring. */
+export const PAGE_ENTER = {
+  initial: { opacity: 0, y: 14 },
+  animate: { opacity: 1, y: 0 },
+  transition: { duration: 0.45, ease: [0.25, 0.46, 0.45, 0.94] as const },
+} as const
+
+/** PageHeader title block: slides in slightly ahead of the body. */
+export const HEADER_ENTER = {
+  initial: { opacity: 0, y: -10 },
+  animate: { opacity: 1, y: 0 },
+  transition: { duration: 0.4, ease: 'easeOut' as const },
+} as const
+
+/** Section reveal with a hint of scale (portfolio-react sectionRevealEnhanced). */
+export const sectionReveal: Variants = {
+  hidden: { opacity: 0, y: 32, scale: 0.99 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    scale: 1,
+    transition: { duration: 0.55, ease: [0.25, 0.46, 0.45, 0.94] },
+  },
+}
+
+/** Wave cascade for dense grids of small items (portfolio-react skill tags). */
+export const waveCascadeContainer: Variants = {
+  hidden: {},
+  visible: {
+    transition: { staggerChildren: 0.04, delayChildren: 0.1 },
+  },
+}
+
+export const waveCascadeItem: Variants = {
+  hidden: { opacity: 0, y: 24, scale: 0.9 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    scale: 1,
+    transition: { duration: 0.35, ease: 'easeOut' },
+  },
+}

--- a/frontend/src/lib/demo/demoTemplates.ts
+++ b/frontend/src/lib/demo/demoTemplates.ts
@@ -63,6 +63,10 @@ export const EXPENSE_TEMPLATES: readonly ExpenseTemplate[] = [
   { category: 'Family', subcategory: 'Extra Expenses', min: 1000, max: 30000, account: ACCOUNTS.hdfc, freq: 0.3 },
   { category: 'Charity', subcategory: 'Donations', min: 100, max: 2000, account: ACCOUNTS.gpay, freq: 0.3 },
   { category: 'Charity', subcategory: 'Religious Offerings', min: 50, max: 500, account: ACCOUNTS.cash, freq: 0.2 },
+  // Payroll taxes, deducted monthly at source alongside payday. Two
+  // subcategories so the Cash Flow sankey's Tax branch is drillable.
+  { category: 'Tax', subcategory: 'TDS on Salary', min: 6500, max: 9500, account: ACCOUNTS.hdfc, day: 1 },
+  { category: 'Tax', subcategory: 'Professional Tax', min: 200, max: 200, account: ACCOUNTS.hdfc, day: 1 },
   { category: 'Miscellaneous', subcategory: 'Unknown', min: 50, max: 2000, account: ACCOUNTS.sbi, freq: 2 },
   { category: 'Miscellaneous', subcategory: 'Software Subscriptions', min: 100, max: 1500, account: ACCOUNTS.swiggyCC, freq: 0.3 },
   { category: 'Miscellaneous', subcategory: 'Bank Fees', min: 50, max: 500, account: ACCOUNTS.sbi, freq: 0.2 },

--- a/frontend/src/pages/income-expense-flow/IncomeExpenseFlowPage.tsx
+++ b/frontend/src/pages/income-expense-flow/IncomeExpenseFlowPage.tsx
@@ -28,6 +28,8 @@ const IncomeExpenseFlowPage = () => {
         isMobile={m.isMobile}
         view={m.view}
         drillPath={m.drillPath}
+        drillDirection={m.drillDirection}
+        zoomOrigin={m.zoomOrigin}
         drillTo={m.drillTo}
         drillInto={m.drillInto}
         drillBack={m.drillBack}

--- a/frontend/src/pages/income-expense-flow/IncomeExpenseFlowPage.tsx
+++ b/frontend/src/pages/income-expense-flow/IncomeExpenseFlowPage.tsx
@@ -38,6 +38,7 @@ const IncomeExpenseFlowPage = () => {
         topExpense={m.topExpense}
         totalIncome={m.totalIncome}
         totalExpense={m.totalExpense}
+        totalTax={m.totalTax}
         netSavings={m.netSavings}
         currentFY={m.currentFY}
       />

--- a/frontend/src/pages/income-expense-flow/IncomeExpenseFlowPage.tsx
+++ b/frontend/src/pages/income-expense-flow/IncomeExpenseFlowPage.tsx
@@ -26,7 +26,11 @@ const IncomeExpenseFlowPage = () => {
       <SankeyChart
         isLoading={m.isLoading}
         isMobile={m.isMobile}
-        sankeyData={m.sankeyData}
+        view={m.view}
+        drillPath={m.drillPath}
+        drillTo={m.drillTo}
+        drillInto={m.drillInto}
+        drillBack={m.drillBack}
         sankeyNodeComponent={m.sankeyNodeComponent}
         topIncome={m.topIncome}
         topExpense={m.topExpense}

--- a/frontend/src/pages/income-expense-flow/__tests__/sankeyDrilldown.test.ts
+++ b/frontend/src/pages/income-expense-flow/__tests__/sankeyDrilldown.test.ts
@@ -9,6 +9,7 @@ import {
   buildOverviewView,
   countSubBuckets,
   foldTopWithOther,
+  isTaxCategory,
   SANKEY_TOP_N,
   type DrillCrumb,
 } from '../sankeyDrilldown'
@@ -179,5 +180,46 @@ describe('buildOverviewView', () => {
     })
     const savingsIndex = view.nodes.findIndex((n) => n.name === 'Savings')
     expect(view.links.some((l) => l.target === savingsIndex)).toBe(false)
+  })
+
+  it('adds a Tax branch out of Total Income when tax exists, hides it otherwise', () => {
+    const withTax = buildOverviewView({
+      incomeEntries: [{ name: 'Salary', amount: 100000 }],
+      expenseEntries: [{ name: 'Family', amount: 30000 }],
+      totalIncome: 100000,
+      totalExpense: 30000,
+      netSavings: 62000,
+      totalTax: 8000,
+    })
+    const taxIndex = withTax.nodes.findIndex((n) => n.name === 'Tax')
+    expect(taxIndex).toBeGreaterThan(-1)
+    const totalIncomeIndex = withTax.nodes.findIndex((n) => n.name === 'Total Income')
+    const taxLink = withTax.links.find((l) => l.target === taxIndex)
+    expect(taxLink?.source).toBe(totalIncomeIndex)
+    expect(taxLink?.value).toBe(8000)
+    // Income splits exactly: tax + savings + expenses = total income.
+    const outflows = withTax.links.filter((l) => l.source === totalIncomeIndex)
+    expect(outflows.reduce((s, l) => s + l.value, 0)).toBe(100000)
+
+    const noTax = buildOverviewView({
+      incomeEntries: [{ name: 'Salary', amount: 100000 }],
+      expenseEntries: [{ name: 'Family', amount: 30000 }],
+      totalIncome: 100000,
+      totalExpense: 30000,
+      netSavings: 70000,
+    })
+    expect(noTax.nodes.some((n) => n.name === 'Tax')).toBe(false)
+  })
+})
+
+describe('isTaxCategory', () => {
+  it('matches tax-like category names, not lookalikes', () => {
+    expect(isTaxCategory('Tax')).toBe(true)
+    expect(isTaxCategory('Taxes')).toBe(true)
+    expect(isTaxCategory('Income Tax')).toBe(true)
+    expect(isTaxCategory('TDS')).toBe(true)
+    expect(isTaxCategory('Advance Tax')).toBe(true)
+    expect(isTaxCategory('Taxi')).toBe(false)
+    expect(isTaxCategory('Transportation')).toBe(false)
   })
 })

--- a/frontend/src/pages/income-expense-flow/__tests__/sankeyDrilldown.test.ts
+++ b/frontend/src/pages/income-expense-flow/__tests__/sankeyDrilldown.test.ts
@@ -210,6 +210,36 @@ describe('buildOverviewView', () => {
     })
     expect(noTax.nodes.some((n) => n.name === 'Tax')).toBe(false)
   })
+
+  it('shows computed TDS at both ends: source node into Gross Income and inside the Tax branch', () => {
+    // Recorded (net) income 100k; slab-computed TDS 12k on top; 2k explicit tax
+    // transactions. Tax branch = 14k; gross = 112k.
+    const view = buildOverviewView({
+      incomeEntries: [{ name: 'Salary', amount: 100000 }],
+      expenseEntries: [{ name: 'Family', amount: 30000 }],
+      totalIncome: 100000,
+      totalExpense: 30000,
+      netSavings: 68000, // 100000 - 30000 - 2000 explicit tax
+      totalTax: 14000, // 2000 explicit + 12000 TDS
+      tdsAtSource: 12000,
+    })
+    const names = view.nodes.map((n) => n.name)
+    expect(names).toContain('Tax Deducted at Source')
+    expect(names).toContain('Gross Income')
+    expect(names).not.toContain('Total Income')
+
+    const grossIndex = names.indexOf('Gross Income')
+    const tdsIndex = names.indexOf('Tax Deducted at Source')
+    // Income side: TDS feeds gross alongside recorded income.
+    const inflows = view.links.filter((l) => l.target === grossIndex)
+    expect(inflows.reduce((s, l) => s + l.value, 0)).toBe(112000)
+    expect(inflows.some((l) => l.source === tdsIndex && l.value === 12000)).toBe(true)
+    // Outflow side: tax + savings + expenses reconcile back to gross.
+    const outflows = view.links.filter((l) => l.source === grossIndex)
+    expect(outflows.reduce((s, l) => s + l.value, 0)).toBe(112000)
+    const taxIndex = names.indexOf('Tax')
+    expect(view.links.find((l) => l.target === taxIndex)?.value).toBe(14000)
+  })
 })
 
 describe('isTaxCategory', () => {

--- a/frontend/src/pages/income-expense-flow/__tests__/sankeyDrilldown.test.ts
+++ b/frontend/src/pages/income-expense-flow/__tests__/sankeyDrilldown.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Transaction } from '@/types'
+
+import {
+  attachOverviewDrills,
+  buildCategoryView,
+  buildOtherView,
+  buildOverviewView,
+  countSubBuckets,
+  foldTopWithOther,
+  SANKEY_TOP_N,
+  type DrillCrumb,
+} from '../sankeyDrilldown'
+
+function txn(
+  type: 'Income' | 'Expense',
+  category: string,
+  amount: number,
+  subcategory?: string,
+): Transaction {
+  return {
+    id: `${type}-${category}-${subcategory ?? 'none'}-${amount}`,
+    date: '2026-05-10',
+    amount,
+    type,
+    category,
+    subcategory,
+    account: 'Bank',
+  }
+}
+
+describe('foldTopWithOther', () => {
+  it('keeps all categories when at or under the cap', () => {
+    const { entries, tail } = foldTopWithOther({ A: 300, B: 200, C: 100 }, 'Other Expense')
+    expect(entries.map((e) => e.name)).toEqual(['A', 'B', 'C'])
+    expect(tail).toEqual([])
+  })
+
+  it('folds the tail into Other (n) and preserves the grand total', () => {
+    const byCategory: Record<string, number> = {}
+    for (let i = 0; i < SANKEY_TOP_N + 3; i++) byCategory[`Cat${i}`] = 1000 - i * 10
+    const { entries, tail } = foldTopWithOther(byCategory, 'Other Expense')
+    expect(entries).toHaveLength(SANKEY_TOP_N + 1)
+    expect(entries.at(-1)!.name).toBe('Other Expense (3)')
+    expect(tail).toHaveLength(3)
+    const visible = entries.reduce((s, e) => s + e.amount, 0)
+    const total = Object.values(byCategory).reduce((a, b) => a + b, 0)
+    expect(visible).toBe(total)
+  })
+})
+
+describe('countSubBuckets + attachOverviewDrills', () => {
+  const txns = [
+    txn('Expense', 'Family', 500, 'Parents'),
+    txn('Expense', 'Family', 300, 'Sister'),
+    txn('Expense', 'Rent', 15000), // single bucket -> leaf
+    txn('Income', 'Salary', 90000, 'Base'),
+    txn('Income', 'Salary', 10000, 'Bonus'),
+  ]
+
+  it('categories with >= 2 sub-buckets get a category drill; single-bucket ones stay leaves', () => {
+    const buckets = countSubBuckets(txns)
+    const entries = attachOverviewDrills(
+      [
+        { name: 'Family', amount: 800 },
+        { name: 'Rent', amount: 15000 },
+      ],
+      [],
+      'expense',
+      buckets.expense,
+    )
+    expect(entries[0].drill).toEqual({ label: 'Family', view: 'category', flow: 'expense' })
+    expect(entries[1].drill).toBeNull()
+  })
+
+  it('the folded Other entry drills into its tail', () => {
+    const buckets = countSubBuckets(txns)
+    const entries = attachOverviewDrills(
+      [
+        { name: 'Family', amount: 800 },
+        { name: 'Other Expense (2)', amount: 999 },
+      ],
+      [
+        { name: 'Snacks', amount: 600 },
+        { name: 'Books', amount: 399 },
+      ],
+      'expense',
+      buckets.expense,
+    )
+    const other = entries[1]
+    expect(other.drill?.view).toBe('other')
+    expect(other.drill?.tail?.map((t) => t.name)).toEqual(['Snacks', 'Books'])
+  })
+})
+
+describe('buildCategoryView', () => {
+  const txns = [
+    txn('Expense', 'Family', 500, 'Parents'),
+    txn('Expense', 'Family', 300, 'Sister'),
+    txn('Expense', 'Family', 200), // no subcategory
+    txn('Expense', 'Rent', 15000),
+    txn('Income', 'Salary', 90000, 'Base'),
+  ]
+  const crumb: DrillCrumb = { label: 'Family', view: 'category', flow: 'expense' }
+
+  it('builds parent -> subcategory links whose values sum to the category total', () => {
+    const view = buildCategoryView(txns, crumb)
+    expect(view.nodes[0].name).toBe('Family')
+    const linkSum = view.links.reduce((s, l) => s + l.value, 0)
+    expect(linkSum).toBe(1000)
+    expect(view.rowsTotal).toBe(1000)
+    // Every link starts at the parent (index 0) for an expense drill.
+    expect(view.links.every((l) => l.source === 0)).toBe(true)
+    const names = view.nodes.map((n) => n.name)
+    expect(names).toContain('Parents')
+    expect(names).toContain('Sister')
+    expect(names).toContain('(no subcategory)')
+  })
+
+  it('orients income drills subcategories -> parent (money flows left to right)', () => {
+    const incomeTxns = [txn('Income', 'Salary', 90000, 'Base'), txn('Income', 'Salary', 10000, 'Bonus')]
+    const view = buildCategoryView(incomeTxns, { label: 'Salary', view: 'category', flow: 'income' })
+    const parentIndex = view.nodes.length - 1
+    expect(view.nodes[parentIndex].name).toBe('Salary')
+    expect(view.links.every((l) => l.target === parentIndex)).toBe(true)
+    expect(view.links.reduce((s, l) => s + l.value, 0)).toBe(100000)
+  })
+
+  it('never emits zero or negative links (recharts NaN-layout guard)', () => {
+    const weird = [txn('Expense', 'Family', 500, 'Parents'), txn('Expense', 'Family', 0, 'Zero')]
+    const view = buildCategoryView(weird, crumb)
+    expect(view.links.every((l) => l.value > 0)).toBe(true)
+  })
+})
+
+describe('buildOtherView', () => {
+  it('unfolds the tail with one link per category', () => {
+    const crumb: DrillCrumb = {
+      label: 'Other Expense (2)',
+      view: 'other',
+      flow: 'expense',
+      tail: [
+        { name: 'Snacks', amount: 600, drill: null },
+        { name: 'Books', amount: 400, drill: null },
+      ],
+    }
+    const view = buildOtherView(crumb)
+    expect(view.nodes.map((n) => n.name)).toEqual(['Other Expense (2)', 'Snacks', 'Books'])
+    expect(view.links.reduce((s, l) => s + l.value, 0)).toBe(1000)
+  })
+})
+
+describe('buildOverviewView', () => {
+  it('reproduces the classic topology with per-node meta', () => {
+    const view = buildOverviewView({
+      incomeEntries: [{ name: 'Salary', amount: 100000 }],
+      expenseEntries: [{ name: 'Family', amount: 30000 }],
+      totalIncome: 100000,
+      totalExpense: 30000,
+      netSavings: 70000,
+    })
+    const names = view.nodes.map((n) => n.name)
+    expect(names).toEqual(['Salary', 'Total Income', 'Savings', 'Expenses', 'Family'])
+    // meta values line up with node order
+    expect(view.meta[0].value).toBe(100000)
+    expect(view.meta[2].value).toBe(70000)
+    // income link + 2 hub links + 1 expense link
+    expect(view.links).toHaveLength(4)
+  })
+
+  it('omits the savings link in a deficit period', () => {
+    const view = buildOverviewView({
+      incomeEntries: [{ name: 'Salary', amount: 50000 }],
+      expenseEntries: [{ name: 'Family', amount: 60000 }],
+      totalIncome: 50000,
+      totalExpense: 60000,
+      netSavings: -10000,
+    })
+    const savingsIndex = view.nodes.findIndex((n) => n.name === 'Savings')
+    expect(view.links.some((l) => l.target === savingsIndex)).toBe(false)
+  })
+})

--- a/frontend/src/pages/income-expense-flow/components/MobileFlowView.tsx
+++ b/frontend/src/pages/income-expense-flow/components/MobileFlowView.tsx
@@ -11,6 +11,7 @@ interface Props {
   readonly expenseByCategory: readonly FlowEntry[]
   readonly totalIncome: number
   readonly totalExpense: number
+  readonly totalTax: number
   readonly netSavings: number
   readonly view: SankeyView
   readonly drillPath: DrillCrumb[]
@@ -29,6 +30,7 @@ export default function MobileFlowView({
   expenseByCategory,
   totalIncome,
   totalExpense,
+  totalTax,
   netSavings,
   view,
   drillPath,
@@ -140,8 +142,8 @@ export default function MobileFlowView({
         <SplitShareBar savingsShare={savingsShare} expenseShare={expenseShare} />
       )}
 
-      {/* Savings vs Expenses split */}
-      <div className="grid grid-cols-2 gap-3">
+      {/* Savings vs Expenses (vs Tax when present) split */}
+      <div className={totalTax > 0 ? 'grid grid-cols-3 gap-2' : 'grid grid-cols-2 gap-3'}>
         <SplitCard
           label="Savings"
           amount={Math.max(netSavings, 0)}
@@ -154,6 +156,14 @@ export default function MobileFlowView({
           percent={expenseShare}
           color={rawColors.app.red}
         />
+        {totalTax > 0 && (
+          <SplitCard
+            label="Tax"
+            amount={totalTax}
+            percent={totalIncome > 0 ? totalTax / totalIncome : 0}
+            color={rawColors.app.orange}
+          />
+        )}
       </div>
 
       {expenseByCategory.length > 0 && (

--- a/frontend/src/pages/income-expense-flow/components/MobileFlowView.tsx
+++ b/frontend/src/pages/income-expense-flow/components/MobileFlowView.tsx
@@ -1,25 +1,27 @@
 import { motion } from 'framer-motion'
-import { ArrowDown } from 'lucide-react'
+import { ArrowDown, ChevronRight } from 'lucide-react'
 
 import { rawColors } from '@/constants/colors'
 import { formatCurrency, formatPercent } from '@/lib/formatters'
 
-interface CategoryEntry {
-  readonly name: string
-  readonly amount: number
-}
+import type { DrillCrumb, FlowEntry, SankeyView } from '../sankeyDrilldown'
 
 interface Props {
-  readonly incomeByCategory: readonly CategoryEntry[]
-  readonly expenseByCategory: readonly CategoryEntry[]
+  readonly incomeByCategory: readonly FlowEntry[]
+  readonly expenseByCategory: readonly FlowEntry[]
   readonly totalIncome: number
   readonly totalExpense: number
   readonly netSavings: number
+  readonly view: SankeyView
+  readonly drillPath: DrillCrumb[]
+  readonly drillInto: (crumb: DrillCrumb) => void
 }
 
 /**
  * Mobile-first vertical flow: Income sources -> Total Income -> Savings + Expenses split
  * -> Expense categories. Bar width is proportional to the row's share of its section.
+ * Rows with a breakdown are tappable and drill into subcategories (the page-level
+ * breadcrumb handles the way back).
  */
 export default function MobileFlowView({
   incomeByCategory,
@@ -27,7 +29,42 @@ export default function MobileFlowView({
   totalIncome,
   totalExpense,
   netSavings,
+  view,
+  drillPath,
+  drillInto,
 }: Props) {
+  const crumb = drillPath.at(-1)
+
+  // Drilled view: one section listing the parent's breakdown.
+  if (crumb) {
+    const rows = view.rows
+    const max = rows.reduce((m, r) => Math.max(m, r.amount), 0)
+    const color = crumb.flow === 'income' ? rawColors.app.green : rawColors.app.red
+    return (
+      <Section
+        title={`${crumb.label} breakdown`}
+        total={view.rowsTotal}
+        totalColor={color}
+      >
+        {rows.map((entry, idx) => (
+          <FlowRow
+            key={entry.name}
+            label={entry.name}
+            amount={entry.amount}
+            percent={view.rowsTotal > 0 ? entry.amount / view.rowsTotal : 0}
+            barWidth={max > 0 ? entry.amount / max : 0}
+            color={color}
+            delay={idx * 0.03}
+            onDrill={entry.drill ? () => drillInto(entry.drill!) : undefined}
+          />
+        ))}
+        {rows.length === 0 && (
+          <p className="text-sm text-muted-foreground">No breakdown available.</p>
+        )}
+      </Section>
+    )
+  }
+
   const incomeMax = incomeByCategory[0]?.amount ?? 0
   const expenseMax = expenseByCategory[0]?.amount ?? 0
   const savingsShare = totalIncome > 0 ? Math.max(netSavings, 0) / totalIncome : 0
@@ -46,6 +83,7 @@ export default function MobileFlowView({
             barWidth={incomeMax > 0 ? entry.amount / incomeMax : 0}
             color={rawColors.app.green}
             delay={idx * 0.03}
+            onDrill={entry.drill ? () => drillInto(entry.drill!) : undefined}
           />
         ))}
       </Section>
@@ -113,6 +151,7 @@ export default function MobileFlowView({
                 barWidth={expenseMax > 0 ? entry.amount / expenseMax : 0}
                 color={rawColors.app.red}
                 delay={idx * 0.03}
+                onDrill={entry.drill ? () => drillInto(entry.drill!) : undefined}
               />
             ))}
           </Section>
@@ -155,6 +194,7 @@ function FlowRow({
   barWidth,
   color,
   delay,
+  onDrill,
 }: Readonly<{
   label: string
   amount: number
@@ -162,15 +202,15 @@ function FlowRow({
   barWidth: number
   color: string
   delay: number
+  onDrill?: () => void
 }>) {
-  return (
-    <motion.div
-      initial={{ opacity: 0, x: -8 }}
-      animate={{ opacity: 1, x: 0 }}
-      transition={{ delay, duration: 0.25 }}
-    >
+  const row = (
+    <>
       <div className="flex items-baseline justify-between gap-2 mb-1">
-        <span className="text-sm text-foreground truncate flex-1 min-w-0">{label}</span>
+        <span className="text-sm text-foreground truncate flex-1 min-w-0 inline-flex items-center gap-1">
+          {label}
+          {onDrill && <ChevronRight className="w-3.5 h-3.5 text-text-quaternary shrink-0" aria-hidden />}
+        </span>
         <span className="text-xs text-text-tertiary shrink-0">{formatPercent(percent * 100)}</span>
       </div>
       <div className="flex items-center gap-2">
@@ -187,6 +227,35 @@ function FlowRow({
           {formatCurrency(amount)}
         </span>
       </div>
+    </>
+  )
+
+  if (onDrill) {
+    return (
+      <motion.div
+        initial={{ opacity: 0, x: -8 }}
+        animate={{ opacity: 1, x: 0 }}
+        transition={{ delay, duration: 0.25 }}
+      >
+        <button
+          type="button"
+          onClick={onDrill}
+          aria-label={`${label}: see breakdown`}
+          className="block w-full text-left -mx-2 px-2 py-1 rounded-lg hover:bg-[var(--overlay-2)] active:bg-[var(--overlay-2)] transition-colors"
+        >
+          {row}
+        </button>
+      </motion.div>
+    )
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: -8 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ delay, duration: 0.25 }}
+    >
+      {row}
     </motion.div>
   )
 }

--- a/frontend/src/pages/income-expense-flow/components/MobileFlowView.tsx
+++ b/frontend/src/pages/income-expense-flow/components/MobileFlowView.tsx
@@ -14,6 +14,7 @@ interface Props {
   readonly netSavings: number
   readonly view: SankeyView
   readonly drillPath: DrillCrumb[]
+  readonly drillDirection: 'in' | 'out'
   readonly drillInto: (crumb: DrillCrumb) => void
 }
 
@@ -31,9 +32,17 @@ export default function MobileFlowView({
   netSavings,
   view,
   drillPath,
+  drillDirection,
   drillInto,
 }: Props) {
   const crumb = drillPath.at(-1)
+  const viewKey = drillPath.map((c) => `${c.flow}:${c.label}`).join('/') || 'overview'
+  // Same zoom language as the desktop chart: drilling in grows the new view
+  // out of the tapped row; going back settles the parent down from oversized.
+  const enterFrom =
+    drillDirection === 'in'
+      ? { opacity: 0, scale: 0.9, y: 12 }
+      : { opacity: 0, scale: 1.06, y: -8 }
 
   // Drilled view: one section listing the parent's breakdown.
   if (crumb) {
@@ -41,27 +50,35 @@ export default function MobileFlowView({
     const max = rows.reduce((m, r) => Math.max(m, r.amount), 0)
     const color = crumb.flow === 'income' ? rawColors.app.green : rawColors.app.red
     return (
-      <Section
-        title={`${crumb.label} breakdown`}
-        total={view.rowsTotal}
-        totalColor={color}
+      <motion.div
+        key={viewKey}
+        initial={enterFrom}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        transition={{ type: 'spring', stiffness: 260, damping: 26 }}
+        style={{ transformOrigin: '50% 20%' }}
       >
-        {rows.map((entry, idx) => (
-          <FlowRow
-            key={entry.name}
-            label={entry.name}
-            amount={entry.amount}
-            percent={view.rowsTotal > 0 ? entry.amount / view.rowsTotal : 0}
-            barWidth={max > 0 ? entry.amount / max : 0}
-            color={color}
-            delay={idx * 0.03}
-            onDrill={entry.drill ? () => drillInto(entry.drill!) : undefined}
-          />
-        ))}
-        {rows.length === 0 && (
-          <p className="text-sm text-muted-foreground">No breakdown available.</p>
-        )}
-      </Section>
+        <Section
+          title={`${crumb.label} breakdown`}
+          total={view.rowsTotal}
+          totalColor={color}
+        >
+          {rows.map((entry, idx) => (
+            <FlowRow
+              key={entry.name}
+              label={entry.name}
+              amount={entry.amount}
+              percent={view.rowsTotal > 0 ? entry.amount / view.rowsTotal : 0}
+              barWidth={max > 0 ? entry.amount / max : 0}
+              color={color}
+              delay={idx * 0.03}
+              onDrill={entry.drill ? () => drillInto(entry.drill!) : undefined}
+            />
+          ))}
+          {rows.length === 0 && (
+            <p className="text-sm text-muted-foreground">No breakdown available.</p>
+          )}
+        </Section>
+      </motion.div>
     )
   }
 
@@ -71,7 +88,14 @@ export default function MobileFlowView({
   const expenseShare = totalIncome > 0 ? totalExpense / totalIncome : 0
 
   return (
-    <div className="space-y-4">
+    <motion.div
+      key={viewKey}
+      initial={enterFrom}
+      animate={{ opacity: 1, scale: 1, y: 0 }}
+      transition={{ type: 'spring', stiffness: 260, damping: 26 }}
+      style={{ transformOrigin: '50% 15%' }}
+      className="space-y-4"
+    >
       {/* Income sources */}
       <Section title="Income sources" total={totalIncome} totalColor={rawColors.app.green}>
         {incomeByCategory.map((entry, idx) => (
@@ -157,7 +181,7 @@ export default function MobileFlowView({
           </Section>
         </>
       )}
-    </div>
+    </motion.div>
   )
 }
 

--- a/frontend/src/pages/income-expense-flow/components/SankeyChart.tsx
+++ b/frontend/src/pages/income-expense-flow/components/SankeyChart.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'framer-motion'
-import { ArrowRightLeft } from 'lucide-react'
+import { ArrowRightLeft, ChevronRight, CornerUpLeft } from 'lucide-react'
 import { Sankey, Tooltip } from 'recharts'
 
 import { ChartContainer, Spinner } from '@/components/ui'
@@ -7,12 +7,17 @@ import { chartTooltipProps } from '@/components/ui/ChartTooltip'
 import { rawColors } from '@/constants/colors'
 import { formatCurrency } from '@/lib/formatters'
 
+import type { DrillCrumb, FlowEntry, SankeyView } from '../sankeyDrilldown'
 import MobileFlowView from './MobileFlowView'
 
 interface SankeyChartProps {
   isLoading: boolean
   isMobile: boolean
-  sankeyData: { nodes: Array<{ name: string }>; links: Array<{ source: number; target: number; value: number }> }
+  view: SankeyView
+  drillPath: DrillCrumb[]
+  drillTo: (depth: number) => void
+  drillInto: (crumb: DrillCrumb) => void
+  drillBack: () => void
   sankeyNodeComponent: React.ComponentType<{
     x: number
     y: number
@@ -21,19 +26,80 @@ interface SankeyChartProps {
     index: number
     payload: { name: string }
   }>
-  topIncome: Array<{ name: string; amount: number }>
-  topExpense: Array<{ name: string; amount: number }>
+  topIncome: FlowEntry[]
+  topExpense: FlowEntry[]
   totalIncome: number
   totalExpense: number
   netSavings: number
   currentFY: string
 }
 
+/** Breadcrumb: "All cash flow / Family". Earlier crumbs are buttons that
+ * truncate the trail; the current level is static text. */
+function DrillBreadcrumb({
+  drillPath,
+  drillTo,
+  drillBack,
+}: Readonly<{ drillPath: DrillCrumb[]; drillTo: (depth: number) => void; drillBack: () => void }>) {
+  if (drillPath.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Click a category with <span className="font-semibold">›</span> to see its breakdown
+      </p>
+    )
+  }
+  return (
+    <nav aria-label="Cash flow drill-down path" className="flex items-center gap-1 text-sm min-w-0">
+      <button
+        type="button"
+        onClick={() => drillTo(0)}
+        className="text-muted-foreground hover:text-foreground transition-colors shrink-0"
+      >
+        All cash flow
+      </button>
+      {drillPath.map((crumb, i) => {
+        const isLast = i === drillPath.length - 1
+        return (
+          <span key={`${crumb.flow}-${crumb.label}`} className="flex items-center gap-1 min-w-0">
+            <ChevronRight className="w-3.5 h-3.5 text-text-quaternary shrink-0" aria-hidden />
+            {isLast ? (
+              <span className="font-semibold text-foreground truncate" aria-current="page">
+                {crumb.label}
+              </span>
+            ) : (
+              <button
+                type="button"
+                onClick={() => drillTo(i + 1)}
+                className="text-muted-foreground hover:text-foreground transition-colors truncate"
+              >
+                {crumb.label}
+              </button>
+            )}
+          </span>
+        )
+      })}
+      <button
+        type="button"
+        onClick={drillBack}
+        className="ml-2 flex items-center gap-1 px-2 py-1 rounded-md border border-border text-xs text-muted-foreground hover:text-foreground hover:bg-[var(--overlay-2)] transition-colors shrink-0"
+        aria-label="Back one level"
+      >
+        <CornerUpLeft className="w-3 h-3" aria-hidden />
+        Back
+      </button>
+    </nav>
+  )
+}
+
 export function SankeyChart(props: Readonly<SankeyChartProps>) {
   const {
     isLoading,
     isMobile,
-    sankeyData,
+    view,
+    drillPath,
+    drillTo,
+    drillInto,
+    drillBack,
     sankeyNodeComponent,
     topIncome,
     topExpense,
@@ -43,14 +109,26 @@ export function SankeyChart(props: Readonly<SankeyChartProps>) {
     currentFY,
   } = props
 
+  const depth = drillPath.length
+  const crumb = drillPath.at(-1)
+  const viewKey = drillPath.map((c) => `${c.flow}:${c.label}`).join('/') || 'overview'
+  const chartHeight = depth === 0 ? 700 : Math.max(320, 90 * view.links.length + 120)
+
+  const chartLabel = crumb
+    ? `Sankey diagram showing the ${crumb.label} breakdown by subcategory.`
+    : 'Sankey diagram showing income sources flowing into total income, then splitting into savings and expense categories.'
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ delay: 0.2 }}
       className="glass rounded-2xl border border-border p-3 sm:p-6 lg:p-8"
+      onKeyDown={(e) => {
+        if (e.key === 'Escape' && depth > 0) drillBack()
+      }}
     >
-      <div className="flex items-center justify-between mb-4 sm:mb-8">
+      <div className="flex flex-wrap items-center justify-between gap-3 mb-4 sm:mb-8">
         <div className="flex items-center gap-3">
           <div className="p-3 bg-app-purple/20 rounded-xl">
             <ArrowRightLeft className="w-6 h-6 text-app-purple" />
@@ -61,10 +139,13 @@ export function SankeyChart(props: Readonly<SankeyChartProps>) {
               <span className="hidden sm:inline">Cash Flow Sankey</span>
             </h3>
             <p className="text-sm text-muted-foreground">
-              Income sources flowing to savings and expenses
+              {crumb
+                ? `Where ${crumb.label} ${crumb.flow === 'expense' ? 'goes' : 'comes from'}`
+                : 'Income sources flowing to savings and expenses'}
             </p>
           </div>
         </div>
+        <DrillBreadcrumb drillPath={drillPath} drillTo={drillTo} drillBack={drillBack} />
       </div>
 
       {isLoading && (
@@ -73,114 +154,115 @@ export function SankeyChart(props: Readonly<SankeyChartProps>) {
         </div>
       )}
 
-      {!isLoading && isMobile && sankeyData.links.length > 0 && (
+      {!isLoading && isMobile && (
         <MobileFlowView
           incomeByCategory={topIncome}
           expenseByCategory={topExpense}
           totalIncome={totalIncome}
           totalExpense={totalExpense}
           netSavings={netSavings}
+          view={view}
+          drillPath={drillPath}
+          drillInto={drillInto}
         />
       )}
 
-      {/* Gate on LINKS, not nodes: the hook always emits the 3 fixed
-          Income/Savings/Expenses nodes, so nodes.length is never 0. With no
-          data there are 0 links and Recharts <Sankey> would render orphan nodes
-          / a NaN layout. Links is the real "has data" signal. */}
-      {!isLoading && !isMobile && sankeyData.links.length > 0 && (
-        <div className="relative rounded-lg border border-border bg-[var(--overlay-1)] p-6">
-          <ChartContainer
-            height={700}
-            ariaLabel="Sankey diagram showing income sources flowing into total income, then splitting into savings and expense categories."
-          >
-            <Sankey
-              data={sankeyData}
-              nodeWidth={20}
-              nodePadding={60}
-              margin={{ top: 30, right: 200, bottom: 30, left: 200 }}
-              node={sankeyNodeComponent as never}
-              link={{
-                stroke: rawColors.app.purple,
-                strokeOpacity: 0.25,
-              }}
+      {/* Gate on LINKS, not nodes: with no data there are 0 links and Recharts
+          <Sankey> would render orphan nodes / a NaN layout. */}
+      {!isLoading && !isMobile && view.links.length > 0 && (
+        <div className="relative overflow-hidden rounded-lg border border-border bg-[var(--overlay-1)] p-6">
+          {/* Recharts Sankey can't animate a data swap, so each drill level
+              remounts (key) and slides in. Enter-only on purpose: exit
+              animations kept the old chart mounted alongside the new one
+              (AnimatePresence exit never completed under StrictMode), which
+              doubled the diagram. The key remount also resets stale tooltip
+              active state. */}
+            <motion.div
+              key={viewKey}
+              initial={{ opacity: 0, x: 32 }}
+              animate={{ opacity: 1, x: 0 }}
+              transition={{ duration: 0.25, ease: 'easeOut' }}
             >
-              <defs>
-                <linearGradient id="incomeGradient" x1="0" y1="0" x2="1" y2="0">
-                  <stop offset="0%" stopColor={rawColors.app.green} stopOpacity={0.8} />
-                  <stop offset="100%" stopColor={rawColors.app.green} stopOpacity={0.8} />
-                </linearGradient>
-                <linearGradient id="middleGradient" x1="0" y1="0" x2="1" y2="0">
-                  <stop offset="0%" stopColor={rawColors.app.indigo} stopOpacity={0.9} />
-                  <stop offset="100%" stopColor={rawColors.app.purple} stopOpacity={0.9} />
-                </linearGradient>
-                <linearGradient id="expenseGradient" x1="0" y1="0" x2="1" y2="0">
-                  <stop offset="0%" stopColor={rawColors.app.red} stopOpacity={0.8} />
-                  <stop offset="100%" stopColor={rawColors.app.red} stopOpacity={0.8} />
-                </linearGradient>
-              </defs>
-              <Tooltip
-                {...chartTooltipProps}
-                formatter={(value, _name, item) => {
-                  if (typeof value !== 'number') return ''
-                  // Recharts' Sankey payload exposes the resolved source/target
-                  // node objects on a link hover -- name the flow instead of a
-                  // bare "Amount". Falls back to the node name for node hovers.
-                  const link = item?.payload as
-                    | { source?: { name?: string }; target?: { name?: string }; name?: string }
-                    | undefined
-                  const source = link?.source?.name
-                  const target = link?.target?.name
-                  const label =
-                    source && target
-                      ? `${source} -> ${target}`
-                      : (link?.name ?? 'Amount')
-                  return [formatCurrency(value), label]
-                }}
-              />
-            </Sankey>
-          </ChartContainer>
+              <ChartContainer height={chartHeight} ariaLabel={chartLabel}>
+                <Sankey
+                  key={viewKey}
+                  data={{ nodes: view.nodes, links: view.links }}
+                  nodeWidth={20}
+                  nodePadding={depth === 0 ? 60 : 40}
+                  margin={{ top: 30, right: 200, bottom: 30, left: 200 }}
+                  node={sankeyNodeComponent as never}
+                  link={{
+                    stroke: rawColors.app.purple,
+                    strokeOpacity: 0.25,
+                  }}
+                >
+                  <Tooltip
+                    {...chartTooltipProps}
+                    formatter={(value, _name, item) => {
+                      if (typeof value !== 'number') return ''
+                      // Link hovers expose resolved source/target node objects;
+                      // node hovers fall back to the node's own name.
+                      const link = item?.payload as
+                        | { source?: { name?: string }; target?: { name?: string }; name?: string }
+                        | undefined
+                      const source = link?.source?.name
+                      const target = link?.target?.name
+                      const label =
+                        source && target ? `${source} -> ${target}` : (link?.name ?? 'Amount')
+                      return [formatCurrency(value), label]
+                    }}
+                  />
+                </Sankey>
+              </ChartContainer>
+            </motion.div>
 
-          <div className="mt-6 pt-6 border-t border-border flex flex-wrap justify-center gap-6">
-            <div className="flex items-center gap-2">
-              <div
-                className="w-4 h-4 rounded"
-                style={{
-                  background: `linear-gradient(to right, ${rawColors.app.green}, ${rawColors.app.greenVibrant})`,
-                }}
-              />
-              <span className="text-sm text-foreground">Income Sources</span>
+          {depth === 0 && (
+            <div className="mt-6 pt-6 border-t border-border flex flex-wrap justify-center gap-6">
+              <div className="flex items-center gap-2">
+                <div
+                  className="w-4 h-4 rounded"
+                  style={{
+                    background: `linear-gradient(to right, ${rawColors.app.green}, ${rawColors.app.greenVibrant})`,
+                  }}
+                />
+                <span className="text-sm text-foreground">Income Sources</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <div
+                  className="w-4 h-4 rounded"
+                  style={{
+                    background: `linear-gradient(to right, ${rawColors.app.indigo}, ${rawColors.app.purple})`,
+                  }}
+                />
+                <span className="text-sm text-foreground">Total Income / Savings</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <div
+                  className="w-4 h-4 rounded"
+                  style={{
+                    background: `linear-gradient(to right, ${rawColors.app.red}, ${rawColors.app.redVibrant})`,
+                  }}
+                />
+                <span className="text-sm text-foreground">Expense Categories</span>
+              </div>
             </div>
-            <div className="flex items-center gap-2">
-              <div
-                className="w-4 h-4 rounded"
-                style={{
-                  background: `linear-gradient(to right, ${rawColors.app.indigo}, ${rawColors.app.purple})`,
-                }}
-              />
-              <span className="text-sm text-foreground">Total Income / Savings</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <div
-                className="w-4 h-4 rounded"
-                style={{
-                  background: `linear-gradient(to right, ${rawColors.app.red}, ${rawColors.app.redVibrant})`,
-                }}
-              />
-              <span className="text-sm text-foreground">Expense Categories</span>
-            </div>
-          </div>
+          )}
         </div>
       )}
 
-      {!isLoading && sankeyData.links.length === 0 && (
+      {!isLoading && !isMobile && view.links.length === 0 && (
         <div className="flex h-[400px] items-center justify-center rounded-lg border border-border bg-[var(--overlay-1)] md:h-[550px] lg:h-[700px]">
           <div className="text-center">
             <ArrowRightLeft className="w-16 h-16 text-text-quaternary mx-auto mb-4" />
             <p className="text-muted-foreground text-lg">
-              No transaction data available for FY {currentFY}
+              {depth > 0
+                ? 'No breakdown available for this selection'
+                : `No transaction data available for FY ${currentFY}`}
             </p>
             <p className="text-text-tertiary text-sm mt-2">
-              Select a different financial year or upload transaction data
+              {depth > 0
+                ? 'Go back to the full cash flow view'
+                : 'Select a different financial year or upload transaction data'}
             </p>
           </div>
         </div>

--- a/frontend/src/pages/income-expense-flow/components/SankeyChart.tsx
+++ b/frontend/src/pages/income-expense-flow/components/SankeyChart.tsx
@@ -69,7 +69,9 @@ function DrillBreadcrumb({
       {drillPath.map((crumb, i) => {
         const isLast = i === drillPath.length - 1
         return (
-          <span key={`${crumb.flow}-${crumb.label}`} className="flex items-center gap-1 min-w-0">
+          // Depth in the key: the same label can legally appear twice in a
+          // path (the Tax branch drilling into a category also named Tax).
+          <span key={`${i}-${crumb.view}-${crumb.label}`} className="flex items-center gap-1 min-w-0">
             <ChevronRight className="w-3.5 h-3.5 text-text-quaternary shrink-0" aria-hidden />
             {isLast ? (
               <span className="font-semibold text-foreground truncate" aria-current="page">

--- a/frontend/src/pages/income-expense-flow/components/SankeyChart.tsx
+++ b/frontend/src/pages/income-expense-flow/components/SankeyChart.tsx
@@ -15,8 +15,12 @@ interface SankeyChartProps {
   isMobile: boolean
   view: SankeyView
   drillPath: DrillCrumb[]
+  /** 'in' after a node click, 'out' after breadcrumb/back -- picks the zoom direction. */
+  drillDirection: 'in' | 'out'
+  /** Clicked node's center in chart px; the drill view zooms in from this spot. */
+  zoomOrigin: { x: number; y: number } | null
   drillTo: (depth: number) => void
-  drillInto: (crumb: DrillCrumb) => void
+  drillInto: (crumb: DrillCrumb, origin?: { x: number; y: number }) => void
   drillBack: () => void
   sankeyNodeComponent: React.ComponentType<{
     x: number
@@ -97,6 +101,8 @@ export function SankeyChart(props: Readonly<SankeyChartProps>) {
     isMobile,
     view,
     drillPath,
+    drillDirection,
+    zoomOrigin,
     drillTo,
     drillInto,
     drillBack,
@@ -113,6 +119,17 @@ export function SankeyChart(props: Readonly<SankeyChartProps>) {
   const crumb = drillPath.at(-1)
   const viewKey = drillPath.map((c) => `${c.flow}:${c.label}`).join('/') || 'overview'
   const chartHeight = depth === 0 ? 700 : Math.max(320, 90 * view.links.length + 120)
+
+  // Zoom navigation. Forward: the new view grows out of the clicked node
+  // (transform-origin at its chart position), like zooming INTO it. Back: the
+  // parent view settles down from oversized, like zooming back OUT. The blur
+  // ramp sells the depth change; the spring keeps it snappy, not floaty.
+  const zoomIn = drillDirection === 'in'
+  const transformOrigin =
+    zoomIn && zoomOrigin ? `${zoomOrigin.x}px ${zoomOrigin.y}px` : '50% 50%'
+  const enterFrom = zoomIn
+    ? { opacity: 0, scale: 0.35, filter: 'blur(6px)' }
+    : { opacity: 0, scale: 1.45, filter: 'blur(6px)' }
 
   const chartLabel = crumb
     ? `Sankey diagram showing the ${crumb.label} breakdown by subcategory.`
@@ -163,6 +180,7 @@ export function SankeyChart(props: Readonly<SankeyChartProps>) {
           netSavings={netSavings}
           view={view}
           drillPath={drillPath}
+          drillDirection={drillDirection}
           drillInto={drillInto}
         />
       )}
@@ -172,17 +190,27 @@ export function SankeyChart(props: Readonly<SankeyChartProps>) {
       {!isLoading && !isMobile && view.links.length > 0 && (
         <div className="relative overflow-hidden rounded-lg border border-border bg-[var(--overlay-1)] p-6">
           {/* Recharts Sankey can't animate a data swap, so each drill level
-              remounts (key) and slides in. Enter-only on purpose: exit
+              remounts (key) and zooms in. Enter-only on purpose: exit
               animations kept the old chart mounted alongside the new one
               (AnimatePresence exit never completed under StrictMode), which
               doubled the diagram. The key remount also resets stale tooltip
-              active state. */}
+              active state. The outer div springs the height between levels so
+              the card doesn't jump-cut when a drill view is shorter. */}
+            <motion.div
+              initial={false}
+              animate={{ height: chartHeight }}
+              transition={{ type: 'spring', stiffness: 260, damping: 32 }}
+              style={{ overflow: 'hidden' }}
+            >
             <motion.div
               key={viewKey}
-              initial={{ opacity: 0, x: 32 }}
-              animate={{ opacity: 1, x: 0 }}
-              transition={{ duration: 0.25, ease: 'easeOut' }}
+              initial={enterFrom}
+              animate={{ opacity: 1, scale: 1, filter: 'blur(0px)' }}
+              transition={{ type: 'spring', stiffness: 220, damping: 26, mass: 0.9 }}
+              style={{ transformOrigin }}
             >
+              {/* Chart renders at final height immediately; the outer wrapper's
+                  height spring just reveals it (no per-frame Sankey relayout). */}
               <ChartContainer height={chartHeight} ariaLabel={chartLabel}>
                 <Sankey
                   key={viewKey}
@@ -214,6 +242,7 @@ export function SankeyChart(props: Readonly<SankeyChartProps>) {
                   />
                 </Sankey>
               </ChartContainer>
+            </motion.div>
             </motion.div>
 
           {depth === 0 && (

--- a/frontend/src/pages/income-expense-flow/components/SankeyChart.tsx
+++ b/frontend/src/pages/income-expense-flow/components/SankeyChart.tsx
@@ -9,6 +9,10 @@ import { formatCurrency } from '@/lib/formatters'
 
 import type { DrillCrumb, FlowEntry, SankeyView } from '../sankeyDrilldown'
 import MobileFlowView from './MobileFlowView'
+import { createSankeyLinkComponent } from './SankeyLinkRenderer'
+
+// One module-level instance: the renderer is stateless, so all views share it.
+const sankeyLinkComponent = createSankeyLinkComponent()
 
 interface SankeyChartProps {
   isLoading: boolean
@@ -34,6 +38,7 @@ interface SankeyChartProps {
   topExpense: FlowEntry[]
   totalIncome: number
   totalExpense: number
+  totalTax: number
   netSavings: number
   currentFY: string
 }
@@ -111,6 +116,7 @@ export function SankeyChart(props: Readonly<SankeyChartProps>) {
     topExpense,
     totalIncome,
     totalExpense,
+    totalTax,
     netSavings,
     currentFY,
   } = props
@@ -135,6 +141,11 @@ export function SankeyChart(props: Readonly<SankeyChartProps>) {
     ? `Sankey diagram showing the ${crumb.label} breakdown by subcategory.`
     : 'Sankey diagram showing income sources flowing into total income, then splitting into savings and expense categories.'
 
+  let subtitle = 'Income sources flowing to savings and expenses'
+  if (crumb) {
+    subtitle = crumb.flow === 'expense' ? `Where ${crumb.label} goes` : `Where ${crumb.label} comes from`
+  }
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
@@ -155,11 +166,7 @@ export function SankeyChart(props: Readonly<SankeyChartProps>) {
               <span className="sm:hidden">Cash Flow</span>
               <span className="hidden sm:inline">Cash Flow Sankey</span>
             </h3>
-            <p className="text-sm text-muted-foreground">
-              {crumb
-                ? `Where ${crumb.label} ${crumb.flow === 'expense' ? 'goes' : 'comes from'}`
-                : 'Income sources flowing to savings and expenses'}
-            </p>
+            <p className="text-sm text-muted-foreground">{subtitle}</p>
           </div>
         </div>
         <DrillBreadcrumb drillPath={drillPath} drillTo={drillTo} drillBack={drillBack} />
@@ -177,6 +184,7 @@ export function SankeyChart(props: Readonly<SankeyChartProps>) {
           expenseByCategory={topExpense}
           totalIncome={totalIncome}
           totalExpense={totalExpense}
+          totalTax={totalTax}
           netSavings={netSavings}
           view={view}
           drillPath={drillPath}
@@ -219,10 +227,7 @@ export function SankeyChart(props: Readonly<SankeyChartProps>) {
                   nodePadding={depth === 0 ? 60 : 40}
                   margin={{ top: 30, right: 200, bottom: 30, left: 200 }}
                   node={sankeyNodeComponent as never}
-                  link={{
-                    stroke: rawColors.app.purple,
-                    strokeOpacity: 0.25,
-                  }}
+                  link={sankeyLinkComponent as never}
                 >
                   <Tooltip
                     {...chartTooltipProps}

--- a/frontend/src/pages/income-expense-flow/components/SankeyLinkRenderer.tsx
+++ b/frontend/src/pages/income-expense-flow/components/SankeyLinkRenderer.tsx
@@ -1,0 +1,96 @@
+import { motion } from 'framer-motion'
+
+import { rawColors } from '@/constants/colors'
+
+import { safeNumber } from '../sankeyUtils'
+
+interface SankeyLinkRendererProps {
+  readonly sourceX: number
+  readonly targetX: number
+  readonly sourceY: number
+  readonly targetY: number
+  readonly sourceControlX: number
+  readonly targetControlX: number
+  readonly linkWidth: number
+  readonly index: number
+}
+
+/**
+ * Animated Sankey link: the ribbon draws in left-to-right on mount (staggered
+ * by index), then a soft dash shimmer keeps drifting along the flow direction
+ * forever -- money visibly "flowing" through the pipes, like the reference
+ * sankey animation. The shimmer is SMIL on stroke-dashoffset (compositor-only,
+ * no React re-renders); the draw-in is framer-motion pathLength.
+ */
+export const SankeyLinkRenderer = ({
+  sourceX: rawSX,
+  targetX: rawTX,
+  sourceY: rawSY,
+  targetY: rawTY,
+  sourceControlX: rawSCX,
+  targetControlX: rawTCX,
+  linkWidth: rawW,
+  index,
+}: SankeyLinkRendererProps) => {
+  const sourceX = safeNumber(rawSX)
+  const targetX = safeNumber(rawTX)
+  const sourceY = safeNumber(rawSY)
+  const targetY = safeNumber(rawTY)
+  const sourceControlX = safeNumber(rawSCX)
+  const targetControlX = safeNumber(rawTCX)
+  const linkWidth = Math.max(safeNumber(rawW), 1)
+
+  const d = `M${sourceX},${sourceY}C${sourceControlX},${sourceY} ${targetControlX},${targetY} ${targetX},${targetY}`
+
+  // Slower drift on thicker ribbons reads as the same "volume speed".
+  const flowDuration = 2.4 + Math.min(linkWidth / 60, 1.6)
+
+  return (
+    <g>
+      {/* Base ribbon: draws in from the source, staggered per link. */}
+      <motion.path
+        d={d}
+        fill="none"
+        stroke={rawColors.app.purple}
+        strokeOpacity={0.25}
+        strokeWidth={linkWidth}
+        initial={{ pathLength: 0 }}
+        animate={{ pathLength: 1 }}
+        transition={{ duration: 0.8, delay: index * 0.06, ease: 'easeOut' }}
+      />
+      {/* Flow shimmer: long soft dashes drifting toward the target, forever. */}
+      <path
+        d={d}
+        fill="none"
+        stroke={rawColors.app.purple}
+        strokeOpacity={0.18}
+        strokeWidth={linkWidth}
+        strokeDasharray="26 42"
+        strokeLinecap="round"
+      >
+        <animate
+          attributeName="stroke-dashoffset"
+          from="68"
+          to="0"
+          dur={`${flowDuration}s`}
+          repeatCount="indefinite"
+        />
+      </path>
+    </g>
+  )
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function createSankeyLinkComponent() {
+  const SankeyLinkComponent = (linkProps: {
+    sourceX: number
+    targetX: number
+    sourceY: number
+    targetY: number
+    sourceControlX: number
+    targetControlX: number
+    linkWidth: number
+    index: number
+  }) => <SankeyLinkRenderer {...linkProps} />
+  return SankeyLinkComponent
+}

--- a/frontend/src/pages/income-expense-flow/components/SankeyNodeRenderer.tsx
+++ b/frontend/src/pages/income-expense-flow/components/SankeyNodeRenderer.tsx
@@ -16,7 +16,8 @@ interface SankeyNodeRendererProps {
   readonly meta: readonly SankeyNodeMeta[]
   readonly chartWidth: number
   readonly fontSize: number
-  readonly onDrill: (crumb: DrillCrumb) => void
+  /** origin = the node's center in chart px, so the next view can zoom in from it. */
+  readonly onDrill: (crumb: DrillCrumb, origin?: { x: number; y: number }) => void
 }
 
 export const SankeyNodeRenderer = ({
@@ -47,7 +48,9 @@ export const SankeyNodeRenderer = ({
   const labelX = onLeftSide ? x - 8 : x + width + 8
   const anchor: 'end' | 'start' = onLeftSide ? 'end' : 'start'
 
-  const activate = drill ? () => onDrill(drill) : undefined
+  const activate = drill
+    ? () => onDrill(drill, { x: x + width / 2, y: y + height / 2 })
+    : undefined
 
   // Drillable nodes are real buttons: pointer cursor, hover ring, chevron
   // after the label, Enter/Space activation (recharts has no per-node

--- a/frontend/src/pages/income-expense-flow/components/SankeyNodeRenderer.tsx
+++ b/frontend/src/pages/income-expense-flow/components/SankeyNodeRenderer.tsx
@@ -1,7 +1,10 @@
+import { useState } from 'react'
+
 import { rawColors } from '@/constants/colors'
 import { formatCurrency } from '@/lib/formatters'
 
-import { getNodeFillColor, safeNumber } from '../sankeyUtils'
+import { safeNumber } from '../sankeyUtils'
+import type { DrillCrumb, SankeyNodeMeta } from '../sankeyDrilldown'
 
 interface SankeyNodeRendererProps {
   readonly x: number
@@ -10,14 +13,10 @@ interface SankeyNodeRendererProps {
   readonly height: number
   readonly index: number
   readonly payload: { name: string }
-  readonly nodeValues: Map<number, number>
-  readonly incomeCategoryCount: number
-  readonly totalIncomeNodeIndex: number
-  readonly savingsNodeIndex: number
-  readonly expensesNodeIndex: number
-  readonly totalIncome: number
+  readonly meta: readonly SankeyNodeMeta[]
   readonly chartWidth: number
   readonly fontSize: number
+  readonly onDrill: (crumb: DrillCrumb) => void
 }
 
 export const SankeyNodeRenderer = ({
@@ -27,45 +26,63 @@ export const SankeyNodeRenderer = ({
   height: rawHeight,
   index,
   payload,
-  nodeValues,
-  incomeCategoryCount,
-  totalIncomeNodeIndex,
-  savingsNodeIndex,
-  expensesNodeIndex,
-  totalIncome,
+  meta,
   chartWidth,
   fontSize,
+  onDrill,
 }: SankeyNodeRendererProps) => {
+  const [hovered, setHovered] = useState(false)
   const x = safeNumber(rawX)
   const y = safeNumber(rawY)
   const width = safeNumber(rawWidth)
   const height = safeNumber(rawHeight)
 
-  const value = nodeValues.get(index) || 0
-  const percentage = totalIncome > 0 ? ((value / totalIncome) * 100).toFixed(1) : '0'
-  const fillColor = getNodeFillColor(
-    index,
-    incomeCategoryCount,
-    totalIncomeNodeIndex,
-    savingsNodeIndex,
-    expensesNodeIndex,
-  )
+  const nodeMeta = meta[index]
+  const value = nodeMeta?.value ?? 0
+  const percentage = (nodeMeta?.pct ?? 0).toFixed(1)
+  const fillColor = nodeMeta?.color ?? rawColors.app.purple
+  const drill = nodeMeta?.drill ?? null
 
   const onLeftSide = x < chartWidth / 2
   const labelX = onLeftSide ? x - 8 : x + width + 8
   const anchor: 'end' | 'start' = onLeftSide ? 'end' : 'start'
 
+  const activate = drill ? () => onDrill(drill) : undefined
+
+  // Drillable nodes are real buttons: pointer cursor, hover ring, chevron
+  // after the label, Enter/Space activation (recharts has no per-node
+  // keyboard support of its own -- SVG2 tabindex works on any element).
+  const interactiveProps = drill
+    ? {
+        role: 'button' as const,
+        tabIndex: 0,
+        'aria-label': `${payload.name}, ${formatCurrency(value)}. Press Enter to see breakdown`,
+        onClick: activate,
+        onKeyDown: (e: React.KeyboardEvent<SVGGElement>) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            activate?.()
+          }
+        },
+        onMouseEnter: () => setHovered(true),
+        onMouseLeave: () => setHovered(false),
+        onFocus: () => setHovered(true),
+        onBlur: () => setHovered(false),
+        style: { cursor: 'pointer', outline: 'none' },
+      }
+    : {}
+
   return (
-    <g>
+    <g {...interactiveProps}>
       <rect
         x={x}
         y={y}
         width={width}
         height={height}
         fill={fillColor}
-        fillOpacity={0.9}
+        fillOpacity={drill && hovered ? 1 : 0.9}
         stroke={fillColor}
-        strokeWidth={0}
+        strokeWidth={drill && hovered ? 2 : 0}
         rx={4}
         ry={4}
       />
@@ -77,8 +94,10 @@ export const SankeyNodeRenderer = ({
         fill={rawColors.chart.textPrimary}
         fontSize={fontSize}
         fontWeight="600"
+        style={drill ? { textDecoration: hovered ? 'underline' : 'none' } : undefined}
       >
         {payload.name}
+        {drill ? ' ›' : ''}
       </text>
       <text
         x={labelX}
@@ -96,14 +115,10 @@ export const SankeyNodeRenderer = ({
 }
 
 interface SankeyNodeWrapperProps {
-  readonly nodeValues: Map<number, number>
-  readonly incomeCategoryCount: number
-  readonly totalIncomeNodeIndex: number
-  readonly savingsNodeIndex: number
-  readonly expensesNodeIndex: number
-  readonly totalIncome: number
+  readonly meta: readonly SankeyNodeMeta[]
   readonly chartWidth: number
   readonly fontSize: number
+  readonly onDrill: (crumb: DrillCrumb) => void
 }
 
 // eslint-disable-next-line react-refresh/only-export-components
@@ -118,14 +133,10 @@ export function createSankeyNodeComponent(context: SankeyNodeWrapperProps) {
   }) => (
     <SankeyNodeRenderer
       {...nodeProps}
-      nodeValues={context.nodeValues}
-      incomeCategoryCount={context.incomeCategoryCount}
-      totalIncomeNodeIndex={context.totalIncomeNodeIndex}
-      savingsNodeIndex={context.savingsNodeIndex}
-      expensesNodeIndex={context.expensesNodeIndex}
-      totalIncome={context.totalIncome}
+      meta={context.meta}
       chartWidth={context.chartWidth}
       fontSize={context.fontSize}
+      onDrill={context.onDrill}
     />
   )
   return SankeyNodeComponent

--- a/frontend/src/pages/income-expense-flow/components/SankeyNodeRenderer.tsx
+++ b/frontend/src/pages/income-expense-flow/components/SankeyNodeRenderer.tsx
@@ -20,6 +20,35 @@ interface SankeyNodeRendererProps {
   readonly onDrill: (crumb: DrillCrumb, origin?: { x: number; y: number }) => void
 }
 
+/**
+ * Button semantics for a drillable node <g>: pointer cursor, hover ring,
+ * Enter/Space activation (recharts has no per-node keyboard support of its
+ * own -- SVG2 tabindex works on any element).
+ */
+function drillableGroupProps(
+  label: string,
+  activate: () => void,
+  setHovered: (v: boolean) => void,
+): React.SVGProps<SVGGElement> {
+  return {
+    role: 'button',
+    tabIndex: 0,
+    'aria-label': label,
+    onClick: activate,
+    onKeyDown: (e: React.KeyboardEvent<SVGGElement>) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault()
+        activate()
+      }
+    },
+    onMouseEnter: () => setHovered(true),
+    onMouseLeave: () => setHovered(false),
+    onFocus: () => setHovered(true),
+    onBlur: () => setHovered(false),
+    style: { cursor: 'pointer', outline: 'none' },
+  }
+}
+
 export const SankeyNodeRenderer = ({
   x: rawX,
   y: rawY,
@@ -48,31 +77,12 @@ export const SankeyNodeRenderer = ({
   const labelX = onLeftSide ? x - 8 : x + width + 8
   const anchor: 'end' | 'start' = onLeftSide ? 'end' : 'start'
 
-  const activate = drill
-    ? () => onDrill(drill, { x: x + width / 2, y: y + height / 2 })
-    : undefined
-
-  // Drillable nodes are real buttons: pointer cursor, hover ring, chevron
-  // after the label, Enter/Space activation (recharts has no per-node
-  // keyboard support of its own -- SVG2 tabindex works on any element).
   const interactiveProps = drill
-    ? {
-        role: 'button' as const,
-        tabIndex: 0,
-        'aria-label': `${payload.name}, ${formatCurrency(value)}. Press Enter to see breakdown`,
-        onClick: activate,
-        onKeyDown: (e: React.KeyboardEvent<SVGGElement>) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault()
-            activate?.()
-          }
-        },
-        onMouseEnter: () => setHovered(true),
-        onMouseLeave: () => setHovered(false),
-        onFocus: () => setHovered(true),
-        onBlur: () => setHovered(false),
-        style: { cursor: 'pointer', outline: 'none' },
-      }
+    ? drillableGroupProps(
+        `${payload.name}, ${formatCurrency(value)}. Press Enter to see breakdown`,
+        () => onDrill(drill, { x: x + width / 2, y: y + height / 2 }),
+        setHovered,
+      )
     : {}
 
   return (

--- a/frontend/src/pages/income-expense-flow/sankeyDrilldown.ts
+++ b/frontend/src/pages/income-expense-flow/sankeyDrilldown.ts
@@ -1,0 +1,270 @@
+/**
+ * Drill-down dataset builders for the Cash Flow Sankey.
+ *
+ * Pattern: replace-view (the whole diagram swaps to a scoped one) with a
+ * breadcrumb back -- the shape every library that documents Sankey drill-down
+ * uses (amCharts drill-down tutorial, Google Charts / ECharts click+redraw).
+ * Expand-in-place reflows the entire layout on every toggle and Recharts
+ * cannot animate a data swap, so it would snap-jump; replace-view keeps each
+ * view stable and gives subcategories the full canvas.
+ *
+ * Every level builds a FRESH { nodes, links } object because Recharts links
+ * reference nodes by numeric array index -- indexes must be rebuilt per view.
+ * A parallel `meta` array (value, pct, color, drill target) replaces the old
+ * role-by-index-range logic, which is wrong for any topology but level 0.
+ */
+
+import { rawColors } from '@/constants/colors'
+import type { Transaction } from '@/types'
+
+/** One list row / child node: category or subcategory with its total. */
+export interface FlowEntry {
+  name: string
+  amount: number
+  /** Crumb to push when activated; null/undefined = leaf (not drillable). */
+  drill?: DrillCrumb | null
+}
+
+/** One level of the drill path (breadcrumb entry). */
+export interface DrillCrumb {
+  /** Node label the user activated, e.g. "Family" or "Other Expense (4)". */
+  label: string
+  /** 'category' shows its subcategories; 'other' unfolds the folded tail. */
+  view: 'category' | 'other'
+  flow: 'income' | 'expense'
+  /** view='other' only: the folded tail categories to display. */
+  tail?: FlowEntry[]
+}
+
+export interface SankeyNodeMeta {
+  value: number
+  /** Share of the view's base total, 0-100. */
+  pct: number
+  color: string
+  drill: DrillCrumb | null
+}
+
+export interface SankeyView {
+  nodes: Array<{ name: string }>
+  links: Array<{ source: number; target: number; value: number }>
+  meta: SankeyNodeMeta[]
+  /** Child-side rows for the mobile list (same drill crumbs as the nodes). */
+  rows: FlowEntry[]
+  rowsTotal: number
+}
+
+export const SANKEY_TOP_N = 8
+
+const INCOME_CYCLE = [
+  rawColors.app.green,
+  rawColors.app.green,
+  rawColors.app.greenVibrant,
+  rawColors.app.teal,
+  rawColors.app.tealVibrant,
+]
+const EXPENSE_CYCLE = [
+  rawColors.app.red,
+  rawColors.app.redVibrant,
+  rawColors.app.pink,
+  rawColors.app.pinkVibrant,
+]
+
+const cycleColor = (flow: 'income' | 'expense', i: number): string => {
+  const cycle = flow === 'income' ? INCOME_CYCLE : EXPENSE_CYCLE
+  return cycle[i % cycle.length]
+}
+
+const pctOf = (amount: number, base: number): number => (base > 0 ? (amount / base) * 100 : 0)
+
+/** Label for rows whose subcategory is empty (matches the spending-rule page). */
+const NO_SUBCATEGORY = '(no subcategory)'
+
+/**
+ * Cap a category map to the top N by amount, folding the remainder into a
+ * single "Other (n)" bucket so visible flows still sum to the KPI totals.
+ * Returns the folded tail too so the "Other" node can drill into it.
+ */
+export function foldTopWithOther(
+  byCategory: Record<string, number>,
+  otherLabel: string,
+): { entries: FlowEntry[]; tail: FlowEntry[] } {
+  const sorted = Object.entries(byCategory)
+    .filter(([, amount]) => amount > 0)
+    .sort((a, b) => b[1] - a[1])
+  if (sorted.length <= SANKEY_TOP_N) {
+    return { entries: sorted.map(([name, amount]) => ({ name, amount })), tail: [] }
+  }
+  const entries = sorted.slice(0, SANKEY_TOP_N).map(([name, amount]) => ({ name, amount }))
+  const tail = sorted.slice(SANKEY_TOP_N).map(([name, amount]) => ({ name, amount }))
+  const otherAmount = tail.reduce((sum, e) => sum + e.amount, 0)
+  entries.push({ name: `${otherLabel} (${tail.length})`, amount: otherAmount })
+  return { entries, tail }
+}
+
+/** Distinct positive subcategory buckets per category, per flow. Drives "is
+ * this category worth drilling into" (>= 2 buckets; a single bucket view
+ * would just restate the category). */
+export function countSubBuckets(
+  transactions: Transaction[],
+): { income: Map<string, Set<string>>; expense: Map<string, Set<string>> } {
+  const income = new Map<string, Set<string>>()
+  const expense = new Map<string, Set<string>>()
+  for (const txn of transactions) {
+    let map: Map<string, Set<string>>
+    if (txn.type === 'Income') map = income
+    else if (txn.type === 'Expense') map = expense
+    else continue
+    if (txn.amount <= 0) continue
+    const category = txn.category || (map === income ? 'Other Income' : 'Other Expense')
+    const sub = txn.subcategory?.trim() || NO_SUBCATEGORY
+    if (!map.has(category)) map.set(category, new Set())
+    map.get(category)!.add(sub)
+  }
+  return { income, expense }
+}
+
+const categoryCrumb = (flow: 'income' | 'expense', label: string): DrillCrumb => ({
+  label,
+  view: 'category',
+  flow,
+})
+
+/** Attach drill crumbs to overview entries: categories with >= 2 sub-buckets
+ * drill to subcategories; the folded "Other (n)" node drills to its tail. */
+export function attachOverviewDrills(
+  entries: FlowEntry[],
+  tail: FlowEntry[],
+  flow: 'income' | 'expense',
+  subBuckets: Map<string, Set<string>>,
+): FlowEntry[] {
+  const hasSubs = (name: string) => (subBuckets.get(name)?.size ?? 0) >= 2
+  const tailWithDrills = tail.map((e) => ({
+    ...e,
+    drill: hasSubs(e.name) ? categoryCrumb(flow, e.name) : null,
+  }))
+  return entries.map((e, i) => {
+    const isOtherFold = tail.length > 0 && i === entries.length - 1
+    if (isOtherFold) {
+      return { ...e, drill: { label: e.name, view: 'other', flow, tail: tailWithDrills } }
+    }
+    return { ...e, drill: hasSubs(e.name) ? categoryCrumb(flow, e.name) : null }
+  })
+}
+
+/**
+ * Category drill view: one parent node and its subcategory breakdown.
+ * Expenses read left-to-right as parent -> subs (money flowing out);
+ * income reads subs -> parent (money flowing in). Subcategories beyond the
+ * top N fold into a non-drillable "Other".
+ */
+export function buildCategoryView(transactions: Transaction[], crumb: DrillCrumb): SankeyView {
+  const txnType = crumb.flow === 'income' ? 'Income' : 'Expense'
+  const bySub: Record<string, number> = {}
+  for (const txn of transactions) {
+    if (txn.type !== txnType || txn.amount <= 0) continue
+    const category = txn.category || (crumb.flow === 'income' ? 'Other Income' : 'Other Expense')
+    if (category !== crumb.label) continue
+    const sub = txn.subcategory?.trim() || NO_SUBCATEGORY
+    bySub[sub] = (bySub[sub] || 0) + txn.amount
+  }
+  const { entries } = foldTopWithOther(bySub, 'Other')
+  const total = entries.reduce((sum, e) => sum + e.amount, 0)
+  return buildParentChildView(crumb, entries, total)
+}
+
+/** "Other (n)" drill view: unfold the tail categories the overview folded.
+ * Tail entries carry their own category crumbs, so a category inside Other
+ * can drill one level deeper to its subcategories. */
+export function buildOtherView(crumb: DrillCrumb): SankeyView {
+  const entries = crumb.tail ?? []
+  const total = entries.reduce((sum, e) => sum + e.amount, 0)
+  return buildParentChildView(crumb, entries, total)
+}
+
+/** Shared two-column layout: parent on the money-source side, children on the
+ * other, links always oriented left-to-right in flow direction. */
+function buildParentChildView(crumb: DrillCrumb, children: FlowEntry[], total: number): SankeyView {
+  const parentColor = crumb.flow === 'income' ? rawColors.app.greenVibrant : rawColors.app.red
+  const parentMeta: SankeyNodeMeta = { value: total, pct: 100, color: parentColor, drill: null }
+
+  const nodes: Array<{ name: string }> = []
+  const links: Array<{ source: number; target: number; value: number }> = []
+  const meta: SankeyNodeMeta[] = []
+
+  const positive = children.filter((e) => e.amount > 0)
+
+  if (crumb.flow === 'expense') {
+    // Parent (index 0) -> children.
+    nodes.push({ name: crumb.label })
+    meta.push(parentMeta)
+    positive.forEach((e, i) => {
+      nodes.push({ name: e.name })
+      meta.push({ value: e.amount, pct: pctOf(e.amount, total), color: cycleColor('expense', i), drill: e.drill ?? null })
+      links.push({ source: 0, target: nodes.length - 1, value: e.amount })
+    })
+  } else {
+    // Children -> parent (last index): income still flows left-to-right.
+    positive.forEach((e, i) => {
+      nodes.push({ name: e.name })
+      meta.push({ value: e.amount, pct: pctOf(e.amount, total), color: cycleColor('income', i), drill: e.drill ?? null })
+    })
+    nodes.push({ name: crumb.label })
+    meta.push(parentMeta)
+    const parentIndex = nodes.length - 1
+    positive.forEach((_, i) => {
+      links.push({ source: i, target: parentIndex, value: positive[i].amount })
+    })
+  }
+
+  return { nodes, links, meta, rows: positive, rowsTotal: total }
+}
+
+/**
+ * Level-0 overview: income sources -> Total Income -> Savings + Expenses ->
+ * expense categories. Same topology the page always had, now with per-node
+ * meta (color, pct, drill target) instead of index-range arithmetic.
+ */
+export function buildOverviewView(args: {
+  incomeEntries: FlowEntry[]
+  expenseEntries: FlowEntry[]
+  totalIncome: number
+  totalExpense: number
+  netSavings: number
+}): SankeyView {
+  const { incomeEntries, expenseEntries, totalIncome, totalExpense, netSavings } = args
+
+  const nodes: Array<{ name: string }> = []
+  const links: Array<{ source: number; target: number; value: number }> = []
+  const meta: SankeyNodeMeta[] = []
+
+  incomeEntries.forEach((e, i) => {
+    nodes.push({ name: e.name })
+    meta.push({ value: e.amount, pct: pctOf(e.amount, totalIncome), color: cycleColor('income', i), drill: e.drill ?? null })
+  })
+
+  const totalIncomeIndex = nodes.length
+  nodes.push({ name: 'Total Income' })
+  meta.push({ value: totalIncome, pct: 100, color: rawColors.app.indigoVibrant, drill: null })
+
+  const savingsIndex = nodes.length
+  nodes.push({ name: 'Savings' })
+  meta.push({ value: Math.max(netSavings, 0), pct: pctOf(Math.max(netSavings, 0), totalIncome), color: rawColors.app.purple, drill: null })
+
+  const expensesIndex = nodes.length
+  nodes.push({ name: 'Expenses' })
+  meta.push({ value: totalExpense, pct: pctOf(totalExpense, totalIncome), color: rawColors.app.red, drill: null })
+
+  expenseEntries.forEach((e, i) => {
+    nodes.push({ name: e.name })
+    meta.push({ value: e.amount, pct: pctOf(e.amount, totalIncome), color: cycleColor('expense', i), drill: e.drill ?? null })
+    links.push({ source: expensesIndex, target: nodes.length - 1, value: e.amount })
+  })
+
+  incomeEntries.forEach((e, i) => {
+    links.push({ source: i, target: totalIncomeIndex, value: e.amount })
+  })
+  if (netSavings > 0) links.push({ source: totalIncomeIndex, target: savingsIndex, value: netSavings })
+  if (totalExpense > 0) links.push({ source: totalIncomeIndex, target: expensesIndex, value: totalExpense })
+
+  return { nodes, links, meta, rows: [], rowsTotal: totalIncome }
+}

--- a/frontend/src/pages/income-expense-flow/sankeyDrilldown.ts
+++ b/frontend/src/pages/income-expense-flow/sankeyDrilldown.ts
@@ -55,6 +55,12 @@ export interface SankeyView {
 
 export const SANKEY_TOP_N = 8
 
+/** Category names that are tax outflows, not living expenses. Keyword match
+ * keeps it dynamic (no hardcoded user category list). */
+const TAX_PATTERN = /\btax(es)?\b|\btds\b|income tax|advance tax|self assessment/i
+
+export const isTaxCategory = (name: string): boolean => TAX_PATTERN.test(name)
+
 const INCOME_CYCLE = [
   rawColors.app.green,
   rawColors.app.green,
@@ -220,9 +226,10 @@ function buildParentChildView(crumb: DrillCrumb, children: FlowEntry[], total: n
 }
 
 /**
- * Level-0 overview: income sources -> Total Income -> Savings + Expenses ->
- * expense categories. Same topology the page always had, now with per-node
- * meta (color, pct, drill target) instead of index-range arithmetic.
+ * Level-0 overview: income sources -> Total Income -> Tax + Savings +
+ * Expenses -> expense categories. Same topology the page always had plus an
+ * optional first-class Tax branch, with per-node meta (color, pct, drill
+ * target) instead of index-range arithmetic.
  */
 export function buildOverviewView(args: {
   incomeEntries: FlowEntry[]
@@ -230,8 +237,13 @@ export function buildOverviewView(args: {
   totalIncome: number
   totalExpense: number
   netSavings: number
+  /** Tax paid out of income (tax-category expenses). 0 hides the branch. */
+  totalTax?: number
+  /** Crumb for drilling into the Tax node's own breakdown. */
+  taxDrill?: DrillCrumb | null
 }): SankeyView {
   const { incomeEntries, expenseEntries, totalIncome, totalExpense, netSavings } = args
+  const totalTax = args.totalTax ?? 0
 
   const nodes: Array<{ name: string }> = []
   const links: Array<{ source: number; target: number; value: number }> = []
@@ -245,6 +257,15 @@ export function buildOverviewView(args: {
   const totalIncomeIndex = nodes.length
   nodes.push({ name: 'Total Income' })
   meta.push({ value: totalIncome, pct: 100, color: rawColors.app.indigoVibrant, drill: null })
+
+  // Tax leaves income before anything else -- its own branch, not an expense
+  // category, so "Expenses" reads as living costs and "Savings" stays honest.
+  let taxIndex = -1
+  if (totalTax > 0) {
+    taxIndex = nodes.length
+    nodes.push({ name: 'Tax' })
+    meta.push({ value: totalTax, pct: pctOf(totalTax, totalIncome), color: rawColors.app.orange, drill: args.taxDrill ?? null })
+  }
 
   const savingsIndex = nodes.length
   nodes.push({ name: 'Savings' })
@@ -263,6 +284,7 @@ export function buildOverviewView(args: {
   incomeEntries.forEach((e, i) => {
     links.push({ source: i, target: totalIncomeIndex, value: e.amount })
   })
+  if (taxIndex >= 0) links.push({ source: totalIncomeIndex, target: taxIndex, value: totalTax })
   if (netSavings > 0) links.push({ source: totalIncomeIndex, target: savingsIndex, value: netSavings })
   if (totalExpense > 0) links.push({ source: totalIncomeIndex, target: expensesIndex, value: totalExpense })
 

--- a/frontend/src/pages/income-expense-flow/sankeyDrilldown.ts
+++ b/frontend/src/pages/income-expense-flow/sankeyDrilldown.ts
@@ -237,13 +237,25 @@ export function buildOverviewView(args: {
   totalIncome: number
   totalExpense: number
   netSavings: number
-  /** Tax paid out of income (tax-category expenses). 0 hides the branch. */
+  /** Total tax burden shown on the Tax branch (explicit tax transactions plus
+   * the computed TDS below). 0 hides the branch. */
   totalTax?: number
+  /**
+   * Slab-computed tax deducted at source (from the FY tax engine), i.e. money
+   * that never hit the ledger because salary is recorded net of TDS. Shown at
+   * BOTH ends: a source node feeding Gross Income on the left, and inside the
+   * Tax branch on the right, so gross in still equals out.
+   */
+  tdsAtSource?: number
   /** Crumb for drilling into the Tax node's own breakdown. */
   taxDrill?: DrillCrumb | null
 }): SankeyView {
   const { incomeEntries, expenseEntries, totalIncome, totalExpense, netSavings } = args
   const totalTax = args.totalTax ?? 0
+  const tdsAtSource = args.tdsAtSource ?? 0
+
+  // Recorded income + implied TDS = the gross every percentage is based on.
+  const grossIncome = totalIncome + tdsAtSource
 
   const nodes: Array<{ name: string }> = []
   const links: Array<{ source: number; target: number; value: number }> = []
@@ -251,12 +263,21 @@ export function buildOverviewView(args: {
 
   incomeEntries.forEach((e, i) => {
     nodes.push({ name: e.name })
-    meta.push({ value: e.amount, pct: pctOf(e.amount, totalIncome), color: cycleColor('income', i), drill: e.drill ?? null })
+    meta.push({ value: e.amount, pct: pctOf(e.amount, grossIncome), color: cycleColor('income', i), drill: e.drill ?? null })
   })
 
+  // TDS enters as an income-side source: part of gross pay that went straight
+  // to the taxman without touching a bank account.
+  let tdsIndex = -1
+  if (tdsAtSource > 0) {
+    tdsIndex = nodes.length
+    nodes.push({ name: 'Tax Deducted at Source' })
+    meta.push({ value: tdsAtSource, pct: pctOf(tdsAtSource, grossIncome), color: rawColors.app.orange, drill: null })
+  }
+
   const totalIncomeIndex = nodes.length
-  nodes.push({ name: 'Total Income' })
-  meta.push({ value: totalIncome, pct: 100, color: rawColors.app.indigoVibrant, drill: null })
+  nodes.push({ name: tdsAtSource > 0 ? 'Gross Income' : 'Total Income' })
+  meta.push({ value: grossIncome, pct: 100, color: rawColors.app.indigoVibrant, drill: null })
 
   // Tax leaves income before anything else -- its own branch, not an expense
   // category, so "Expenses" reads as living costs and "Savings" stays honest.
@@ -264,29 +285,30 @@ export function buildOverviewView(args: {
   if (totalTax > 0) {
     taxIndex = nodes.length
     nodes.push({ name: 'Tax' })
-    meta.push({ value: totalTax, pct: pctOf(totalTax, totalIncome), color: rawColors.app.orange, drill: args.taxDrill ?? null })
+    meta.push({ value: totalTax, pct: pctOf(totalTax, grossIncome), color: rawColors.app.orange, drill: args.taxDrill ?? null })
   }
 
   const savingsIndex = nodes.length
   nodes.push({ name: 'Savings' })
-  meta.push({ value: Math.max(netSavings, 0), pct: pctOf(Math.max(netSavings, 0), totalIncome), color: rawColors.app.purple, drill: null })
+  meta.push({ value: Math.max(netSavings, 0), pct: pctOf(Math.max(netSavings, 0), grossIncome), color: rawColors.app.purple, drill: null })
 
   const expensesIndex = nodes.length
   nodes.push({ name: 'Expenses' })
-  meta.push({ value: totalExpense, pct: pctOf(totalExpense, totalIncome), color: rawColors.app.red, drill: null })
+  meta.push({ value: totalExpense, pct: pctOf(totalExpense, grossIncome), color: rawColors.app.red, drill: null })
 
   expenseEntries.forEach((e, i) => {
     nodes.push({ name: e.name })
-    meta.push({ value: e.amount, pct: pctOf(e.amount, totalIncome), color: cycleColor('expense', i), drill: e.drill ?? null })
+    meta.push({ value: e.amount, pct: pctOf(e.amount, grossIncome), color: cycleColor('expense', i), drill: e.drill ?? null })
     links.push({ source: expensesIndex, target: nodes.length - 1, value: e.amount })
   })
 
   incomeEntries.forEach((e, i) => {
     links.push({ source: i, target: totalIncomeIndex, value: e.amount })
   })
+  if (tdsIndex >= 0) links.push({ source: tdsIndex, target: totalIncomeIndex, value: tdsAtSource })
   if (taxIndex >= 0) links.push({ source: totalIncomeIndex, target: taxIndex, value: totalTax })
   if (netSavings > 0) links.push({ source: totalIncomeIndex, target: savingsIndex, value: netSavings })
   if (totalExpense > 0) links.push({ source: totalIncomeIndex, target: expensesIndex, value: totalExpense })
 
-  return { nodes, links, meta, rows: [], rowsTotal: totalIncome }
+  return { nodes, links, meta, rows: [], rowsTotal: grossIncome }
 }

--- a/frontend/src/pages/income-expense-flow/sankeyUtils.ts
+++ b/frontend/src/pages/income-expense-flow/sankeyUtils.ts
@@ -1,39 +1,3 @@
-import { rawColors } from '@/constants/colors'
-
 export function safeNumber(value: number): number {
   return Number.isFinite(value) ? value : 0
-}
-
-export function getNodeFillColor(
-  index: number,
-  incomeCategoryCount: number,
-  totalIncomeNodeIndex: number,
-  savingsNodeIndex: number,
-  expensesNodeIndex: number,
-): string {
-  if (index < incomeCategoryCount) {
-    const greenColors = [
-      rawColors.app.green,
-      rawColors.app.green,
-      rawColors.app.greenVibrant,
-      rawColors.app.teal,
-      rawColors.app.tealVibrant,
-    ]
-    return greenColors[index % greenColors.length]
-  }
-
-  if (index === totalIncomeNodeIndex) return rawColors.app.indigoVibrant
-  if (index === savingsNodeIndex) return rawColors.app.purple
-  if (index === expensesNodeIndex) return rawColors.app.red
-
-  // Expense categories stay in the red family so they read as "expense=red"
-  // and match the legend; orange/yellow drifted toward income/savings hues.
-  const redColors = [
-    rawColors.app.red,
-    rawColors.app.redVibrant,
-    rawColors.app.pink,
-    rawColors.app.pinkVibrant,
-  ]
-  const expenseIndex = index - (incomeCategoryCount + 3)
-  return redColors[expenseIndex % redColors.length]
 }

--- a/frontend/src/pages/income-expense-flow/useIncomeExpenseFlow.ts
+++ b/frontend/src/pages/income-expense-flow/useIncomeExpenseFlow.ts
@@ -26,6 +26,10 @@ export function useIncomeExpenseFlow() {
 
   // Drill path (breadcrumb stack). Empty = the full overview diagram.
   const [drillPath, setDrillPath] = useState<DrillCrumb[]>([])
+  // Last navigation direction + the clicked node's chart coordinates. Forward
+  // zooms the new view IN from the clicked spot; back zooms it OUT from center.
+  const [drillDirection, setDrillDirection] = useState<'in' | 'out'>('in')
+  const [zoomOrigin, setZoomOrigin] = useState<{ x: number; y: number } | null>(null)
 
   const fyTransactions = useMemo(() => {
     const startDate = dateRange.start_date
@@ -48,16 +52,22 @@ export function useIncomeExpenseFlow() {
     setDrillPath([])
   }
 
-  const drillInto = useCallback((crumb: DrillCrumb) => {
+  const drillInto = useCallback((crumb: DrillCrumb, origin?: { x: number; y: number }) => {
+    setDrillDirection('in')
+    setZoomOrigin(origin ?? null)
     setDrillPath((path) => [...path, crumb])
   }, [])
 
   /** Truncate to the first `depth` crumbs; 0 = back to overview. */
   const drillTo = useCallback((depth: number) => {
+    setDrillDirection('out')
+    setZoomOrigin(null)
     setDrillPath((path) => (depth >= path.length ? path : path.slice(0, depth)))
   }, [])
 
   const drillBack = useCallback(() => {
+    setDrillDirection('out')
+    setZoomOrigin(null)
     setDrillPath((path) => path.slice(0, -1))
   }, [])
 
@@ -153,6 +163,8 @@ export function useIncomeExpenseFlow() {
     timeFilterProps,
     view,
     drillPath,
+    drillDirection,
+    zoomOrigin,
     drillInto,
     drillTo,
     drillBack,

--- a/frontend/src/pages/income-expense-flow/useIncomeExpenseFlow.ts
+++ b/frontend/src/pages/income-expense-flow/useIncomeExpenseFlow.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 import { useTransactions } from '@/hooks/api/useTransactions'
 import { useAnalyticsTimeFilter } from '@/hooks/useAnalyticsTimeFilter'
@@ -6,26 +6,15 @@ import { useIsMobile } from '@/hooks/useIsMobile'
 import { getDateKey } from '@/lib/dateUtils'
 
 import { createSankeyNodeComponent } from './components/SankeyNodeRenderer'
-
-/** Cap a category map to the top N by amount, folding the remainder into a
- * single "Other (n)" bucket so the displayed flows still sum to the totals
- * shown on the KPI cards (a raw top-10 slice silently dropped the tail). */
-const SANKEY_TOP_N = 8
-function topCategoriesWithOther(
-  byCategory: Record<string, number>,
-  otherLabel: string,
-): Array<{ name: string; amount: number }> {
-  const sorted = Object.entries(byCategory)
-    .filter(([, amount]) => amount > 0)
-    .sort((a, b) => b[1] - a[1])
-  if (sorted.length <= SANKEY_TOP_N) {
-    return sorted.map(([name, amount]) => ({ name, amount }))
-  }
-  const head = sorted.slice(0, SANKEY_TOP_N).map(([name, amount]) => ({ name, amount }))
-  const restCount = sorted.length - SANKEY_TOP_N
-  const otherAmount = sorted.slice(SANKEY_TOP_N).reduce((sum, [, amount]) => sum + amount, 0)
-  return [...head, { name: `${otherLabel} (${restCount})`, amount: otherAmount }]
-}
+import {
+  attachOverviewDrills,
+  buildCategoryView,
+  buildOtherView,
+  buildOverviewView,
+  countSubBuckets,
+  foldTopWithOther,
+  type DrillCrumb,
+} from './sankeyDrilldown'
 
 export function useIncomeExpenseFlow() {
   const { data: allTransactions = [], isLoading } = useTransactions()
@@ -34,6 +23,9 @@ export function useIncomeExpenseFlow() {
   const isMobile = useIsMobile(1024)
 
   const { dateRange, currentFY, timeFilterProps } = useAnalyticsTimeFilter(allTransactions)
+
+  // Drill path (breadcrumb stack). Empty = the full overview diagram.
+  const [drillPath, setDrillPath] = useState<DrillCrumb[]>([])
 
   const fyTransactions = useMemo(() => {
     const startDate = dateRange.start_date
@@ -45,6 +37,29 @@ export function useIncomeExpenseFlow() {
       return txDate >= startDate && (!dateRange.end_date || txDate <= dateRange.end_date)
     })
   }, [allTransactions, dateRange])
+
+  // Changing the time filter can remove the drilled category entirely, so a
+  // period switch always returns to the overview. State-adjust-during-render
+  // (not an effect) per React's "adjusting state when props change" pattern.
+  const rangeKey = `${dateRange.start_date ?? ''}|${dateRange.end_date ?? ''}`
+  const [prevRangeKey, setPrevRangeKey] = useState(rangeKey)
+  if (rangeKey !== prevRangeKey) {
+    setPrevRangeKey(rangeKey)
+    setDrillPath([])
+  }
+
+  const drillInto = useCallback((crumb: DrillCrumb) => {
+    setDrillPath((path) => [...path, crumb])
+  }, [])
+
+  /** Truncate to the first `depth` crumbs; 0 = back to overview. */
+  const drillTo = useCallback((depth: number) => {
+    setDrillPath((path) => (depth >= path.length ? path : path.slice(0, depth)))
+  }, [])
+
+  const drillBack = useCallback(() => {
+    setDrillPath((path) => path.slice(0, -1))
+  }, [])
 
   const computed = useMemo(() => {
     const incomeByCategory = fyTransactions
@@ -78,94 +93,69 @@ export function useIncomeExpenseFlow() {
     // therefore the KPI cards). A raw slice(0,10) silently dropped categories
     // 11+, so the flows didn't sum to Total Income / Expenses for users with
     // many categories.
-    const topIncomeCats = topCategoriesWithOther(incomeByCategory, 'Other Income')
-    const topExpenseCats = topCategoriesWithOther(expenseByCategory, 'Other Expense')
+    const incomeFold = foldTopWithOther(incomeByCategory, 'Other Income')
+    const expenseFold = foldTopWithOther(expenseByCategory, 'Other Expense')
 
-    const nodes: Array<{ name: string; color?: string }> = []
-    const links: Array<{ source: number; target: number; value: number; color?: string }> = []
-    let nodeIndex = 0
-    const incomeNodeIndexByName = new Map<string, number>()
-    const expenseNodeIndexByName = new Map<string, number>()
-    const nodeValues = new Map<number, number>()
+    // Categories with >= 2 subcategory buckets are click-to-drill; the folded
+    // "Other (n)" node drills into the tail it hides.
+    const subBuckets = countSubBuckets(fyTransactions)
+    const topIncome = attachOverviewDrills(
+      incomeFold.entries,
+      incomeFold.tail,
+      'income',
+      subBuckets.income,
+    )
+    const topExpense = attachOverviewDrills(
+      expenseFold.entries,
+      expenseFold.tail,
+      'expense',
+      subBuckets.expense,
+    )
 
-    topIncomeCats.forEach(({ name, amount }) => {
-      incomeNodeIndexByName.set(name, nodeIndex)
-      nodeValues.set(nodeIndex, amount)
-      nodes.push({ name })
-      nodeIndex++
-    })
+    return { totalIncome, totalExpense, netSavings, savingsRate, topIncome, topExpense }
+  }, [fyTransactions])
 
-    const totalIncomeNodeIndex = nodeIndex
-    nodeValues.set(nodeIndex, totalIncome)
-    nodes.push({ name: 'Total Income' })
-    nodeIndex++
-
-    const savingsNodeIndex = nodeIndex
-    nodeValues.set(nodeIndex, Math.max(netSavings, 0))
-    nodes.push({ name: 'Savings' })
-    nodeIndex++
-
-    const expensesNodeIndex = nodeIndex
-    nodeValues.set(nodeIndex, totalExpense)
-    nodes.push({ name: 'Expenses' })
-    nodeIndex++
-
-    topExpenseCats.forEach(({ name, amount }) => {
-      expenseNodeIndexByName.set(name, nodeIndex)
-      nodeValues.set(nodeIndex, amount)
-      nodes.push({ name })
-      nodeIndex++
-    })
-
-    topIncomeCats.forEach(({ name, amount }) => {
-      const sourceIndex = incomeNodeIndexByName.get(name)
-      if (sourceIndex !== undefined) {
-        links.push({ source: sourceIndex, target: totalIncomeNodeIndex, value: amount })
-      }
-    })
-
-    if (netSavings > 0) {
-      links.push({ source: totalIncomeNodeIndex, target: savingsNodeIndex, value: netSavings })
+  // The currently displayed view: overview, a category's subcategories, or an
+  // unfolded "Other" tail. Fresh { nodes, links } object per level -- Recharts
+  // links reference nodes by array index, so indexes are rebuilt per view.
+  const view = useMemo(() => {
+    const crumb = drillPath.at(-1)
+    if (!crumb) {
+      return buildOverviewView({
+        incomeEntries: computed.topIncome,
+        expenseEntries: computed.topExpense,
+        totalIncome: computed.totalIncome,
+        totalExpense: computed.totalExpense,
+        netSavings: computed.netSavings,
+      })
     }
-    if (totalExpense > 0) {
-      links.push({ source: totalIncomeNodeIndex, target: expensesNodeIndex, value: totalExpense })
-    }
+    if (crumb.view === 'other') return buildOtherView(crumb)
+    return buildCategoryView(fyTransactions, crumb)
+  }, [drillPath, computed, fyTransactions])
 
-    topExpenseCats.forEach(({ name, amount }) => {
-      const targetIndex = expenseNodeIndexByName.get(name)
-      if (targetIndex !== undefined) {
-        links.push({ source: expensesNodeIndex, target: targetIndex, value: amount })
-      }
-    })
+  const chartWidth = isMobile ? 720 : 900
+  const sankeyNodeComponent = useMemo(
+    () =>
+      createSankeyNodeComponent({
+        meta: view.meta,
+        chartWidth,
+        fontSize: isMobile ? 11 : 13,
+        onDrill: drillInto,
+      }),
+    [view.meta, chartWidth, isMobile, drillInto],
+  )
 
-    const incomeCategoryCount = topIncomeCats.length
-    const chartWidth = isMobile ? 720 : 900
-    const sankeyNodeComponent = createSankeyNodeComponent({
-      nodeValues,
-      incomeCategoryCount,
-      totalIncomeNodeIndex,
-      savingsNodeIndex,
-      expensesNodeIndex,
-      totalIncome,
-      chartWidth,
-      fontSize: isMobile ? 11 : 13,
-    })
-
-    // Mobile rows reuse the same top-N + Other lists so phone + desktop agree.
-    const topIncome = topIncomeCats
-    const topExpense = topExpenseCats
-
-    return {
-      totalIncome,
-      totalExpense,
-      netSavings,
-      savingsRate,
-      sankeyData: { nodes, links },
-      sankeyNodeComponent,
-      topIncome,
-      topExpense,
-    }
-  }, [fyTransactions, isMobile])
-
-  return { ...computed, isLoading, isMobile, currentFY, timeFilterProps }
+  return {
+    ...computed,
+    isLoading,
+    isMobile,
+    currentFY,
+    timeFilterProps,
+    view,
+    drillPath,
+    drillInto,
+    drillTo,
+    drillBack,
+    sankeyNodeComponent,
+  }
 }

--- a/frontend/src/pages/income-expense-flow/useIncomeExpenseFlow.ts
+++ b/frontend/src/pages/income-expense-flow/useIncomeExpenseFlow.ts
@@ -13,7 +13,9 @@ import {
   buildOverviewView,
   countSubBuckets,
   foldTopWithOther,
+  isTaxCategory,
   type DrillCrumb,
+  type FlowEntry,
 } from './sankeyDrilldown'
 
 export function useIncomeExpenseFlow() {
@@ -83,20 +85,21 @@ export function useIncomeExpenseFlow() {
         {} as Record<string, number>,
       )
 
-    const expenseByCategory = fyTransactions
-      .filter((txn) => txn.type === 'Expense')
-      .reduce(
-        (acc, txn) => {
-          const category = txn.category || 'Other Expense'
-          acc[category] = (acc[category] || 0) + txn.amount
-          return acc
-        },
-        {} as Record<string, number>,
-      )
+    // Tax outflows split from living expenses: the Sankey shows Tax as its own
+    // branch out of Total Income, so "Expenses" reads as living costs.
+    const expenseByCategory: Record<string, number> = {}
+    const taxByCategory: Record<string, number> = {}
+    for (const txn of fyTransactions) {
+      if (txn.type !== 'Expense') continue
+      const category = txn.category || 'Other Expense'
+      const target = isTaxCategory(category) ? taxByCategory : expenseByCategory
+      target[category] = (target[category] || 0) + txn.amount
+    }
 
     const totalIncome = Object.values(incomeByCategory).reduce((a, b) => a + b, 0)
     const totalExpense = Object.values(expenseByCategory).reduce((a, b) => a + b, 0)
-    const netSavings = totalIncome - totalExpense
+    const totalTax = Object.values(taxByCategory).reduce((a, b) => a + b, 0)
+    const netSavings = totalIncome - totalExpense - totalTax
     const savingsRate = totalIncome > 0 ? (netSavings / totalIncome) * 100 : 0
 
     // Top-N + "Other" so every visible flow reconciles with the totals (and
@@ -122,7 +125,35 @@ export function useIncomeExpenseFlow() {
       subBuckets.expense,
     )
 
-    return { totalIncome, totalExpense, netSavings, savingsRate, topIncome, topExpense }
+    // Tax node drills into its categories (Income Tax, TDS, ...) when there is
+    // more than one; a single tax category drills into its subcategories.
+    const taxEntries: FlowEntry[] = Object.entries(taxByCategory)
+      .filter(([, amount]) => amount > 0)
+      .sort((a, b) => b[1] - a[1])
+      .map(([name, amount]) => ({
+        name,
+        amount,
+        drill: (subBuckets.expense.get(name)?.size ?? 0) >= 2
+          ? { label: name, view: 'category' as const, flow: 'expense' as const }
+          : null,
+      }))
+    let taxDrill: DrillCrumb | null = null
+    if (taxEntries.length > 1) {
+      taxDrill = { label: 'Tax', view: 'other', flow: 'expense', tail: taxEntries }
+    } else if (taxEntries.length === 1) {
+      taxDrill = taxEntries[0].drill ?? null
+    }
+
+    return {
+      totalIncome,
+      totalExpense,
+      totalTax,
+      netSavings,
+      savingsRate,
+      topIncome,
+      topExpense,
+      taxDrill,
+    }
   }, [fyTransactions])
 
   // The currently displayed view: overview, a category's subcategories, or an
@@ -137,6 +168,8 @@ export function useIncomeExpenseFlow() {
         totalIncome: computed.totalIncome,
         totalExpense: computed.totalExpense,
         netSavings: computed.netSavings,
+        totalTax: computed.totalTax,
+        taxDrill: computed.taxDrill,
       })
     }
     if (crumb.view === 'other') return buildOtherView(crumb)

--- a/frontend/src/pages/income-expense-flow/useIncomeExpenseFlow.ts
+++ b/frontend/src/pages/income-expense-flow/useIncomeExpenseFlow.ts
@@ -1,9 +1,12 @@
 import { useCallback, useMemo, useState } from 'react'
 
 import { useTransactions } from '@/hooks/api/useTransactions'
+import { usePreferences } from '@/hooks/api/usePreferences'
 import { useAnalyticsTimeFilter } from '@/hooks/useAnalyticsTimeFilter'
 import { useIsMobile } from '@/hooks/useIsMobile'
 import { getDateKey } from '@/lib/dateUtils'
+import { FY_START_MONTH } from '@/lib/taxCalculator'
+import { computePaidTax, groupTransactionsByFY } from '@/pages/tax-planning/taxPlanningUtils'
 
 import { createSankeyNodeComponent } from './components/SankeyNodeRenderer'
 import {
@@ -20,9 +23,28 @@ import {
 
 export function useIncomeExpenseFlow() {
   const { data: allTransactions = [], isLoading } = useTransactions()
+  const { data: preferences } = usePreferences()
   // Gate the horizontal Sankey to lg+ (>=1024px): it uses left/right:200 margins
   // that crush a tablet, so phones and tablets get the vertical MobileFlowView.
   const isMobile = useIsMobile(1024)
+
+  // Same tax engine inputs the Income Tax page uses, so the sankey's Tax
+  // figures agree with that page for the same FY.
+  const fiscalYearStartMonth = preferences?.fiscal_year_start_month || FY_START_MONTH
+  const salaryIsNetOfTds = preferences?.salary_is_net_of_tds ?? true
+  const preferredRegime = preferences?.preferred_tax_regime || 'new'
+  const epfTaxableFraction = preferences?.epf_withdrawal_taxable
+    ? (preferences.epf_taxable_percent ?? 100) / 100
+    : 0
+  const incomeClassification = useMemo(
+    () => ({
+      taxable: preferences?.taxable_income_categories || [],
+      investmentReturns: preferences?.investment_returns_categories || [],
+      nonTaxable: preferences?.non_taxable_income_categories || [],
+      other: preferences?.other_income_categories || [],
+    }),
+    [preferences],
+  )
 
   const { dateRange, currentFY, timeFilterProps } = useAnalyticsTimeFilter(allTransactions)
 
@@ -125,8 +147,26 @@ export function useIncomeExpenseFlow() {
       subBuckets.expense,
     )
 
-    // Tax node drills into its categories (Income Tax, TDS, ...) when there is
-    // more than one; a single tax category drills into its subcategories.
+    // FY-wise slab computation (same engine as the Income Tax page): group the
+    // filtered window by FY and sum each FY's computed tax-already-paid. With
+    // net-of-TDS salaries the ledger never sees that money, so the computed
+    // figure over and above explicit tax transactions is "deducted at source".
+    const byFY = groupTransactionsByFY(
+      fyTransactions,
+      fiscalYearStartMonth,
+      incomeClassification,
+      epfTaxableFraction,
+    )
+    const computedTax = Object.entries(byFY).reduce(
+      (sum, [fy, fyData]) =>
+        sum + computePaidTax(fy, fyData, null, preferredRegime, salaryIsNetOfTds),
+      0,
+    )
+    const tdsAtSource = Math.max(0, computedTax - totalTax)
+    const taxTotal = totalTax + tdsAtSource
+
+    // Tax node drills into its breakdown: explicit tax categories plus the
+    // computed at-source figure when present.
     const taxEntries: FlowEntry[] = Object.entries(taxByCategory)
       .filter(([, amount]) => amount > 0)
       .sort((a, b) => b[1] - a[1])
@@ -137,6 +177,10 @@ export function useIncomeExpenseFlow() {
           ? { label: name, view: 'category' as const, flow: 'expense' as const }
           : null,
       }))
+    if (tdsAtSource > 0) {
+      taxEntries.push({ name: 'TDS deducted at source (computed)', amount: tdsAtSource, drill: null })
+      taxEntries.sort((a, b) => b.amount - a.amount)
+    }
     let taxDrill: DrillCrumb | null = null
     if (taxEntries.length > 1) {
       taxDrill = { label: 'Tax', view: 'other', flow: 'expense', tail: taxEntries }
@@ -147,14 +191,22 @@ export function useIncomeExpenseFlow() {
     return {
       totalIncome,
       totalExpense,
-      totalTax,
+      totalTax: taxTotal,
+      tdsAtSource,
       netSavings,
       savingsRate,
       topIncome,
       topExpense,
       taxDrill,
     }
-  }, [fyTransactions])
+  }, [
+    fyTransactions,
+    fiscalYearStartMonth,
+    incomeClassification,
+    epfTaxableFraction,
+    preferredRegime,
+    salaryIsNetOfTds,
+  ])
 
   // The currently displayed view: overview, a category's subcategories, or an
   // unfolded "Other" tail. Fresh { nodes, links } object per level -- Recharts
@@ -169,6 +221,7 @@ export function useIncomeExpenseFlow() {
         totalExpense: computed.totalExpense,
         netSavings: computed.netSavings,
         totalTax: computed.totalTax,
+        tdsAtSource: computed.tdsAtSource,
         taxDrill: computed.taxDrill,
       })
     }

--- a/frontend/src/pages/investment-analytics/components/GrowthOverTimeChart.tsx
+++ b/frontend/src/pages/investment-analytics/components/GrowthOverTimeChart.tsx
@@ -79,8 +79,9 @@ export function GrowthOverTimeChart({
               <Tooltip
                 {...chartTooltipProps}
                 formatter={(value, name) => [currencyTooltipFormatter(value), name || '']}
+                // recharts 3.10 widened labelFormatter's label to ReactNode.
                 labelFormatter={(label) =>
-                  formatDate(label, {
+                  formatDate(String(label), {
                     month: 'long',
                     day: 'numeric',
                     year: 'numeric',

--- a/frontend/src/pages/net-worth/components/NetWorthTrendChart.tsx
+++ b/frontend/src/pages/net-worth/components/NetWorthTrendChart.tsx
@@ -180,8 +180,9 @@ export function NetWorthTrendChart(props: Readonly<NetWorthTrendChartProps>) {
               <Tooltip
                 {...chartTooltipProps}
                 formatter={currencyTooltipFormatter}
+                // recharts 3.10 widened labelFormatter's label to ReactNode.
                 labelFormatter={(label) =>
-                  formatDate(label, {
+                  formatDate(String(label), {
                     month: 'long',
                     day: 'numeric',
                     year: 'numeric',

--- a/frontend/src/pages/trends-forecasts/TrendsForecastsPage.tsx
+++ b/frontend/src/pages/trends-forecasts/TrendsForecastsPage.tsx
@@ -294,8 +294,9 @@ export default function TrendsForecastsPage() {
                 />
                 <Tooltip
                   {...chartTooltipProps}
+                  // recharts 3.10 widened labelFormatter's label to ReactNode.
                   labelFormatter={(label) =>
-                    formatDate(label, {
+                    formatDate(String(label), {
                       month: 'long',
                       day: 'numeric',
                       year: 'numeric',


### PR DESCRIPTION
## What

Click-to-drill on the Cash Flow Sankey. Clicking a category node (e.g. **Family**, **Housing**, or an income source like **Employment Income**) swaps the diagram to that category's subcategory breakdown; a breadcrumb above the chart ("All cash flow > Housing") navigates back, along with a **Back** button and the Escape key. Works for every income and expense category on both the desktop Sankey and the mobile flow list.

## Design (researched before building)

Live research pass (Recharts source/API + real-product UX) settled on the **replace-view** pattern with breadcrumb back:

- Every library that documents Sankey drill-down uses replace-view (amCharts official drill-down tutorial: swap chart data + breadcrumb; Google Charts / ECharts: click event + redraw). Expand-in-place exists only as a custom D3 hack whose documented failure mode is whole-diagram reflow and disorientation.
- Monarch Money (the reference finance Sankey) only links category clicks to a transactions list; its users explicitly asked for click-to-drill and "really NEEDS a back button" -- this ships exactly that.
- Recharts mechanics (verified in installed source): links reference nodes by numeric array index, so each level builds a fresh `{nodes, links}` dataset; a `key` remount per level resets stale tooltip active state; zero-value links are filtered (open recharts issue #2650); recharts has no per-node keyboard support, so nodes are hand-rolled `role="button"` with Enter/Space activation.

## How it works

- `sankeyDrilldown.ts` -- pure dataset builders: overview (classic topology), category view (parent -> subcategories; income mirrored so money still flows left-to-right), and "Other (n)" view (unfolds the folded tail; tail categories can drill one level deeper to their own subcategories). Per-node meta (value, pct, color, drill target) replaces the old fragile role-by-index-range logic.
- Drillable nodes (>= 2 subcategory buckets) show a chevron after the label, pointer cursor, hover ring + underline; leaves (single-bucket categories, hub nodes like Total Income/Savings) stay non-clickable.
- Amounts reconcile at every level: the drill parent equals the overview node value (verified live: Housing Rs 7,02,577 both places), and subcategory links sum to the parent.
- Time-filter changes reset to the overview (the drilled category may not exist in the new period).
- Mobile: the same rows are tappable buttons that show the breakdown list; breadcrumb handles the way back.
- recharts bumped 3.9.0 -> 3.10.0 (picks up the skipped-depth overlap fix and dense-graph freeze fix relevant to these view shapes); three existing `labelFormatter` callers adapted to the widened ReactNode label type.

## Verification

- `pnpm run lint` clean, `pnpm run type-check` clean, `pnpm test` 314 passed (10 new for the drill-down builders).
- Live in demo mode (desktop 1440px + mobile 375px):
  - Housing -> Rent/Utilities/Domestic Help/Household Items, totals reconcile (Rs 7,02,577 = 100% of drill view).
  - Employment Income -> Salary/Bonuses/EPF Contribution/Expense Reimbursement (income orientation preserved).
  - Other Expense (3) -> Personal Care/EMI/Education, then Personal Care -> Clothing/Grooming (3-level breadcrumb: All cash flow > Other Expense (3) > Personal Care).
  - Back via breadcrumb root, Back button, and Escape all return correctly; single chart instance after transition; no console errors.
