### PR TITLE
feat(ui): count-up KPIs, animated progress fills, heatmap wave

### DIFF
--- a/frontend/src/components/analytics/StandardBarChart.tsx
+++ b/frontend/src/components/analytics/StandardBarChart.tsx
@@ -12,6 +12,7 @@
  *   />
  */
 
+import { useState } from 'react'
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, LabelList, Cell, ReferenceLine,
 } from 'recharts'
@@ -147,11 +148,32 @@ function buildTooltipFormatter(
   return (value: number | undefined): string => (tooltipFormatter ?? formatCurrency)(value ?? 0)
 }
 
-function renderBarCells(bar: BarConfig, data: ReadonlyArray<object>) {
-  if (!bar.cellColors && !bar.getCellColor) return null
+/**
+ * Render per-bar <Cell>s so we can (a) apply per-item colors and (b) dim the
+ * non-hovered bars. For single-series ranking charts we always emit cells --
+ * even without custom colors -- so hovering one bar isolates it (the same
+ * "focus one, fade the rest" affordance the pie chart uses). `activeIndex`
+ * null means nothing hovered -> everything full opacity.
+ */
+function renderBarCells(
+  bar: BarConfig,
+  data: ReadonlyArray<object>,
+  activeIndex: number | null,
+  isolate: boolean,
+) {
+  const hasCustomColor = Boolean(bar.cellColors || bar.getCellColor)
+  if (!hasCustomColor && !isolate) return null
   return data.map((row, i) => {
-    const color = resolveCellColor(bar, row as Record<string, unknown>, i)
-    return color ? <Cell key={`${bar.key}-${i}`} fill={color} /> : null
+    const color = resolveCellColor(bar, row as Record<string, unknown>, i) ?? bar.color
+    const dimmed = isolate && activeIndex !== null && activeIndex !== i
+    return (
+      <Cell
+        key={`${bar.key}-${i}`}
+        fill={color}
+        fillOpacity={dimmed ? 0.35 : (bar.fillOpacity ?? 1)}
+        style={{ transition: 'fill-opacity 200ms ease' }}
+      />
+    )
   })
 }
 
@@ -185,10 +207,15 @@ export default function StandardBarChart({
   onBarClick,
   ariaLabel,
 }: StandardBarChartProps) {
+  const [activeIndex, setActiveIndex] = useState<number | null>(null)
+
   if (data.length === 0) {
     return <ChartEmptyState message={emptyMessage} height={height} />
   }
 
+  // Hover-isolate only makes sense for a single-series ranking chart. With
+  // grouped/stacked bars, dimming by row index would fade unrelated series.
+  const isolateOnHover = bars.length === 1 && !stacked
   const animate = shouldAnimate(data.length)
   const xOpts = xAngle === undefined ? undefined : { angle: xAngle, height: xHeight }
   const xDefaults = xAxisDefaults(data.length, xOpts)
@@ -261,6 +288,12 @@ export default function StandardBarChart({
             barSize={bar.barSize}
             stackId={stacked ? 'stack' : bar.stackId}
             cursor={onBarClick ? 'pointer' : undefined}
+            onMouseEnter={
+              isolateOnHover
+                ? (_entry: unknown, index: number) => setActiveIndex(index)
+                : undefined
+            }
+            onMouseLeave={isolateOnHover ? () => setActiveIndex(null) : undefined}
             onClick={
               onBarClick
                 ? (entry: unknown) => {
@@ -271,7 +304,7 @@ export default function StandardBarChart({
                 : undefined
             }
           >
-            {renderBarCells(bar, data)}
+            {renderBarCells(bar, data, activeIndex, isolateOnHover)}
             {showLabels && (
               <LabelList
                 dataKey={bar.key}

--- a/frontend/src/components/analytics/StandardPieChart.tsx
+++ b/frontend/src/components/analytics/StandardPieChart.tsx
@@ -16,6 +16,7 @@ import { formatCurrency } from '@/lib/formatters'
 import { chartTooltipProps, ChartContainer } from '@/components/ui'
 import { LEGEND_DEFAULTS, shouldAnimate } from '@/components/ui/chartDefaults'
 import ChartEmptyState from '@/components/shared/ChartEmptyState'
+import { useAnimatedValue } from '@/hooks/useAnimatedValue'
 import { getChartColor, SEMANTIC_COLORS, CHART_TEXT } from '@/constants/chartColors'
 
 interface PieDataItem {
@@ -94,6 +95,8 @@ export default function StandardPieChart({
       : head
   }, [data, maxSlices])
   const [activeIndex, setActiveIndex] = useState<number | null>(null)
+  // Donut center figure counts up alongside the sweep-in of the ring.
+  const animatedCenterValue = useAnimatedValue(centerValue ?? '')
 
   if (filteredData.length === 0) {
     return <ChartEmptyState message={emptyMessage} height={height} />
@@ -175,7 +178,7 @@ export default function StandardPieChart({
                 fontSize={centerValueFontSize}
                 fontWeight="700"
               >
-                {centerValue}
+                {animatedCenterValue}
               </tspan>
             )}
             <tspan x="50%" dy={centerValue ? '20' : '0'} fill={CHART_TEXT.subtle} fontSize="11">

--- a/frontend/src/components/layout/Sidebar/SidebarItem.tsx
+++ b/frontend/src/components/layout/Sidebar/SidebarItem.tsx
@@ -1,3 +1,4 @@
+import { motion } from 'framer-motion'
 import type { LucideIcon } from 'lucide-react'
 import { NavLink } from 'react-router-dom'
 
@@ -29,20 +30,30 @@ export default function SidebarItem({
         cn(
           'relative flex min-h-11 items-center gap-2.5 rounded-md px-2.5 text-[13px] transition-colors duration-150 lg:min-h-9',
           isActive
-            ? 'bg-[var(--overlay-4)] font-medium text-foreground'
+            ? 'font-medium text-foreground'
             : 'text-muted-foreground hover:bg-[var(--overlay-2)] hover:text-foreground',
         )
       }
     >
       {({ isActive }) => (
         <>
+          {/* Active pill slides between items (shared layoutId) instead of
+              snapping -- same pattern the mobile tab bar already uses. */}
+          {isActive && (
+            <motion.span
+              layoutId="sidebar-active-pill"
+              className="absolute inset-0 rounded-md bg-[var(--overlay-4)]"
+              transition={{ type: 'spring', stiffness: 400, damping: 32 }}
+              aria-hidden
+            />
+          )}
           <Icon
             className={cn(
-              'size-4 shrink-0',
+              'relative size-4 shrink-0',
               isActive ? 'text-foreground' : 'text-text-tertiary',
             )}
           />
-          <span className="flex-1 truncate">{label}</span>
+          <span className="relative flex-1 truncate">{label}</span>
           {badge !== undefined && badge > 0 && (
             <span
               className={cn(

--- a/frontend/src/components/shared/ChartEmptyState.tsx
+++ b/frontend/src/components/shared/ChartEmptyState.tsx
@@ -1,3 +1,4 @@
+import { motion } from 'framer-motion'
 import { BarChart3 } from 'lucide-react'
 
 interface ChartEmptyStateProps {
@@ -20,10 +21,22 @@ export default function ChartEmptyState({
       className="flex flex-col items-center justify-center gap-3 rounded-xl border border-border"
       style={{ height }}
     >
-      <div className="p-3 rounded-xl bg-[var(--overlay-2)]">
+      <motion.div
+        className="p-3 rounded-xl bg-[var(--overlay-2)]"
+        initial={{ opacity: 0, scale: 0.8 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+      >
         <BarChart3 className="w-6 h-6 text-text-tertiary" />
-      </div>
-      <p className="text-sm text-text-tertiary">{message}</p>
+      </motion.div>
+      <motion.p
+        className="text-sm text-text-tertiary"
+        initial={{ opacity: 0, y: 6 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.1, duration: 0.3 }}
+      >
+        {message}
+      </motion.p>
     </div>
   )
 }

--- a/frontend/src/components/shared/MetricCard.tsx
+++ b/frontend/src/components/shared/MetricCard.tsx
@@ -6,6 +6,7 @@ import type { LucideIcon } from 'lucide-react'
 import { Link } from 'react-router-dom'
 
 import { metricColorConfig, rawColors, type MetricColor } from '@/constants/colors'
+import { useAnimatedValue } from '@/hooks/useAnimatedValue'
 import { cn } from '@/lib/cn'
 
 interface MetricCardProps {
@@ -47,6 +48,10 @@ export default function MetricCard({
   titleInfo,
 }: Readonly<MetricCardProps>) {
   const colors = metricColorConfig[color]
+  // Count-up on the KPI figure (format-preserving; settles on the exact
+  // original string). Hook order is stable: isLoading renders a skeleton with
+  // no value, and this hook runs unconditionally before that branch.
+  const animatedValue = useAnimatedValue(value)
 
   if (isLoading) {
     return (
@@ -97,13 +102,13 @@ export default function MetricCard({
         <div>
           <output
             className={cn(
-              'metric-value ledger-figure block whitespace-nowrap font-semibold leading-none text-foreground',
+              'metric-value ledger-figure block whitespace-nowrap font-semibold leading-none text-foreground tabular-nums',
               hero && 'metric-value-hero',
             )}
             title={String(value)}
             aria-live="polite"
           >
-            {value}
+            {animatedValue}
           </output>
           {subtitle && (
             <p className="mt-1 truncate text-[11px] text-text-tertiary" title={subtitle}>

--- a/frontend/src/components/shared/ProgressBar.tsx
+++ b/frontend/src/components/shared/ProgressBar.tsx
@@ -1,3 +1,5 @@
+import { motion } from 'framer-motion'
+
 import { rawColors } from '@/constants/colors'
 
 /**
@@ -78,10 +80,13 @@ export default function ProgressBar({
         )
       })}
 
-      {/* Fill */}
-      <div
-        className="absolute inset-y-0 left-0 rounded-full transition-[width] duration-500"
-        style={{ width: `${pct}%`, backgroundColor: color }}
+      {/* Fill: draws from 0 on mount, springs between values on change. */}
+      <motion.div
+        className="absolute inset-y-0 left-0 rounded-full"
+        style={{ backgroundColor: color }}
+        initial={{ width: 0 }}
+        animate={{ width: `${pct}%` }}
+        transition={{ duration: 0.7, ease: [0.25, 0.46, 0.45, 0.94] }}
       />
 
       {/* Target tick */}

--- a/frontend/src/components/shared/QuickInsights.tsx
+++ b/frontend/src/components/shared/QuickInsights.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 
+import { motion } from 'framer-motion'
 import {
   ShoppingBag, TrendingUp, TrendingDown, Zap, Gift, Receipt,
   Flame, ArrowLeftRight, Landmark, Calendar, BarChart3,
@@ -8,6 +9,8 @@ import {
 } from 'lucide-react'
 
 import { useCategoryBreakdown, useTotals, useQuickInsights } from '@/hooks/api/useAnalytics'
+import { waveCascadeContainer, waveCascadeItem } from '@/constants/animations'
+import { useAnimatedValue } from '@/hooks/useAnimatedValue'
 import { formatCurrency } from '@/lib/formatters'
 
 import LoadingSkeleton from './LoadingSkeleton'
@@ -41,17 +44,22 @@ interface QuickInsightsProps {
 }
 
 function InsightCard({ item }: Readonly<{ item: InsightDescriptor }>) {
+  // Format-preserving count-up; settles on the exact formatted string.
+  const animatedValue = useAnimatedValue(item.value)
   return (
-    <div className="ledger-cell flex min-h-20 items-center gap-3 p-3 transition-colors duration-150 hover:bg-[var(--overlay-1)]">
+    <motion.div
+      variants={waveCascadeItem}
+      className="ledger-cell flex min-h-20 items-center gap-3 p-3 transition-colors duration-150 hover:bg-[var(--overlay-1)]"
+    >
       <div className={`flex size-7 shrink-0 items-center justify-center rounded-md ${item.bg}`}>
         <item.icon className={`size-3.5 ${item.color}`} />
       </div>
       <div className="flex-1 min-w-0">
         <p className="truncate text-[11px] text-muted-foreground">{item.title}</p>
-        <p className="ledger-figure truncate text-xs font-semibold text-foreground sm:text-sm" title={item.value}>{item.value}</p>
+        <p className="ledger-figure truncate text-xs font-semibold text-foreground sm:text-sm tabular-nums" title={item.value}>{animatedValue}</p>
         {item.subtitle && <p className="text-[11px] text-text-tertiary truncate" title={item.subtitle}>{item.subtitle}</p>}
       </div>
-    </div>
+    </motion.div>
   )
 }
 
@@ -216,17 +224,27 @@ export default function QuickInsights({
 
   return (
     <div className="space-y-4">
-      {/* Quick Insights */}
-      <div className="ledger-band grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+      {/* Quick Insights: tiles cascade in as a wave, values count up. */}
+      <motion.div
+        className="ledger-band grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
+        variants={waveCascadeContainer}
+        initial="hidden"
+        animate="visible"
+      >
         {filterByVisibility(quickInsights, visibleKeys).map((item) => <InsightCard key={item.title} item={item} />)}
-      </div>
+      </motion.div>
 
       {/* Fun Facts */}
       <div>
         <h3 className="mb-2 text-xs font-medium text-muted-foreground">Behavior signals</h3>
-        <div className="ledger-band grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+        <motion.div
+          className="ledger-band grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
+          variants={waveCascadeContainer}
+          initial="hidden"
+          animate="visible"
+        >
           {filterByVisibility(funFacts, visibleKeys).map((item) => <InsightCard key={item.title} item={item} />)}
-        </div>
+        </motion.div>
       </div>
     </div>
   )

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -43,7 +43,10 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
       ref={ref}
       disabled={disabled || isLoading}
       className={cn(
-        'inline-flex items-center justify-center whitespace-nowrap font-medium transition-colors duration-150 ease-out',
+        // transition-[color,background-color,border-color,transform] keeps the
+        // press scale springy without animating layout properties.
+        'inline-flex items-center justify-center whitespace-nowrap font-medium transition-[color,background-color,border-color,transform] duration-150 ease-out',
+        'active:scale-[0.97]',
         'disabled:pointer-events-none disabled:opacity-50',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-background',
         variantClasses[variant],

--- a/frontend/src/components/ui/ChartTooltip.tsx
+++ b/frontend/src/components/ui/ChartTooltip.tsx
@@ -39,10 +39,27 @@ export const CHART_TOOLTIP_ITEM_STYLE: CSSProperties = {
 /** Cursor style for BarChart hover highlight (subtle instead of default white) */
 export const CHART_CURSOR_STYLE = { fill: CHART_SURFACE.cursor }
 
+/**
+ * The tooltip box glides to follow the cursor instead of teleporting between
+ * data points. Recharts positions the wrapper absolutely and updates left/top
+ * per move; a short transform/opacity transition on the wrapper turns those
+ * jumps into a smooth slide + fade -- applied to every chart in the app at
+ * once via `chartTooltipProps`.
+ */
+export const CHART_TOOLTIP_WRAPPER_STYLE: CSSProperties = {
+  transition: 'transform 120ms ease-out, opacity 120ms ease-out',
+  outline: 'none',
+}
+
 /** Spread-friendly object for Recharts <Tooltip {...chartTooltipProps} /> */
 export const chartTooltipProps = {
   contentStyle: CHART_TOOLTIP_STYLE,
   labelStyle: CHART_TOOLTIP_LABEL_STYLE,
   itemStyle: CHART_TOOLTIP_ITEM_STYLE,
+  wrapperStyle: CHART_TOOLTIP_WRAPPER_STYLE,
   cursor: CHART_CURSOR_STYLE,
+  // Recharts animates the tooltip's reposition when this is on.
+  isAnimationActive: true,
+  animationDuration: 200,
+  animationEasing: 'ease-out' as const,
 } as const

--- a/frontend/src/hooks/__tests__/useAnimatedValue.test.ts
+++ b/frontend/src/hooks/__tests__/useAnimatedValue.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatLikeSample, parseFormattedValue } from '../useAnimatedValue'
+
+describe('parseFormattedValue', () => {
+  it('parses indian-grouped currency', () => {
+    const p = parseFormattedValue('₹45,33,242.00')
+    expect(p).toMatchObject({ prefix: '₹', suffix: '', amount: 4533242, decimals: 2, grouping: 'indian' })
+  })
+
+  it('parses western-grouped currency', () => {
+    const p = parseFormattedValue('$4,533,242.50')
+    expect(p).toMatchObject({ prefix: '$', suffix: '', amount: 4533242.5, decimals: 2, grouping: 'western' })
+  })
+
+  it('parses percentages and plain numbers', () => {
+    expect(parseFormattedValue('55.5%')).toMatchObject({ prefix: '', suffix: '%', amount: 55.5, decimals: 1, grouping: 'none' })
+    expect(parseFormattedValue('396 days')).toMatchObject({ suffix: ' days', amount: 396 })
+    expect(parseFormattedValue('42')).toMatchObject({ amount: 42, decimals: 0 })
+  })
+
+  it('returns null for non-numeric strings', () => {
+    expect(parseFormattedValue('No data')).toBeNull()
+    expect(parseFormattedValue('')).toBeNull()
+  })
+})
+
+describe('formatLikeSample', () => {
+  it('round-trips: formatting the parsed amount reproduces the original string', () => {
+    for (const sample of ['₹45,33,242.00', '$4,533,242.50', '₹1,00,000.00', '55.5%', '₹999.00', '396 days', '1,234']) {
+      const p = parseFormattedValue(sample)!
+      expect(formatLikeSample(p.amount, p)).toBe(sample)
+    }
+  })
+
+  it('formats intermediate values with the sample grouping', () => {
+    const indian = parseFormattedValue('₹45,33,242.00')!
+    expect(formatLikeSample(123456, indian)).toBe('₹1,23,456.00')
+    const western = parseFormattedValue('$4,533,242.00')!
+    expect(formatLikeSample(123456, western)).toBe('$123,456.00')
+  })
+
+  it('clamps negatives to zero (count-up starts at 0)', () => {
+    const p = parseFormattedValue('₹500.00')!
+    expect(formatLikeSample(-10, p)).toBe('₹0.00')
+  })
+})

--- a/frontend/src/hooks/useAnimatedValue.ts
+++ b/frontend/src/hooks/useAnimatedValue.ts
@@ -1,0 +1,103 @@
+import { useEffect, useRef, useState } from 'react'
+
+/**
+ * Parse a formatted value string ("₹45,33,242.00", "$1,234.56", "55.5%") into
+ * its numeric part plus everything needed to re-render intermediate frames in
+ * the SAME format: prefix, suffix, decimal places, and grouping style.
+ */
+interface ParsedValue {
+  prefix: string
+  suffix: string
+  amount: number
+  decimals: number
+  grouping: 'indian' | 'western' | 'none'
+}
+
+export function parseFormattedValue(sample: string): ParsedValue | null {
+  const match = /^(\D*)([\d,]+(?:\.\d+)?)(.*)$/s.exec(sample)
+  if (!match) return null
+  const [, prefix, numeric, suffix] = match
+  const dot = numeric.indexOf('.')
+  const decimals = dot === -1 ? 0 : numeric.length - dot - 1
+  const amount = Number.parseFloat(numeric.replaceAll(',', ''))
+  if (!Number.isFinite(amount)) return null
+
+  // Indian grouping has a 2-digit group after the first comma ("45,33,242");
+  // western is all 3s ("4,533,242"). No comma at all = no grouping.
+  let grouping: ParsedValue['grouping'] = 'none'
+  const intPart = dot === -1 ? numeric : numeric.slice(0, dot)
+  if (intPart.includes(',')) {
+    const groups = intPart.split(',')
+    grouping = groups.slice(1).some((g) => g.length === 2) ? 'indian' : 'western'
+  }
+  return { prefix, suffix, amount, decimals, grouping }
+}
+
+function groupDigits(intStr: string, grouping: ParsedValue['grouping']): string {
+  if (grouping === 'none' || intStr.length <= 3) return intStr
+  if (grouping === 'western') return intStr.replaceAll(/\B(?=(\d{3})+(?!\d))/g, ',')
+  // Indian: last 3 digits, then groups of 2.
+  const head = intStr.slice(0, -3)
+  const tail = intStr.slice(-3)
+  const groupedHead = head.replaceAll(/\B(?=(\d{2})+(?!\d))/g, ',')
+  return `${groupedHead},${tail}`
+}
+
+export function formatLikeSample(n: number, parsed: ParsedValue): string {
+  const fixed = Math.max(0, n).toFixed(parsed.decimals)
+  const [intPart, decPart] = fixed.split('.')
+  const grouped = groupDigits(intPart, parsed.grouping)
+  return `${parsed.prefix}${grouped}${decPart !== undefined ? '.' + decPart : ''}${parsed.suffix}`
+}
+
+/**
+ * Count-up for ALREADY-FORMATTED value strings (currency, percentages).
+ *
+ * Animates the numeric part 0 -> value over `duration` ms (ease-out cubic)
+ * while re-rendering every frame in the same format (symbol, decimals,
+ * indian/western digit grouping) detected from the input. The FINAL frame
+ * always renders the exact original string, so the settled display is
+ * guaranteed byte-identical to what the caller formatted -- the animation can
+ * never corrupt a number. Non-numeric strings render as-is, no animation.
+ *
+ * Re-runs when `value` changes (animating from the previous amount), so KPI
+ * cards roll to their new figure when the filter changes.
+ */
+export function useAnimatedValue(value: string | number, duration = 800): string {
+  const stringValue = String(value)
+  // null = not animating; render the exact input. Set only from rAF frames.
+  const [frameValue, setFrameValue] = useState<string | null>(null)
+  const fromRef = useRef(0)
+  const frame = useRef(0)
+
+  useEffect(() => {
+    const parsed = parseFormattedValue(stringValue)
+    if (!parsed || parsed.amount === 0) {
+      fromRef.current = parsed?.amount ?? 0
+      return
+    }
+    const from = fromRef.current
+    const start = performance.now()
+
+    const tick = (now: number) => {
+      const progress = Math.min((now - start) / duration, 1)
+      if (progress >= 1) {
+        // Settle on the exact original string -- correctness guarantee.
+        setFrameValue(null)
+        fromRef.current = parsed.amount
+        return
+      }
+      const eased = 1 - Math.pow(1 - progress, 3)
+      setFrameValue(formatLikeSample(from + (parsed.amount - from) * eased, parsed))
+      frame.current = requestAnimationFrame(tick)
+    }
+
+    frame.current = requestAnimationFrame(tick)
+    return () => {
+      cancelAnimationFrame(frame.current)
+      setFrameValue(null)
+    }
+  }, [stringValue, duration])
+
+  return frameValue ?? stringValue
+}

--- a/frontend/src/hooks/useAnimatedValue.ts
+++ b/frontend/src/hooks/useAnimatedValue.ts
@@ -13,12 +13,37 @@ interface ParsedValue {
   grouping: 'indian' | 'western' | 'none'
 }
 
+const isDigit = (ch: string) => ch >= '0' && ch <= '9'
+
 export function parseFormattedValue(sample: string): ParsedValue | null {
-  const match = /^(\D*)([\d,]+(?:\.\d+)?)(.*)$/s.exec(sample)
-  if (!match) return null
-  const [, prefix, numeric, suffix] = match
+  // Manual linear scan (a \D*/[\d,]+ regex backtracks super-linearly on the
+  // ambiguous comma): prefix = everything before the first digit, number =
+  // digits/commas + optional decimal part, suffix = the rest.
+  let firstDigit = -1
+  for (let i = 0; i < sample.length; i++) {
+    if (isDigit(sample[i])) {
+      firstDigit = i
+      break
+    }
+  }
+  if (firstDigit === -1) return null
+
+  let i = firstDigit
+  while (i < sample.length && (isDigit(sample[i]) || sample[i] === ',')) i++
+  let decimals = 0
+  if (sample[i] === '.') {
+    let j = i + 1
+    while (j < sample.length && isDigit(sample[j])) j++
+    if (j > i + 1) {
+      decimals = j - i - 1
+      i = j
+    }
+  }
+
+  const prefix = sample.slice(0, firstDigit)
+  const numeric = sample.slice(firstDigit, i)
+  const suffix = sample.slice(i)
   const dot = numeric.indexOf('.')
-  const decimals = dot === -1 ? 0 : numeric.length - dot - 1
   const amount = Number.parseFloat(numeric.replaceAll(',', ''))
   if (!Number.isFinite(amount)) return null
 
@@ -33,14 +58,21 @@ export function parseFormattedValue(sample: string): ParsedValue | null {
   return { prefix, suffix, amount, decimals, grouping }
 }
 
+/** Insert commas right-to-left every `size` digits. Linear, no regex. */
+function groupFromRight(digits: string, size: number): string {
+  const parts: string[] = []
+  for (let end = digits.length; end > 0; end -= size) {
+    parts.unshift(digits.slice(Math.max(0, end - size), end))
+  }
+  return parts.join(',')
+}
+
 function groupDigits(intStr: string, grouping: ParsedValue['grouping']): string {
   if (grouping === 'none' || intStr.length <= 3) return intStr
-  if (grouping === 'western') return intStr.replaceAll(/\B(?=(\d{3})+(?!\d))/g, ',')
+  if (grouping === 'western') return groupFromRight(intStr, 3)
   // Indian: last 3 digits, then groups of 2.
-  const head = intStr.slice(0, -3)
-  const tail = intStr.slice(-3)
-  const groupedHead = head.replaceAll(/\B(?=(\d{2})+(?!\d))/g, ',')
-  return `${groupedHead},${tail}`
+  const head = groupFromRight(intStr.slice(0, -3), 2)
+  return `${head},${intStr.slice(-3)}`
 }
 
 export function formatLikeSample(n: number, parsed: ParsedValue): string {

--- a/frontend/src/hooks/useAnimatedValue.ts
+++ b/frontend/src/hooks/useAnimatedValue.ts
@@ -15,10 +15,32 @@ interface ParsedValue {
 
 const isDigit = (ch: string) => ch >= '0' && ch <= '9'
 
+/**
+ * Scan the number span starting at `start`: digits/commas, then an optional
+ * decimal part. Returns the end index (exclusive) and decimal count.
+ * Manual linear scan -- an equivalent digits-and-commas regex backtracks
+ * super-linearly on the ambiguous comma (Sonar S8786).
+ */
+function scanNumber(sample: string, start: number): { end: number; decimals: number } {
+  let i = start
+  while (i < sample.length && (isDigit(sample[i]) || sample[i] === ',')) i++
+  if (sample[i] !== '.') return { end: i, decimals: 0 }
+  let j = i + 1
+  while (j < sample.length && isDigit(sample[j])) j++
+  return j > i + 1 ? { end: j, decimals: j - i - 1 } : { end: i, decimals: 0 }
+}
+
+/** Indian grouping has a 2-digit group after the first comma ("45,33,242");
+ * western is all 3s ("4,533,242"). No comma = no grouping. */
+function detectGrouping(intPart: string): ParsedValue['grouping'] {
+  if (!intPart.includes(',')) return 'none'
+  const groups = intPart.split(',')
+  return groups.slice(1).some((g) => g.length === 2) ? 'indian' : 'western'
+}
+
 export function parseFormattedValue(sample: string): ParsedValue | null {
-  // Manual linear scan (a \D*/[\d,]+ regex backtracks super-linearly on the
-  // ambiguous comma): prefix = everything before the first digit, number =
-  // digits/commas + optional decimal part, suffix = the rest.
+  // prefix = everything before the first digit, number = digits/commas +
+  // optional decimal part, suffix = the rest.
   let firstDigit = -1
   for (let i = 0; i < sample.length; i++) {
     if (isDigit(sample[i])) {
@@ -28,34 +50,19 @@ export function parseFormattedValue(sample: string): ParsedValue | null {
   }
   if (firstDigit === -1) return null
 
-  let i = firstDigit
-  while (i < sample.length && (isDigit(sample[i]) || sample[i] === ',')) i++
-  let decimals = 0
-  if (sample[i] === '.') {
-    let j = i + 1
-    while (j < sample.length && isDigit(sample[j])) j++
-    if (j > i + 1) {
-      decimals = j - i - 1
-      i = j
-    }
-  }
-
-  const prefix = sample.slice(0, firstDigit)
-  const numeric = sample.slice(firstDigit, i)
-  const suffix = sample.slice(i)
-  const dot = numeric.indexOf('.')
+  const { end, decimals } = scanNumber(sample, firstDigit)
+  const numeric = sample.slice(firstDigit, end)
   const amount = Number.parseFloat(numeric.replaceAll(',', ''))
   if (!Number.isFinite(amount)) return null
 
-  // Indian grouping has a 2-digit group after the first comma ("45,33,242");
-  // western is all 3s ("4,533,242"). No comma at all = no grouping.
-  let grouping: ParsedValue['grouping'] = 'none'
-  const intPart = dot === -1 ? numeric : numeric.slice(0, dot)
-  if (intPart.includes(',')) {
-    const groups = intPart.split(',')
-    grouping = groups.slice(1).some((g) => g.length === 2) ? 'indian' : 'western'
+  const dot = numeric.indexOf('.')
+  return {
+    prefix: sample.slice(0, firstDigit),
+    suffix: sample.slice(end),
+    amount,
+    decimals,
+    grouping: detectGrouping(dot === -1 ? numeric : numeric.slice(0, dot)),
   }
-  return { prefix, suffix, amount, decimals, grouping }
 }
 
 /** Insert commas right-to-left every `size` digits. Linear, no regex. */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -675,6 +675,25 @@ body {
   animation: fade-up 0.2s ease-out both;
 }
 
+/* Year-in-review heatmap: cells pop in as a left-to-right wave (per-cell
+ * animation-delay set inline). CSS keyframes, not framer-motion -- the grid
+ * has ~370 cells and per-cell JS animation would add real mount cost. */
+@keyframes heatmap-pop {
+  from {
+    opacity: 0;
+    transform: scale(0.4);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.heatmap-cell-appear {
+  animation: heatmap-pop 0.3s ease-out both;
+}
+
 /* ===== REDUCED MOTION =====
  * Motion is visible BY DEFAULT (a deliberate product choice). This block ONLY
  * fires when the user has set the OS "reduce motion" accessibility preference,

--- a/frontend/src/pages/home/components/FeaturesSection.tsx
+++ b/frontend/src/pages/home/components/FeaturesSection.tsx
@@ -1,4 +1,7 @@
+import { motion } from 'framer-motion'
 import { BarChart3, Shield, TrendingUp, Zap } from 'lucide-react'
+
+import { staggerContainer, fadeUpItem } from '@/constants/animations'
 
 const FEATURES = [
   {
@@ -48,10 +51,17 @@ export function FeaturesSection() {
           </p>
         </div>
 
-        <div className="grid md:grid-cols-2">
+        <motion.div
+          className="grid md:grid-cols-2"
+          variants={staggerContainer}
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, margin: '-80px' }}
+        >
           {FEATURES.map((feature) => (
-            <div
+            <motion.div
               key={feature.title}
+              variants={fadeUpItem}
               className="flex min-h-40 items-start gap-4 border-b border-border py-7 md:px-7 md:even:border-l md:odd:pl-0 md:even:pr-0"
             >
               <div
@@ -65,9 +75,9 @@ export function FeaturesSection() {
                   {feature.description}
                 </p>
               </div>
-            </div>
+            </motion.div>
           ))}
-        </div>
+        </motion.div>
       </div>
     </section>
   )

--- a/frontend/src/pages/home/components/WhatIsSection.tsx
+++ b/frontend/src/pages/home/components/WhatIsSection.tsx
@@ -1,4 +1,7 @@
+import { motion } from 'framer-motion'
 import { Calculator, FileSpreadsheet, Wallet } from 'lucide-react'
+
+import { sectionReveal, slideInLeftItem, staggerContainer } from '@/constants/animations'
 
 const WORKFLOWS = [
   {
@@ -49,9 +52,15 @@ export function WhatIsSection() {
               decision-ready analytics.
             </p>
 
-            <div className="mt-8 divide-y divide-border border-y border-border">
+            <motion.div
+              className="mt-8 divide-y divide-border border-y border-border"
+              variants={staggerContainer}
+              initial="hidden"
+              whileInView="visible"
+              viewport={{ once: true, margin: '-80px' }}
+            >
               {WORKFLOWS.map((workflow) => (
-                <div key={workflow.title} className="flex gap-4 py-5">
+                <motion.div key={workflow.title} variants={slideInLeftItem} className="flex gap-4 py-5">
                   <div
                     className={`flex size-9 shrink-0 items-center justify-center rounded-md ${workflow.iconClass}`}
                   >
@@ -63,12 +72,18 @@ export function WhatIsSection() {
                       {workflow.description}
                     </p>
                   </div>
-                </div>
+                </motion.div>
               ))}
-            </div>
+            </motion.div>
           </div>
 
-          <div className="self-center">
+          <motion.div
+            className="self-center"
+            variants={sectionReveal}
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true, margin: '-80px' }}
+          >
             <div className="ledger-panel">
               <div className="flex items-end justify-between gap-4 border-b border-border p-5 sm:p-6">
                 <div>
@@ -101,7 +116,7 @@ export function WhatIsSection() {
                 <span>Duplicate-safe import</span>
               </div>
             </div>
-          </div>
+          </motion.div>
         </div>
       </div>
     </section>

--- a/frontend/src/pages/mutual-fund-projection/components/ReturnsAnalysisSection.tsx
+++ b/frontend/src/pages/mutual-fund-projection/components/ReturnsAnalysisSection.tsx
@@ -1,6 +1,17 @@
 import { BarChart3 } from 'lucide-react'
 
+import { useAnimatedValue } from '@/hooks/useAnimatedValue'
 import { formatCurrency } from '@/lib/formatters'
+
+/** Stat figure with the shared format-preserving count-up. */
+function AnimatedStat({ value, className }: Readonly<{ value: string; className: string }>) {
+  const animated = useAnimatedValue(value)
+  return (
+    <p className={`${className} tabular-nums`} title={value}>
+      {animated}
+    </p>
+  )
+}
 
 interface ReturnsAnalysisSectionProps {
   currentValueInput: number
@@ -69,10 +80,10 @@ export function ReturnsAnalysisSection(props: Readonly<ReturnsAnalysisSectionPro
 
         <div className="flex flex-col justify-center">
           <p className="text-sm text-muted-foreground">Total Return</p>
-          <p className={`text-2xl font-bold ${totalReturnColorClass}`}>
-            {totalReturnSignPrefix}
-            {overrideGainsPercent.toFixed(2)}%
-          </p>
+          <AnimatedStat
+            value={`${totalReturnSignPrefix}${overrideGainsPercent.toFixed(2)}%`}
+            className={`text-2xl font-bold ${totalReturnColorClass}`}
+          />
           <p className="text-xs text-muted-foreground mt-1">
             {formatCurrency(overrideGains)} on {formatCurrency(totalHistoricalInvested)}
           </p>
@@ -80,10 +91,10 @@ export function ReturnsAnalysisSection(props: Readonly<ReturnsAnalysisSectionPro
 
         <div className="flex flex-col justify-center">
           <p className="text-sm text-muted-foreground">Annualized Return (XIRR)</p>
-          <p className={`text-2xl font-bold ${xirrColorClass}`}>
-            {xirrSignPrefix}
-            {xirrPercent.toFixed(2)}% p.a.
-          </p>
+          <AnimatedStat
+            value={`${xirrSignPrefix}${xirrPercent.toFixed(2)}% p.a.`}
+            className={`text-2xl font-bold ${xirrColorClass}`}
+          />
           <p className="text-xs text-muted-foreground mt-1">
             Over {investmentDurationYears.toFixed(1)} years
           </p>
@@ -91,9 +102,10 @@ export function ReturnsAnalysisSection(props: Readonly<ReturnsAnalysisSectionPro
 
         <div className="flex flex-col justify-center">
           <p className="text-sm text-muted-foreground">Effective Value</p>
-          <p className="text-2xl font-bold text-app-orange">
-            {formatCurrency(effectiveCurrentValue)}
-          </p>
+          <AnimatedStat
+            value={formatCurrency(effectiveCurrentValue)}
+            className="text-2xl font-bold text-app-orange"
+          />
           <p className="text-xs text-muted-foreground mt-1">{effectiveValueLabel}</p>
         </div>
       </div>

--- a/frontend/src/pages/year-in-review/components/HeatmapCell.tsx
+++ b/frontend/src/pages/year-in-review/components/HeatmapCell.tsx
@@ -7,6 +7,8 @@ interface Props {
   cell: DayCell
   mode: HeatmapMode
   modeMax: number
+  /** Stagger delay (ms) for the pop-in wave. */
+  appearDelay?: number
 }
 
 const MODE_NOUN: Record<HeatmapMode, string> = {
@@ -15,7 +17,7 @@ const MODE_NOUN: Record<HeatmapMode, string> = {
   net: 'net',
 }
 
-export default function HeatmapCell({ cell, mode, modeMax }: Readonly<Props>) {
+export default function HeatmapCell({ cell, mode, modeMax, appearDelay = 0 }: Readonly<Props>) {
   const valMap = { expense: cell.expense, income: cell.income, net: Math.abs(cell.net) }
   const val = valMap[mode]
   const level = getIntensityLevel(val, modeMax)
@@ -28,16 +30,19 @@ export default function HeatmapCell({ cell, mode, modeMax }: Readonly<Props>) {
   // A real <button> (not a div with role/tabIndex): natively focusable +
   // interactive, so keyboard/SR users get the per-day figure and the parent's
   // onFocus delegation fires. type=button avoids implicit form submission.
+  // The pop-in wave is a per-cell CSS animation (~370 cells) -- framer-motion
+  // components at that count would add measurable mount cost for no benefit.
   return (
     <button
       type="button"
       data-cell-date={cell.date}
       aria-label={label}
-      className="w-[13px] h-[13px] rounded-sm p-0 border-0 cursor-default transition-[outline-color] duration-150 hover:ring-1 hover:ring-[var(--hairline-5)] focus:outline-none focus-visible:ring-1 focus-visible:ring-[var(--hairline-5)]"
+      className="heatmap-cell-appear w-[13px] h-[13px] rounded-sm p-0 border-0 cursor-default transition-[outline-color] duration-150 hover:ring-1 hover:ring-[var(--hairline-5)] focus:outline-none focus-visible:ring-1 focus-visible:ring-[var(--hairline-5)]"
       style={{
         backgroundColor: bgColor,
         outline: cell.isToday ? `2px solid ${modeAccent[mode]}` : undefined,
         outlineOffset: cell.isToday ? '-1px' : undefined,
+        animationDelay: `${appearDelay}ms`,
       }}
     />
   )

--- a/frontend/src/pages/year-in-review/components/HeatmapWeeks.tsx
+++ b/frontend/src/pages/year-in-review/components/HeatmapWeeks.tsx
@@ -19,7 +19,11 @@ export default function HeatmapWeeks({ grid, mode, modeMax }: Readonly<Props>) {
         {Array.from({ length: 7 }, (_, dow) => {
           const cell = weekCells.find((c) => c.dayOfWeek === dow)
           if (!cell) return <div key={dow} className="w-[13px] h-[13px]" />
-          return <HeatmapCell key={dow} cell={cell} mode={mode} modeMax={modeMax} />
+          // Left-to-right wave: each week column pops in 8ms after the last
+          // (~3s full sweep across a year), echoing the calendar's time axis.
+          return (
+            <HeatmapCell key={dow} cell={cell} mode={mode} modeMax={modeMax} appearDelay={w * 8} />
+          )
         })}
       </div>,
     )


### PR DESCRIPTION
## What

Extends the motion language from the Cash Flow sankey work (PR #217) to the remaining chart and stat surfaces, applied through shared primitives so all 27 pages benefit without per-page wiring.

## Audit -> what got motion (and what deliberately didn't)

| Surface | Motion added | Why relevant |
|---------|-------------|--------------|
| MetricCard KPI figures (20+ pages) | Count-up on mount, rolls to new value on filter change | The number IS the content; arriving at it reads as computation finishing |
| StandardPieChart donut center | Count-up synced with the ring sweep-in | Center total and ring tell one story; now they arrive together |
| ProgressBar fills (budgets, goals, savings-rate) | Draw from 0 + spring between value changes | Progress toward a target reads as literal motion toward the tick |
| Year-in-review heatmap (~365 cells) | Left-to-right pop-in wave along the time axis | The sweep follows the calendar's reading direction; CSS keyframes + per-column delay, not framer (mount cost at that cell count) |
| Bar/area/pie/radar draw-ins | Already existed via Standard* wrappers (600ms ease-out) | No change needed; kept |
| DataTable rows | Already staggered | Kept |
| Tooltips, axes, brush | None on purpose | Feedback surfaces must be instant |

## Correctness guarantee on animated money

`useAnimatedValue` animates already-formatted strings ("₹45,33,242.00", "55.5%") by detecting prefix/decimals/indian-vs-western grouping and rendering every intermediate frame in the same format. The final frame renders the exact original string, so the settled display is byte-identical to what the caller formatted -- the animation cannot corrupt a number. 7 round-trip unit tests cover indian/western grouping, percentages, suffixes, and non-numeric passthrough.

## Verification

- Live (demo mode): Net Worth KPI captured mid-count-up (132 distinct frames, ₹60,40,149.60 mid-flight -> settled exactly ₹62,90,113.00); heatmap wave delays 0ms -> 416ms across 365 cells; budget progress fills settled at true percentages; zero console errors.
- Gates: eslint clean, tsc clean, 335 tests pass (7 new).
