### PR TITLE
feat: surface unclassified income categories in settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Income classification audit** in Settings. Income categories the ledger carries but no classification list claims are now listed with their transaction count and amount, each with a one-click bucket picker and a bulk "apply suggestions" action. Saved keys that match zero transactions (drifted spellings left behind after an import) are listed separately and can be removed.
+- **`GET /api/calculations/income-facets`** returns every income category and subcategory bucket with its row count and total.
 - **Workspace header** with the current page label, command-palette access, notifications, and a context-aware AI entry point.
 - **Product screenshots** for desktop and mobile landing-page presentation.
 - **Authentication regression coverage** for provider loading/retry states, dialog focus management, and OAuth callback failures.

--- a/backend/src/ledger_sync/api/calculations.py
+++ b/backend/src/ledger_sync/api/calculations.py
@@ -456,6 +456,58 @@ def get_data_date_range(
     }
 
 
+@router.get("/income-facets")
+def get_income_facets(
+    current_user: CurrentUser,
+    db: DatabaseSession,
+) -> dict[str, list[dict[str, Any]]]:
+    """Every ``(category, subcategory)`` income bucket with its row count and sum.
+
+    Powers the Settings income-classification audit, which reconciles the four
+    saved ``*_income_categories`` preference lists against what the ledger
+    actually carries. Those lists are EXACT-MATCH key sets and a stored
+    non-empty list is honoured verbatim, so a bucket missing from all four is
+    silently unclassified and a saved key matching no row silently sums zero.
+    Answering "which buckets exist, and how much money is in each?" needs the
+    counts and totals, which ``/categories/master`` (distinct names only) does
+    not carry.
+
+    Reads raw transactions rather than the ``category_trends`` rollup: the
+    rollup can lag a fresh import, and a bucket missing from it would read as
+    "already classified" -- exactly the silent gap this endpoint exists to
+    close. Aggregated in SQL, so the response is a few rows either way.
+    """
+    base = build_transaction_query(db, current_user).subquery()
+    cat_col = func.coalesce(base.c.category, "Uncategorized")
+    subcat_col = func.coalesce(base.c.subcategory, "Other")
+
+    rows = (
+        db.query(
+            cat_col.label("category"),
+            subcat_col.label("subcategory"),
+            func.coalesce(func.sum(base.c.amount), 0).label("total"),
+            func.count().label("count"),
+        )
+        .filter(base.c.type == TransactionType.INCOME)
+        .group_by(cat_col, subcat_col)
+        .all()
+    )
+
+    return {
+        "facets": [
+            {
+                "category": row.category,
+                "subcategory": row.subcategory,
+                # Income amounts are stored positive, but abs() keeps a
+                # sign-flipped correction row from subtracting from its bucket.
+                "total": abs(float(row.total)),
+                "count": row.count,
+            }
+            for row in rows
+        ],
+    }
+
+
 @router.get("/income-analysis")
 def get_income_analysis(
     current_user: CurrentUser,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -79,6 +79,25 @@ def test_db_session() -> Session:
 
 
 @pytest.fixture
+def make_user(test_db_session: Session):
+    """Factory for extra users on ``test_db_session`` (user-scoping tests)."""
+
+    def _make(email: str) -> User:
+        user = User(
+            email=email,
+            hashed_password=TEST_BCRYPT_HASH,
+            full_name=email,
+            is_active=True,
+            is_verified=True,
+        )
+        test_db_session.add(user)
+        test_db_session.commit()
+        return user
+
+    return _make
+
+
+@pytest.fixture
 def test_user(test_db_session: Session) -> User:
     """Create a test user for transaction ownership."""
     user = User(

--- a/backend/tests/integration/test_income_facets.py
+++ b/backend/tests/integration/test_income_facets.py
@@ -1,0 +1,211 @@
+"""Integration tests for the GET /api/calculations/income-facets endpoint.
+
+The endpoint feeds the Settings income-classification audit, which reconciles
+the four exact-match ``*_income_categories`` preference lists against the
+buckets the ledger actually carries. The audit is only as trustworthy as this
+response, so these tests lock in:
+
+1. One row per ``(category, subcategory)`` income bucket with count + sum.
+2. Income only -- expenses and transfers never appear.
+3. User scoping, soft-delete exclusion, and the excluded-accounts preference.
+4. Null subcategory coalescing to the same label the rest of the app uses
+   ("Other"), so a key the UI shows can be matched.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from ledger_sync.api.calculations import get_income_facets
+from ledger_sync.db.base import Base
+from ledger_sync.db.models import Transaction, TransactionType, User, UserPreferences
+
+# Fake bcrypt hash for test fixtures -- not a real credential.
+TEST_BCRYPT_HASH = "$2b$12$dummy_hash_for_testing_purposes"  # noqa: S105
+
+
+@pytest.fixture
+def facets_db() -> Session:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+
+
+def _make_user(session: Session, email: str) -> User:
+    user = User(
+        email=email,
+        hashed_password=TEST_BCRYPT_HASH,
+        full_name=email,
+        is_active=True,
+        is_verified=True,
+    )
+    session.add(user)
+    session.commit()
+    return user
+
+
+def _add(
+    session: Session,
+    user_id: int,
+    tx_id: str,
+    tx_type: TransactionType,
+    category: str,
+    subcategory: str | None,
+    amount: str = "100.00",
+    *,
+    account: str = "HDFC",
+    is_deleted: bool = False,
+) -> None:
+    session.add(
+        Transaction(
+            user_id=user_id,
+            transaction_id=tx_id,
+            date=datetime(2024, 1, 15, tzinfo=UTC),
+            amount=Decimal(amount),
+            currency="INR",
+            type=tx_type,
+            account=account,
+            category=category,
+            subcategory=subcategory,
+            source_file="test.xlsx",
+            last_seen_at=datetime(2024, 1, 15, tzinfo=UTC),
+            is_deleted=is_deleted,
+        )
+    )
+
+
+def _by_key(response: dict) -> dict[str, dict]:
+    return {f"{f['category']}::{f['subcategory']}": f for f in response["facets"]}
+
+
+def test_groups_income_by_category_and_subcategory(facets_db: Session) -> None:
+    user = _make_user(facets_db, "a@example.com")
+    _add(facets_db, user.id, "1", TransactionType.INCOME, "Salary", "Basic", "50000.00")
+    _add(facets_db, user.id, "2", TransactionType.INCOME, "Salary", "Basic", "50000.00")
+    _add(facets_db, user.id, "3", TransactionType.INCOME, "Salary", "Bonus", "10000.00")
+    _add(
+        facets_db,
+        user.id,
+        "4",
+        TransactionType.INCOME,
+        "Refunds & Cashbacks",
+        "Deposit Return",
+        "200.00",
+    )
+    facets_db.commit()
+
+    facets = _by_key(get_income_facets(user, facets_db))
+
+    assert set(facets) == {
+        "Salary::Basic",
+        "Salary::Bonus",
+        "Refunds & Cashbacks::Deposit Return",
+    }
+    assert facets["Salary::Basic"] == {
+        "category": "Salary",
+        "subcategory": "Basic",
+        "total": 100000.0,
+        "count": 2,
+    }
+    assert facets["Refunds & Cashbacks::Deposit Return"]["total"] == 200.0
+    assert facets["Refunds & Cashbacks::Deposit Return"]["count"] == 1
+
+
+def test_excludes_expenses_and_transfers(facets_db: Session) -> None:
+    user = _make_user(facets_db, "b@example.com")
+    _add(facets_db, user.id, "in", TransactionType.INCOME, "Salary", "Basic")
+    _add(facets_db, user.id, "out", TransactionType.EXPENSE, "Food", "Groceries")
+    _add(facets_db, user.id, "mv", TransactionType.TRANSFER, "Transfer", "Internal")
+    facets_db.commit()
+
+    facets = _by_key(get_income_facets(user, facets_db))
+
+    assert set(facets) == {"Salary::Basic"}
+
+
+def test_is_user_scoped(facets_db: Session) -> None:
+    alice = _make_user(facets_db, "alice@example.com")
+    bob = _make_user(facets_db, "bob@example.com")
+    _add(facets_db, alice.id, "a1", TransactionType.INCOME, "Salary", "Basic")
+    _add(facets_db, bob.id, "b1", TransactionType.INCOME, "Freelance", "Consulting")
+    facets_db.commit()
+
+    facets = _by_key(get_income_facets(alice, facets_db))
+
+    assert set(facets) == {"Salary::Basic"}
+
+
+def test_excludes_soft_deleted(facets_db: Session) -> None:
+    user = _make_user(facets_db, "c@example.com")
+    _add(facets_db, user.id, "live", TransactionType.INCOME, "Salary", "Basic")
+    _add(
+        facets_db,
+        user.id,
+        "dead",
+        TransactionType.INCOME,
+        "Ghost",
+        "Removed",
+        is_deleted=True,
+    )
+    facets_db.commit()
+
+    facets = _by_key(get_income_facets(user, facets_db))
+
+    assert set(facets) == {"Salary::Basic"}
+
+
+def test_honours_excluded_accounts(facets_db: Session) -> None:
+    user = _make_user(facets_db, "d@example.com")
+    facets_db.add(
+        UserPreferences(user_id=user.id, excluded_accounts=json.dumps(["Excluded Wallet"]))
+    )
+    _add(facets_db, user.id, "keep", TransactionType.INCOME, "Salary", "Basic")
+    _add(
+        facets_db,
+        user.id,
+        "drop",
+        TransactionType.INCOME,
+        "Gift",
+        "Cash Gift",
+        account="Excluded Wallet",
+    )
+    facets_db.commit()
+
+    facets = _by_key(get_income_facets(user, facets_db))
+
+    assert set(facets) == {"Salary::Basic"}
+
+
+def test_coalesces_null_subcategory_to_other(facets_db: Session) -> None:
+    # The audit matches on "Category::Subcategory" strings built from these
+    # labels, so they must agree with /categories/master's coalescing.
+    # (``category`` is NOT NULL in the schema; only ``subcategory`` is
+    # nullable, so only that side is exercisable here.)
+    user = _make_user(facets_db, "e@example.com")
+    _add(facets_db, user.id, "1", TransactionType.INCOME, "Salary", None)
+    _add(facets_db, user.id, "2", TransactionType.INCOME, "Salary", "Basic")
+    facets_db.commit()
+
+    facets = _by_key(get_income_facets(user, facets_db))
+
+    assert set(facets) == {"Salary::Other", "Salary::Basic"}
+
+
+def test_sign_flipped_correction_row_does_not_shrink_its_bucket(facets_db: Session) -> None:
+    # Income is stored positive; a negative correction row would otherwise
+    # subtract from the bucket and understate the money at stake.
+    user = _make_user(facets_db, "f@example.com")
+    _add(facets_db, user.id, "1", TransactionType.INCOME, "Salary", "Basic", "-500.00")
+    facets_db.commit()
+
+    facets = _by_key(get_income_facets(user, facets_db))
+
+    assert facets["Salary::Basic"]["total"] == 500.0

--- a/backend/tests/integration/test_income_facets.py
+++ b/backend/tests/integration/test_income_facets.py
@@ -17,39 +17,17 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime
 from decimal import Decimal
-
-import pytest
-from sqlalchemy import create_engine
-from sqlalchemy.orm import Session, sessionmaker
+from typing import TYPE_CHECKING
 
 from ledger_sync.api.calculations import get_income_facets
-from ledger_sync.db.base import Base
-from ledger_sync.db.models import Transaction, TransactionType, User, UserPreferences
+from ledger_sync.db.models import Transaction, TransactionType, UserPreferences
 
-# Fake bcrypt hash for test fixtures -- not a real credential.
-TEST_BCRYPT_HASH = "$2b$12$dummy_hash_for_testing_purposes"  # noqa: S105
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
+    from sqlalchemy.orm import Session
 
-@pytest.fixture
-def facets_db() -> Session:
-    engine = create_engine("sqlite:///:memory:")
-    Base.metadata.create_all(engine)
-    session = sessionmaker(bind=engine)()
-    yield session
-    session.close()
-
-
-def _make_user(session: Session, email: str) -> User:
-    user = User(
-        email=email,
-        hashed_password=TEST_BCRYPT_HASH,
-        full_name=email,
-        is_active=True,
-        is_verified=True,
-    )
-    session.add(user)
-    session.commit()
-    return user
+    from ledger_sync.db.models import User
 
 
 def _add(
@@ -86,23 +64,24 @@ def _by_key(response: dict) -> dict[str, dict]:
     return {f"{f['category']}::{f['subcategory']}": f for f in response["facets"]}
 
 
-def test_groups_income_by_category_and_subcategory(facets_db: Session) -> None:
-    user = _make_user(facets_db, "a@example.com")
-    _add(facets_db, user.id, "1", TransactionType.INCOME, "Salary", "Basic", "50000.00")
-    _add(facets_db, user.id, "2", TransactionType.INCOME, "Salary", "Basic", "50000.00")
-    _add(facets_db, user.id, "3", TransactionType.INCOME, "Salary", "Bonus", "10000.00")
+def test_groups_income_by_category_and_subcategory(
+    test_db_session: Session, test_user: User
+) -> None:
+    _add(test_db_session, test_user.id, "1", TransactionType.INCOME, "Salary", "Basic", "50000.00")
+    _add(test_db_session, test_user.id, "2", TransactionType.INCOME, "Salary", "Basic", "50000.00")
+    _add(test_db_session, test_user.id, "3", TransactionType.INCOME, "Salary", "Bonus", "10000.00")
     _add(
-        facets_db,
-        user.id,
+        test_db_session,
+        test_user.id,
         "4",
         TransactionType.INCOME,
         "Refunds & Cashbacks",
         "Deposit Return",
         "200.00",
     )
-    facets_db.commit()
+    test_db_session.commit()
 
-    facets = _by_key(get_income_facets(user, facets_db))
+    facets = _by_key(get_income_facets(test_user, test_db_session))
 
     assert set(facets) == {
         "Salary::Basic",
@@ -119,93 +98,91 @@ def test_groups_income_by_category_and_subcategory(facets_db: Session) -> None:
     assert facets["Refunds & Cashbacks::Deposit Return"]["count"] == 1
 
 
-def test_excludes_expenses_and_transfers(facets_db: Session) -> None:
-    user = _make_user(facets_db, "b@example.com")
-    _add(facets_db, user.id, "in", TransactionType.INCOME, "Salary", "Basic")
-    _add(facets_db, user.id, "out", TransactionType.EXPENSE, "Food", "Groceries")
-    _add(facets_db, user.id, "mv", TransactionType.TRANSFER, "Transfer", "Internal")
-    facets_db.commit()
+def test_excludes_expenses_and_transfers(test_db_session: Session, test_user: User) -> None:
+    _add(test_db_session, test_user.id, "in", TransactionType.INCOME, "Salary", "Basic")
+    _add(test_db_session, test_user.id, "out", TransactionType.EXPENSE, "Food", "Groceries")
+    _add(test_db_session, test_user.id, "mv", TransactionType.TRANSFER, "Transfer", "Internal")
+    test_db_session.commit()
 
-    facets = _by_key(get_income_facets(user, facets_db))
-
-    assert set(facets) == {"Salary::Basic"}
-
-
-def test_is_user_scoped(facets_db: Session) -> None:
-    alice = _make_user(facets_db, "alice@example.com")
-    bob = _make_user(facets_db, "bob@example.com")
-    _add(facets_db, alice.id, "a1", TransactionType.INCOME, "Salary", "Basic")
-    _add(facets_db, bob.id, "b1", TransactionType.INCOME, "Freelance", "Consulting")
-    facets_db.commit()
-
-    facets = _by_key(get_income_facets(alice, facets_db))
+    facets = _by_key(get_income_facets(test_user, test_db_session))
 
     assert set(facets) == {"Salary::Basic"}
 
 
-def test_excludes_soft_deleted(facets_db: Session) -> None:
-    user = _make_user(facets_db, "c@example.com")
-    _add(facets_db, user.id, "live", TransactionType.INCOME, "Salary", "Basic")
+def test_is_user_scoped(
+    test_db_session: Session, test_user: User, make_user: Callable[[str], User]
+) -> None:
+    other = make_user("other@example.com")
+    _add(test_db_session, test_user.id, "a1", TransactionType.INCOME, "Salary", "Basic")
+    _add(test_db_session, other.id, "b1", TransactionType.INCOME, "Freelance", "Consulting")
+    test_db_session.commit()
+
+    facets = _by_key(get_income_facets(test_user, test_db_session))
+
+    assert set(facets) == {"Salary::Basic"}
+
+
+def test_excludes_soft_deleted(test_db_session: Session, test_user: User) -> None:
+    _add(test_db_session, test_user.id, "live", TransactionType.INCOME, "Salary", "Basic")
     _add(
-        facets_db,
-        user.id,
+        test_db_session,
+        test_user.id,
         "dead",
         TransactionType.INCOME,
         "Ghost",
         "Removed",
         is_deleted=True,
     )
-    facets_db.commit()
+    test_db_session.commit()
 
-    facets = _by_key(get_income_facets(user, facets_db))
+    facets = _by_key(get_income_facets(test_user, test_db_session))
 
     assert set(facets) == {"Salary::Basic"}
 
 
-def test_honours_excluded_accounts(facets_db: Session) -> None:
-    user = _make_user(facets_db, "d@example.com")
-    facets_db.add(
-        UserPreferences(user_id=user.id, excluded_accounts=json.dumps(["Excluded Wallet"]))
+def test_honours_excluded_accounts(test_db_session: Session, test_user: User) -> None:
+    test_db_session.add(
+        UserPreferences(user_id=test_user.id, excluded_accounts=json.dumps(["Excluded Wallet"]))
     )
-    _add(facets_db, user.id, "keep", TransactionType.INCOME, "Salary", "Basic")
+    _add(test_db_session, test_user.id, "keep", TransactionType.INCOME, "Salary", "Basic")
     _add(
-        facets_db,
-        user.id,
+        test_db_session,
+        test_user.id,
         "drop",
         TransactionType.INCOME,
         "Gift",
         "Cash Gift",
         account="Excluded Wallet",
     )
-    facets_db.commit()
+    test_db_session.commit()
 
-    facets = _by_key(get_income_facets(user, facets_db))
+    facets = _by_key(get_income_facets(test_user, test_db_session))
 
     assert set(facets) == {"Salary::Basic"}
 
 
-def test_coalesces_null_subcategory_to_other(facets_db: Session) -> None:
+def test_coalesces_null_subcategory_to_other(test_db_session: Session, test_user: User) -> None:
     # The audit matches on "Category::Subcategory" strings built from these
     # labels, so they must agree with /categories/master's coalescing.
     # (``category`` is NOT NULL in the schema; only ``subcategory`` is
     # nullable, so only that side is exercisable here.)
-    user = _make_user(facets_db, "e@example.com")
-    _add(facets_db, user.id, "1", TransactionType.INCOME, "Salary", None)
-    _add(facets_db, user.id, "2", TransactionType.INCOME, "Salary", "Basic")
-    facets_db.commit()
+    _add(test_db_session, test_user.id, "1", TransactionType.INCOME, "Salary", None)
+    _add(test_db_session, test_user.id, "2", TransactionType.INCOME, "Salary", "Basic")
+    test_db_session.commit()
 
-    facets = _by_key(get_income_facets(user, facets_db))
+    facets = _by_key(get_income_facets(test_user, test_db_session))
 
     assert set(facets) == {"Salary::Other", "Salary::Basic"}
 
 
-def test_sign_flipped_correction_row_does_not_shrink_its_bucket(facets_db: Session) -> None:
+def test_sign_flipped_correction_row_does_not_shrink_its_bucket(
+    test_db_session: Session, test_user: User
+) -> None:
     # Income is stored positive; a negative correction row would otherwise
     # subtract from the bucket and understate the money at stake.
-    user = _make_user(facets_db, "f@example.com")
-    _add(facets_db, user.id, "1", TransactionType.INCOME, "Salary", "Basic", "-500.00")
-    facets_db.commit()
+    _add(test_db_session, test_user.id, "1", TransactionType.INCOME, "Salary", "Basic", "-500.00")
+    test_db_session.commit()
 
-    facets = _by_key(get_income_facets(user, facets_db))
+    facets = _by_key(get_income_facets(test_user, test_db_session))
 
     assert facets["Salary::Basic"]["total"] == 500.0

--- a/docs/API.md
+++ b/docs/API.md
@@ -218,6 +218,7 @@ Common status codes:
 | `GET` | `/api/calculations/insights` | Calculated insight metrics |
 | `GET` | `/api/calculations/category-monthly-history` | Monthly history for categories |
 | `GET` | `/api/calculations/data-date-range` | Earliest and latest active transaction dates |
+| `GET` | `/api/calculations/income-facets` | Income category and subcategory buckets with row counts and totals |
 | `GET` | `/api/calculations/income-analysis` | Income source analysis |
 | `GET` | `/api/calculations/category-daily-series` | Daily category series |
 | `GET` | `/api/calculations/quick-insights` | Dashboard quick-insight values |

--- a/docs/HANDBOOK.md
+++ b/docs/HANDBOOK.md
@@ -414,7 +414,7 @@ Both start expanded.
 
 3. **Account Classifications** - assign accounts to Cash, Bank Accounts, Credit Cards, Investments, Loans/Lended, or Other Wallets.
 4. **Expense Categories** - essential and fixed-expense classification.
-5. **Income Classification** - taxable, investment return, non-taxable, and other income buckets.
+5. **Income Classification** - taxable, investment return, non-taxable, and other income buckets. The section opens with an audit: any income category your transactions carry that sits in none of the four buckets is listed with its transaction count and amount, so the money never silently drops out of your taxable-income and cashback totals. Pick a bucket per row, or apply every keyword suggestion at once. Saved categories that match no transactions (usually a spelling left behind after a rename) are listed below and can be removed.
 6. **Categorization Rules** - ordered note/account matching rules with optional retroactive application.
 7. **Investment Mappings** - map investment accounts to the four analytics categories.
 

--- a/docs/PAGES.md
+++ b/docs/PAGES.md
@@ -525,7 +525,7 @@ Twelve sections:
 2. Income and Salary Structure
 3. Account Classifications
 4. Expense Categories
-5. Income Classification
+5. Income Classification (reads `/api/calculations/income-facets` to audit the four `*_income_categories` lists against the ledger: unclassified buckets with their amount, plus saved keys matching no transactions)
 6. Categorization Rules
 7. Investment Mappings
 8. Display Preferences

--- a/frontend/src/hooks/api/useAnalytics.ts
+++ b/frontend/src/hooks/api/useAnalytics.ts
@@ -84,6 +84,14 @@ export const masterCategoriesOptions = () =>
     ...STABLE,
   })
 
+/** Income buckets with row counts + sums, for the Settings classification audit. */
+export const incomeFacetsOptions = () =>
+  queryOptions({
+    queryKey: ['calculations', 'income-facets'] as const,
+    queryFn: async () => (await calculationsApi.getIncomeFacets()).data,
+    ...STABLE,
+  })
+
 // ─── Hook Wrappers ───────────────────────────────────────────────────────────
 
 export const useKPIs = (params?: { start_date?: string; end_date?: string }) => useQuery(kpisOptions(params))
@@ -111,3 +119,4 @@ export const useDataDateRange = () => {
   }
 }
 export const useMasterCategories = () => useQuery(masterCategoriesOptions())
+export const useIncomeFacets = () => useQuery(incomeFacetsOptions())

--- a/frontend/src/lib/demo/demoComputedReads.ts
+++ b/frontend/src/lib/demo/demoComputedReads.ts
@@ -7,7 +7,7 @@ import type {
   SpendingRuleResponse,
   TransferFlow,
 } from '@/services/api/analyticsV2'
-import type { QuickInsightsData } from '@/services/api/calculations'
+import type { IncomeFacetsData, QuickInsightsData } from '@/services/api/calculations'
 import type { SavedView } from '@/services/api/savedViews'
 import type { TransactionFacets } from '@/services/api/transactions'
 import type { Transaction } from '@/types'
@@ -82,6 +82,21 @@ export function generateDemoDataDateRange(txs: Transaction[]): {
   if (txs.length === 0) return { min_date: null, max_date: null }
   // txs arrive sorted newest-first.
   return { min_date: txs.at(-1)?.date ?? null, max_date: txs[0].date }
+}
+
+/** Mirrors /api/calculations/income-facets: income buckets with count + sum. */
+export function generateDemoIncomeFacets(txs: Transaction[]): IncomeFacetsData {
+  const buckets = new Map<string, { category: string; subcategory: string; total: number; count: number }>()
+  for (const t of txs.filter(isIncome)) {
+    const category = t.category || 'Uncategorized'
+    const subcategory = t.subcategory || 'Other'
+    const key = `${category}::${subcategory}`
+    const bucket = buckets.get(key) ?? { category, subcategory, total: 0, count: 0 }
+    bucket.total += Math.abs(t.amount)
+    bucket.count += 1
+    buckets.set(key, bucket)
+  }
+  return { facets: [...buckets.values()] }
 }
 
 export function generateDemoQuickInsights(txs: Transaction[]): QuickInsightsData {

--- a/frontend/src/pages/settings/SettingsPage.tsx
+++ b/frontend/src/pages/settings/SettingsPage.tsx
@@ -169,7 +169,9 @@ export default function SettingsPage() {
             index={sectionIndex++}
             allIncomeCategories={s.allIncomeCategories}
             localPrefs={s.localPrefs}
-            unclassifiedIncomeItems={s.unclassifiedIncomeItems}
+            incomeAudit={s.incomeAudit}
+            applyIncomeSuggestions={s.applyIncomeSuggestions}
+            removeIncomeKey={s.removeIncomeKey}
             setLocalPrefs={s.setLocalPrefs}
             setHasChanges={s.setHasChanges}
             defaultCollapsed={false}

--- a/frontend/src/pages/settings/__tests__/incomeClassificationAudit.test.ts
+++ b/frontend/src/pages/settings/__tests__/incomeClassificationAudit.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from 'vitest'
+import {
+  auditIncomeClassification,
+  getDefaultIncomeClassifications,
+  suggestIncomeBucket,
+  type IncomeFacet,
+} from '../helpers'
+
+/**
+ * The four `*_income_categories` preference lists are exact-match key sets and
+ * a stored non-empty list is honoured verbatim by the backend, so the shipped
+ * defaults never gap-fill a partially-configured list. These tests pin the two
+ * silent failure modes the audit exists to surface.
+ */
+
+const EMPTY_LISTS = { taxable: [], investment: [], non_taxable: [], other: [] }
+
+describe('suggestIncomeBucket', () => {
+  it.each([
+    ['Salary', 'Basic Salary', 'taxable'],
+    ['Salary', 'Performance Bonus', 'taxable'],
+    ['Investment Returns', 'Dividends', 'investment'],
+    ['Investment Returns', 'Savings Account Interest', 'investment'],
+    ['Refunds & Cashbacks', 'Credit Card Cashbacks', 'non_taxable'],
+    ['Refunds & Cashbacks', 'Product/Service Refunds', 'non_taxable'],
+    ['Refunds & Cashbacks', 'Deposit Return', 'non_taxable'],
+    ['Other Income', 'Gifts Received', 'other'],
+  ])('maps %s / %s to %s', (category, subcategory, expected) => {
+    expect(suggestIncomeBucket(category, subcategory)).toBe(expected)
+  })
+
+  it('returns null when no keyword matches, instead of guessing', () => {
+    expect(suggestIncomeBucket('Mystery Inflow', 'Something Unnamed')).toBeNull()
+  })
+
+  it('prefers the subcategory keyword over the parent category keyword', () => {
+    // 'Other Income' would match the 'other' rule via the category, but the
+    // subcategory is unambiguous salary.
+    expect(suggestIncomeBucket('Other Income', 'Consulting Retainer')).toBe('taxable')
+  })
+})
+
+describe('auditIncomeClassification', () => {
+  /**
+   * Reproduces the reported real-data state: `non_taxable_income_categories`
+   * holds four keys, two of them the drifted SINGULAR "Refund & Cashbacks"
+   * spelling that matches zero rows, while the two PLURAL refund buckets that
+   * do exist in the ledger appear in no list at all.
+   */
+  const DRIFTED_FACETS: IncomeFacet[] = [
+    { category: 'Salary', subcategory: 'Basic Salary', count: 30, total: 1_500_000 },
+    {
+      category: 'Refunds & Cashbacks',
+      subcategory: 'Credit Card Cashbacks',
+      count: 40,
+      total: 8_000,
+    },
+    { category: 'Refunds & Cashbacks', subcategory: 'Other Cashbacks', count: 12, total: 2_500 },
+    {
+      category: 'Refunds & Cashbacks',
+      subcategory: 'Product/Service Refunds',
+      count: 21,
+      total: 4_475.8,
+    },
+    { category: 'Refunds & Cashbacks', subcategory: 'Deposit Return', count: 1, total: 200 },
+  ]
+
+  const DRIFTED_LISTS = {
+    taxable: ['Salary::Basic Salary'],
+    investment: [],
+    non_taxable: [
+      'Refunds & Cashbacks::Credit Card Cashbacks',
+      'Refunds & Cashbacks::Other Cashbacks',
+      'Refund & Cashbacks::Credit Card Cashbacks',
+      'Refund & Cashbacks::Other Cashbacks',
+    ],
+    other: [],
+  }
+
+  it('flags exactly the refund buckets no list claims, with their money impact', () => {
+    const audit = auditIncomeClassification(DRIFTED_FACETS, DRIFTED_LISTS)
+
+    expect(audit.unclassified.map((item) => item.key)).toEqual([
+      'Refunds & Cashbacks::Product/Service Refunds',
+      'Refunds & Cashbacks::Deposit Return',
+    ])
+    // The number from the report: 21 + 1 rows, 4,475.80 + 200.00.
+    expect(audit.unclassifiedRows).toBe(22)
+    expect(audit.unclassifiedTotal).toBeCloseTo(4_675.8, 2)
+  })
+
+  it('suggests non_taxable for both, so one click classifies all 22 rows', () => {
+    const audit = auditIncomeClassification(DRIFTED_FACETS, DRIFTED_LISTS)
+    expect(audit.unclassified.every((item) => item.suggested === 'non_taxable')).toBe(true)
+
+    // Applying the suggestions leaves nothing unclassified and moves nothing
+    // that was already configured.
+    const applied = {
+      ...DRIFTED_LISTS,
+      non_taxable: [
+        ...DRIFTED_LISTS.non_taxable,
+        ...audit.unclassified.map((item) => item.key),
+      ],
+    }
+    const after = auditIncomeClassification(DRIFTED_FACETS, applied)
+    expect(after.unclassified).toEqual([])
+    expect(after.unclassifiedTotal).toBe(0)
+    expect(after.unclassifiedRows).toBe(0)
+    expect(applied.taxable).toEqual(DRIFTED_LISTS.taxable)
+  })
+
+  it('reports the drifted singular keys as dead, with the list holding them', () => {
+    const audit = auditIncomeClassification(DRIFTED_FACETS, DRIFTED_LISTS)
+    expect(audit.deadKeys).toEqual([
+      { key: 'Refund & Cashbacks::Credit Card Cashbacks', classification: 'non_taxable' },
+      { key: 'Refund & Cashbacks::Other Cashbacks', classification: 'non_taxable' },
+    ])
+  })
+
+  it('sorts unclassified buckets by money impact, biggest first', () => {
+    const audit = auditIncomeClassification(
+      [
+        { category: 'A', subcategory: 'Small', count: 5, total: 100 },
+        { category: 'A', subcategory: 'Big', count: 1, total: 90_000 },
+        { category: 'A', subcategory: 'Mid', count: 3, total: 5_000 },
+      ],
+      EMPTY_LISTS,
+    )
+    expect(audit.unclassified.map((item) => item.subcategory)).toEqual(['Big', 'Mid', 'Small'])
+  })
+
+  it('treats a case-only difference as classified, mirroring matchesClassification', () => {
+    const audit = auditIncomeClassification(
+      [{ category: 'Salary', subcategory: 'Basic Salary', count: 1, total: 100 }],
+      { ...EMPTY_LISTS, taxable: ['salary::basic salary'] },
+    )
+    expect(audit.unclassified).toEqual([])
+    expect(audit.deadKeys).toEqual([])
+  })
+
+  it('attributes a key present in two lists to the first list consumers check', () => {
+    const audit = auditIncomeClassification(
+      [{ category: 'Salary', subcategory: 'Basic Salary', count: 1, total: 100 }],
+      {
+        ...EMPTY_LISTS,
+        taxable: ['Salary::Basic Salary'],
+        other: ['Salary::Basic Salary'],
+      },
+    )
+    // Consumers resolve taxable -> investment -> non_taxable -> other, so the
+    // duplicate in `other` is inert rather than dead.
+    expect(audit.unclassified).toEqual([])
+    expect(audit.deadKeys).toEqual([])
+  })
+
+  it('finds nothing to report on an empty ledger with empty lists', () => {
+    const audit = auditIncomeClassification([], EMPTY_LISTS)
+    expect(audit).toEqual({
+      unclassified: [],
+      deadKeys: [],
+      unclassifiedTotal: 0,
+      unclassifiedRows: 0,
+    })
+  })
+
+  it('flags a bucket no keyword rule covers with a null suggestion', () => {
+    const audit = auditIncomeClassification(
+      [
+        {
+          category: 'One-time Income',
+          subcategory: 'Selling Assets (car, property etc.)',
+          count: 1,
+          total: 7_000,
+        },
+      ],
+      { ...EMPTY_LISTS, taxable: ['Salary::Basic Salary'] },
+    )
+    expect(audit.unclassified).toHaveLength(1)
+    // 'one-time' matches on the category, so this one has a suggestion; the
+    // point of the assertion is that a partially-configured list still gets
+    // audited rather than skipped.
+    expect(audit.unclassified[0].suggested).toBe('other')
+    expect(audit.deadKeys).toEqual([{ key: 'Salary::Basic Salary', classification: 'taxable' }])
+  })
+})
+
+describe('getDefaultIncomeClassifications', () => {
+  it('shares its keyword rules with the audit suggestions', () => {
+    const defaults = getDefaultIncomeClassifications(
+      { 'Refunds & Cashbacks': ['Product/Service Refunds', 'Deposit Return'] },
+      EMPTY_LISTS,
+    )
+    expect(defaults.non_taxable).toEqual([
+      'Refunds & Cashbacks::Product/Service Refunds',
+      'Refunds & Cashbacks::Deposit Return',
+    ])
+
+    const audit = auditIncomeClassification(
+      [
+        {
+          category: 'Refunds & Cashbacks',
+          subcategory: 'Product/Service Refunds',
+          count: 21,
+          total: 4_475.8,
+        },
+        { category: 'Refunds & Cashbacks', subcategory: 'Deposit Return', count: 1, total: 200 },
+      ],
+      EMPTY_LISTS,
+    )
+    expect(audit.unclassified.map((item) => item.suggested)).toEqual([
+      'non_taxable',
+      'non_taxable',
+    ])
+  })
+
+  it('leaves already-classified items in place', () => {
+    const defaults = getDefaultIncomeClassifications(
+      { Salary: ['Basic Salary'] },
+      { ...EMPTY_LISTS, other: ['Salary::Basic Salary'] },
+    )
+    expect(defaults.taxable).toEqual([])
+    expect(defaults.other).toEqual(['Salary::Basic Salary'])
+  })
+})

--- a/frontend/src/pages/settings/helpers.ts
+++ b/frontend/src/pages/settings/helpers.ts
@@ -2,6 +2,9 @@
  * Constants and helper functions for the Settings page.
  */
 
+import type { IncomeClassificationType } from './types'
+import { INCOME_CLASSIFICATION_KEY_MAP } from './types'
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -161,12 +164,37 @@ export function getDefaultClassifications(
   return defaults
 }
 
-const INCOME_CLASSIFICATION_RULES: Array<{ keywords: string[]; bucket: 'taxable' | 'investment' | 'non_taxable' | 'other' }> = [
+const INCOME_CLASSIFICATION_RULES: Array<{ keywords: string[]; bucket: IncomeClassificationType }> = [
   { keywords: ['salary', 'stipend', 'bonus', 'freelance', 'gig work', 'consulting', 'rsus', 'self employment', 'rental', 'employment income'], bucket: 'taxable' },
   { keywords: ['dividend', 'interest', 'capital gain', 'f&o', 'stock market', 'investment', 'mutual fund', 'trading'], bucket: 'investment' },
   { keywords: ['cashback', 'refund', 'reward', 'reimbursement', 'deposit return'], bucket: 'non_taxable' },
   { keywords: ['gift', 'prize', 'pocket money', 'epf contribution', 'one-time', 'other', 'modified balancing'], bucket: 'other' },
 ]
+
+/**
+ * Suggest a tax bucket for one income subcategory by keyword matching.
+ *
+ * Single source of truth for the keyword rules: both the first-run default
+ * seeding (`getDefaultIncomeClassifications`) and the unclassified-income
+ * prompt (`auditIncomeClassification`) read it, so a suggestion the user sees
+ * in Settings is the same one the defaults would have picked.
+ *
+ * Returns `null` when nothing matches -- an honest "we don't know", which the
+ * UI must surface rather than guess at.
+ */
+export function suggestIncomeBucket(
+  category: string,
+  subcategory: string,
+): IncomeClassificationType | null {
+  const subLower = subcategory.toLowerCase()
+  const catLower = category.toLowerCase()
+  // Check subcategory first (specific), then category (broad) to avoid
+  // broad keywords like 'employment income' swallowing specific subcategories
+  const matched =
+    INCOME_CLASSIFICATION_RULES.find((rule) => rule.keywords.some((kw) => subLower.includes(kw))) ??
+    INCOME_CLASSIFICATION_RULES.find((rule) => rule.keywords.some((kw) => catLower.includes(kw)))
+  return matched?.bucket ?? null
+}
 
 /**
  * Classify income subcategory items (format: "Category::Subcategory") into
@@ -199,18 +227,118 @@ export function getDefaultIncomeClassifications(
       const item = `${cat}::${sub}`
       if (alreadyClassified.has(item)) continue
 
-      const subLower = sub.toLowerCase()
-      const catLower = cat.toLowerCase()
-      // Check subcategory first (specific), then category (broad) to avoid
-      // broad keywords like 'employment income' swallowing specific subcategories
-      const matched =
-        INCOME_CLASSIFICATION_RULES.find((rule) => rule.keywords.some((kw) => subLower.includes(kw))) ??
-        INCOME_CLASSIFICATION_RULES.find((rule) => rule.keywords.some((kw) => catLower.includes(kw)))
-      if (matched) result[matched.bucket].push(item)
+      const bucket = suggestIncomeBucket(cat, sub)
+      if (bucket) result[bucket].push(item)
     }
   }
 
   return result
+}
+
+// ---------------------------------------------------------------------------
+// Income classification audit
+// ---------------------------------------------------------------------------
+
+/** One "Category::Subcategory" income bucket as it exists in the ledger. */
+export interface IncomeFacet {
+  category: string
+  subcategory: string
+  count: number
+  total: number
+}
+
+/** A ledger income bucket that no classification list claims. */
+export interface UnclassifiedIncomeItem {
+  key: string
+  category: string
+  subcategory: string
+  count: number
+  total: number
+  /** Keyword-derived bucket, or `null` when no rule matches. */
+  suggested: IncomeClassificationType | null
+}
+
+/** A saved classification key that matches zero ledger rows. */
+export interface DeadIncomeKey {
+  key: string
+  classification: IncomeClassificationType
+}
+
+export interface IncomeClassificationAudit {
+  unclassified: UnclassifiedIncomeItem[]
+  deadKeys: DeadIncomeKey[]
+  /** Money sitting in unclassified buckets -- the cost of leaving the prompt alone. */
+  unclassifiedTotal: number
+  /** Transaction count behind `unclassifiedTotal`. */
+  unclassifiedRows: number
+}
+
+type IncomeClassificationLists = Record<IncomeClassificationType, string[]>
+
+/**
+ * Reconcile the four saved classification lists against the ledger's actual
+ * income buckets.
+ *
+ * Why this exists: the lists are EXACT-MATCH key sets and a stored non-empty
+ * list is honoured verbatim by the backend (`core/analytics/base.py`). So a
+ * partially-configured list has two silent failure modes, neither of which
+ * raises anything:
+ *   - a ledger bucket in NO list falls through every consumer's classification
+ *     chain (`classifyIncomeType` returns 'other', `_is_taxable_income` returns
+ *     false), so the money quietly leaves every classified total; and
+ *   - a saved key no transaction carries contributes zero, so a drifted
+ *     spelling reads as a configured-and-working bucket while summing nothing.
+ *
+ * Matching is case-insensitive to mirror `matchesClassification` in
+ * `lib/preferencesUtils.ts` -- a key differing only in case is honoured by the
+ * consumers, so flagging it here would be a false alarm.
+ */
+export function auditIncomeClassification(
+  facets: IncomeFacet[],
+  lists: IncomeClassificationLists,
+): IncomeClassificationAudit {
+  const claimedBy = new Map<string, IncomeClassificationType>()
+  for (const type of Object.keys(INCOME_CLASSIFICATION_KEY_MAP) as IncomeClassificationType[]) {
+    for (const key of lists[type]) {
+      const lower = key.toLowerCase()
+      // First list wins, matching the fixed resolution order consumers use.
+      if (!claimedBy.has(lower)) claimedBy.set(lower, type)
+    }
+  }
+
+  const ledgerKeys = new Set(
+    facets.map((f) => `${f.category}::${f.subcategory}`.toLowerCase()),
+  )
+
+  const unclassified: UnclassifiedIncomeItem[] = []
+  for (const facet of facets) {
+    const key = `${facet.category}::${facet.subcategory}`
+    if (claimedBy.has(key.toLowerCase())) continue
+    unclassified.push({
+      key,
+      category: facet.category,
+      subcategory: facet.subcategory,
+      count: facet.count,
+      total: facet.total,
+      suggested: suggestIncomeBucket(facet.category, facet.subcategory),
+    })
+  }
+  // Biggest money impact first -- that is the row worth fixing.
+  unclassified.sort((a, b) => b.total - a.total)
+
+  const deadKeys: DeadIncomeKey[] = []
+  for (const type of Object.keys(INCOME_CLASSIFICATION_KEY_MAP) as IncomeClassificationType[]) {
+    for (const key of lists[type]) {
+      if (!ledgerKeys.has(key.toLowerCase())) deadKeys.push({ key, classification: type })
+    }
+  }
+
+  return {
+    unclassified,
+    deadKeys,
+    unclassifiedTotal: unclassified.reduce((sum, item) => sum + item.total, 0),
+    unclassifiedRows: unclassified.reduce((sum, item) => sum + item.count, 0),
+  }
 }
 
 const INVESTMENT_MAPPING_RULES: Array<{ keywords: string[]; endsWith?: string[]; type: string }> = [

--- a/frontend/src/pages/settings/sections/IncomeClassificationAudit.tsx
+++ b/frontend/src/pages/settings/sections/IncomeClassificationAudit.tsx
@@ -1,0 +1,154 @@
+/**
+ * Income classification audit - surfaces the two silent failure modes of the
+ * four exact-match `*_income_categories` preference lists:
+ *
+ *   1. a ledger income bucket that NO list claims (money that quietly leaves
+ *      every classified total, because a stored non-empty list is honoured
+ *      verbatim and the shipped defaults never gap-fill it), and
+ *   2. a saved key that matches ZERO ledger rows (a drifted spelling reads as
+ *      configured-and-working while summing nothing).
+ */
+
+import { AlertTriangle, Sparkles, Trash2 } from 'lucide-react'
+import { Button, Money } from '@/components/ui'
+import type { IncomeClassificationAudit as Audit } from '../helpers'
+import type { IncomeClassificationType } from '../types'
+import { INCOME_CLASSIFICATION_TYPES } from '../types'
+
+interface Props {
+  audit: Audit
+  onClassify: (item: string, type: IncomeClassificationType) => void
+  onApplySuggestions: () => void
+  onRemoveKey: (key: string) => void
+}
+
+/** Bucket label without its leading emoji (the emoji is decorative here). */
+function bucketLabel(type: IncomeClassificationType): string {
+  const match = INCOME_CLASSIFICATION_TYPES.find((t) => t.value === type)
+  return match ? match.label.replace(/^[^\s]+\s/, '') : type
+}
+
+export default function IncomeClassificationAudit({
+  audit,
+  onClassify,
+  onApplySuggestions,
+  onRemoveKey,
+}: Readonly<Props>) {
+  const suggestionCount = audit.unclassified.filter((item) => item.suggested !== null).length
+
+  return (
+    <div className="space-y-3">
+      {audit.unclassified.length > 0 && (
+        <div className="rounded-xl border border-app-yellow/30 bg-app-yellow/10 p-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="flex items-center gap-1.5 text-sm font-medium text-warning-text">
+                <AlertTriangle className="h-4 w-4 shrink-0" aria-hidden="true" />
+                {audit.unclassified.length}{' '}unclassified income{' '}
+                {audit.unclassified.length === 1 ? 'category' : 'categories'}
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                <Money value={audit.unclassifiedTotal} className="inline" /> across{' '}
+                {audit.unclassifiedRows}{' '}
+                {audit.unclassifiedRows === 1 ? 'transaction' : 'transactions'} is left out of every
+                classified total (taxable income, cashbacks, investment returns). Pick a bucket for
+                each.
+              </p>
+            </div>
+            {suggestionCount > 0 && (
+              <Button
+                id="apply-income-suggestions"
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={onApplySuggestions}
+                icon={<Sparkles className="h-3.5 w-3.5" />}
+              >
+                Apply {suggestionCount}{' '}
+                {suggestionCount === 1 ? 'suggestion' : 'suggestions'}
+              </Button>
+            )}
+          </div>
+
+          <ul className="mt-3 flex flex-col gap-2">
+            {audit.unclassified.map((item) => (
+              <li
+                key={item.key}
+                className="flex flex-wrap items-center gap-2 rounded-lg border border-[var(--hairline-1)] bg-[var(--overlay-2)] p-2"
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm text-foreground">{item.subcategory}</p>
+                  <p className="truncate text-[11px] text-muted-foreground">
+                    {item.category} &middot; {item.count}{' '}
+                    {item.count === 1 ? 'txn' : 'txns'}
+                  </p>
+                </div>
+                <Money value={item.total} width="sm" />
+                <select
+                  id={`income-audit-${encodeURIComponent(item.key)}`}
+                  aria-label={`Classify ${item.category} ${item.subcategory}`}
+                  value=""
+                  onChange={(event) => {
+                    if (event.target.value) {
+                      onClassify(item.key, event.target.value as IncomeClassificationType)
+                    }
+                  }}
+                  className="ledger-control min-h-11 w-full shrink-0 rounded-lg border border-border px-2 py-2 text-xs text-foreground focus:border-primary focus:outline-none sm:w-48 lg:pointer-fine:min-h-10"
+                >
+                  <option value="" className="bg-background">
+                    Classify as...
+                  </option>
+                  {INCOME_CLASSIFICATION_TYPES.map((type) => (
+                    <option key={type.value} value={type.value} className="bg-background">
+                      {bucketLabel(type.value)}
+                      {item.suggested === type.value ? ' (suggested)' : ''}
+                    </option>
+                  ))}
+                </select>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {audit.deadKeys.length > 0 && (
+        <div className="rounded-xl border border-border bg-[var(--overlay-1)] p-4">
+          <p className="text-sm font-medium text-foreground">
+            {audit.deadKeys.length}{' '}saved{' '}
+            {audit.deadKeys.length === 1 ? 'category matches' : 'categories match'} no transactions
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            These keys contribute zero to their bucket -- usually a renamed or misspelled category
+            left behind after an import. Harmless, but they hide the fact that nothing is counted.
+          </p>
+          <ul className="mt-3 flex flex-col gap-2">
+            {audit.deadKeys.map((dead) => (
+              <li
+                key={`${dead.classification}-${dead.key}`}
+                className="flex flex-wrap items-center gap-2 rounded-lg border border-[var(--hairline-1)] bg-[var(--overlay-2)] p-2"
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm text-foreground">{dead.key.replace('::', ' / ')}</p>
+                  <p className="text-[11px] text-muted-foreground">
+                    in {bucketLabel(dead.classification)}
+                  </p>
+                </div>
+                <Button
+                  id={`remove-dead-income-key-${encodeURIComponent(dead.key)}`}
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => onRemoveKey(dead.key)}
+                  icon={<Trash2 className="h-3.5 w-3.5" />}
+                  aria-label={`Remove ${dead.key} from ${bucketLabel(dead.classification)}`}
+                >
+                  <span className="hidden sm:inline">Remove</span>
+                </Button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/settings/sections/IncomeClassificationSection.tsx
+++ b/frontend/src/pages/settings/sections/IncomeClassificationSection.tsx
@@ -5,15 +5,19 @@
 import type { Dispatch, SetStateAction } from 'react'
 import { DollarSign } from 'lucide-react'
 import EmptyState from '@/components/shared/EmptyState'
+import type { IncomeClassificationAudit as Audit } from '../helpers'
 import type { LocalPrefs, IncomeClassificationType } from '../types'
 import { INCOME_CLASSIFICATION_TYPES, INCOME_CLASSIFICATION_KEY_MAP } from '../types'
 import { Section } from '../sectionPrimitives'
+import IncomeClassificationAudit from './IncomeClassificationAudit'
 
 interface Props {
   index: number
   allIncomeCategories: Record<string, string[]>
   localPrefs: LocalPrefs
-  unclassifiedIncomeItems: string[]
+  incomeAudit: Audit
+  applyIncomeSuggestions: () => void
+  removeIncomeKey: (key: string) => void
   setLocalPrefs: Dispatch<SetStateAction<LocalPrefs | null>>
   setHasChanges: (v: boolean) => void
   defaultCollapsed?: boolean
@@ -36,7 +40,9 @@ export default function IncomeClassificationSection({
   index,
   allIncomeCategories,
   localPrefs,
-  unclassifiedIncomeItems,
+  incomeAudit,
+  applyIncomeSuggestions,
+  removeIncomeKey,
   setLocalPrefs,
   setHasChanges,
   defaultCollapsed = true,
@@ -74,6 +80,13 @@ export default function IncomeClassificationSection({
         />
       ) : (
         <div className="space-y-4">
+          <IncomeClassificationAudit
+            audit={incomeAudit}
+            onClassify={handleClassify}
+            onApplySuggestions={applyIncomeSuggestions}
+            onRemoveKey={removeIncomeKey}
+          />
+
           {Object.entries(allIncomeCategories).map(([parentCat, subs]) => (
             <div key={parentCat}>
               <h4 className="text-xs font-medium text-muted-foreground mb-2 uppercase tracking-wider">
@@ -129,7 +142,7 @@ export default function IncomeClassificationSection({
                 </span>
               )
             })}
-            <span>{unclassifiedIncomeItems.length} unclassified</span>
+            <span>{incomeAudit.unclassified.length} unclassified</span>
           </div>
         </div>
       )}

--- a/frontend/src/pages/settings/useSettingsState.ts
+++ b/frontend/src/pages/settings/useSettingsState.ts
@@ -4,7 +4,7 @@
 
 import { useState, useEffect, useMemo, useCallback } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
-import { useAccountBalances, useMasterCategories } from '@/hooks/api/useAnalytics'
+import { useAccountBalances, useIncomeFacets, useMasterCategories } from '@/hooks/api/useAnalytics'
 import { useClosedAccounts } from '@/hooks/api/useAccountStatus'
 import { accountClassificationsService } from '@/services/api/accountClassifications'
 import { categorizationRulesService, type CategorizationRuleInput } from '@/services/api/categorizationRules'
@@ -16,9 +16,10 @@ import type { SalaryComponents, RsuGrant, GrowthAssumptions } from '@/types/sala
 import { DEFAULT_GROWTH_ASSUMPTIONS } from '@/types/salary'
 import { sortVestings } from '@/lib/rsuVesting'
 import type { LocalPrefs, LocalPrefKey, LocalRule } from './types'
-import { ACCOUNT_TYPES } from './types'
+import { ACCOUNT_TYPES, INCOME_CLASSIFICATION_KEY_MAP } from './types'
+import type { IncomeFacet } from './helpers'
 import {
-  getDefaultClassifications, getDefaultIncomeClassifications, getDefaultInvestmentMappings, normalizeArray, getStoredWidgets, buildInitialLocalPrefs,
+  auditIncomeClassification, getDefaultClassifications, getDefaultIncomeClassifications, getDefaultInvestmentMappings, normalizeArray, getStoredWidgets, buildInitialLocalPrefs,
 } from './helpers'
 
 export function useSettingsState() {
@@ -49,6 +50,12 @@ export function useSettingsState() {
     isError: closedAccountsError,
     refetch: refetchClosedAccounts,
   } = useClosedAccounts()
+  const {
+    data: incomeFacetsData,
+    isLoading: incomeFacetsLoading,
+    isError: incomeFacetsError,
+    refetch: refetchIncomeFacets,
+  } = useIncomeFacets()
   const { guardDemoAction } = useDemoGuard()
 
   // Local state
@@ -129,22 +136,54 @@ export function useSettingsState() {
     [localPrefs],
   )
 
-  const allClassifiedIncome = useMemo(() => {
-    if (!localPrefs) return new Set<string>()
-    return new Set<string>([
-      ...localPrefs.taxable_income_categories,
-      ...localPrefs.investment_returns_categories,
-      ...localPrefs.non_taxable_income_categories,
-      ...localPrefs.other_income_categories,
-    ])
-  }, [localPrefs])
+  /**
+   * Every income bucket the user has, with its money impact.
+   *
+   * `/income-facets` carries the counts and sums but applies the
+   * excluded-accounts filter, while the section's own list is built from
+   * `/categories/master` (which does not). Anything in the list without a
+   * facet is added at zero so the audit covers exactly the rows the user can
+   * see, and so an excluded-account-only bucket is not mistaken for a dead
+   * (drifted-spelling) key.
+   */
+  const incomeFacets = useMemo<IncomeFacet[]>(() => {
+    const facets = incomeFacetsData?.facets ?? []
+    const seen = new Set(facets.map((f) => `${f.category}::${f.subcategory}`.toLowerCase()))
+    const padded: IncomeFacet[] = facets.map((f) => ({
+      category: f.category,
+      subcategory: f.subcategory,
+      count: f.count,
+      total: f.total,
+    }))
+    for (const [category, subs] of Object.entries(allIncomeCategories)) {
+      for (const subcategory of subs) {
+        if (seen.has(`${category}::${subcategory}`.toLowerCase())) continue
+        padded.push({ category, subcategory, count: 0, total: 0 })
+      }
+    }
+    return padded
+  }, [incomeFacetsData, allIncomeCategories])
 
-  const unclassifiedIncomeItems = useMemo(
+  /**
+   * Reconciles the four saved classification lists against those buckets.
+   * Replaces the old name-only "unclassified" count, which could not say how
+   * much money was sitting outside every bucket and never surfaced saved keys
+   * that match nothing.
+   */
+  const incomeAudit = useMemo(
     () =>
-      Object.entries(allIncomeCategories).flatMap(([cat, subs]) =>
-        subs.map((sub) => `${cat}::${sub}`).filter((item) => !allClassifiedIncome.has(item)),
+      auditIncomeClassification(
+        incomeFacets,
+        localPrefs
+          ? {
+              taxable: localPrefs.taxable_income_categories,
+              investment: localPrefs.investment_returns_categories,
+              non_taxable: localPrefs.non_taxable_income_categories,
+              other: localPrefs.other_income_categories,
+            }
+          : { taxable: [], investment: [], non_taxable: [], other: [] },
       ),
-    [allIncomeCategories, allClassifiedIncome],
+    [incomeFacets, localPrefs],
   )
 
   const unmappedInvestmentAccounts = useMemo(
@@ -276,8 +315,9 @@ export function useSettingsState() {
       refetchCategories(),
       refetchBalances(),
       refetchClosedAccounts(),
+      refetchIncomeFacets(),
     ])
-  }, [refetchPreferences, refetchCategories, refetchBalances, refetchClosedAccounts])
+  }, [refetchPreferences, refetchCategories, refetchBalances, refetchClosedAccounts, refetchIncomeFacets])
 
   // Categorization rule handlers
   const addRule = useCallback(() => {
@@ -339,6 +379,45 @@ export function useSettingsState() {
     },
     [],
   )
+
+  /**
+   * Apply every keyword suggestion the audit produced in one go.
+   *
+   * The first-run auto-classify effect above deliberately bails out once any
+   * list is non-empty (a configured list stays authoritative -- the backend
+   * honours it verbatim). This is the explicit, user-driven equivalent: it only
+   * ever ADDS buckets no list claims, so nothing already classified moves.
+   * Buckets with no keyword match (`suggested: null`) are left alone -- the
+   * user picks those from the per-row dropdown.
+   */
+  const applyIncomeSuggestions = useCallback(() => {
+    const suggestions = incomeAudit.unclassified.filter((item) => item.suggested !== null)
+    if (suggestions.length === 0) return
+    setLocalPrefs((prev) => {
+      if (!prev) return prev
+      const next = { ...prev }
+      for (const item of suggestions) {
+        if (!item.suggested) continue
+        const key = INCOME_CLASSIFICATION_KEY_MAP[item.suggested]
+        next[key] = [...next[key], item.key]
+      }
+      return next
+    })
+    setHasChanges(true)
+  }, [incomeAudit])
+
+  /** Drop a saved classification key that matches zero ledger rows. */
+  const removeIncomeKey = useCallback((key: string) => {
+    setLocalPrefs((prev) => {
+      if (!prev) return prev
+      const next = { ...prev }
+      for (const prefKey of Object.values(INCOME_CLASSIFICATION_KEY_MAP)) {
+        next[prefKey] = next[prefKey].filter((saved) => saved !== key)
+      }
+      return next
+    })
+    setHasChanges(true)
+  }, [])
 
   const updateSalaryStructure = useCallback((structure: Record<string, SalaryComponents>) => {
     setLocalSalaryStructure(structure)
@@ -449,12 +528,14 @@ export function useSettingsState() {
     categoriesLoading ||
     balancesLoading ||
     closedAccountsLoading ||
+    incomeFacetsLoading ||
     rulesLoading
   const loadError =
     preferencesError ||
     categoriesError ||
     balancesError ||
     closedAccountsError ||
+    incomeFacetsError ||
     classificationsError ||
     rulesError
 
@@ -467,7 +548,7 @@ export function useSettingsState() {
     accounts, allExpenseCategories, allIncomeCategories,
     investmentAccounts, creditCardAccounts, accountsByCategory,
     unclassifiedAccounts, excludedAccounts, fixedCategories,
-    unclassifiedIncomeItems, unmappedInvestmentAccounts,
+    incomeAudit, applyIncomeSuggestions, removeIncomeKey, unmappedInvestmentAccounts,
     updateLocalPref, setLocalPrefs, handleSave, handleReset,
     localSalaryStructure, updateSalaryStructure,
     localRsuGrants, updateRsuGrants,

--- a/frontend/src/services/api/calculations.ts
+++ b/frontend/src/services/api/calculations.ts
@@ -76,6 +76,10 @@ export interface IncomeAnalysisData {
   growth_rate: number
 }
 
+export interface IncomeFacetsData {
+  facets: { category: string; subcategory: string; total: number; count: number }[]
+}
+
 export interface QuickInsightsData {
   min_date: string | null
   max_date: string | null
@@ -124,6 +128,10 @@ export const calculationsApi = {
     apiClient.get<Record<string, number[]>>('/api/calculations/category-monthly-history', {
       params: { months: months.join(','), transaction_type: transactionType },
     }),
+
+  /** Every income (category, subcategory) bucket with its row count and sum. */
+  getIncomeFacets: () =>
+    apiClient.get<IncomeFacetsData>('/api/calculations/income-facets'),
 
   /** Min/max transaction date (YYYY-MM-DD) for time-filter nav bounds. */
   getDataDateRange: () =>

--- a/frontend/src/services/api/client.ts
+++ b/frontend/src/services/api/client.ts
@@ -29,6 +29,7 @@ import {
   generateDemoDailySummaries,
   generateDemoDataDateRange,
   generateDemoFacets,
+  generateDemoIncomeFacets,
   generateDemoInvestmentHoldings,
   generateDemoMerchantIntelligence,
   generateDemoQuickInsights,
@@ -61,6 +62,7 @@ const DEMO_ROUTES: ReadonlyArray<readonly [string, DemoResolver]> = [
   ['/calculations/category-breakdown', (txs, params) => generateDemoCategoryBreakdown(txs, params)],
   ['/calculations/quick-insights', (txs) => generateDemoQuickInsights(txs)],
   ['/calculations/data-date-range', (txs) => generateDemoDataDateRange(txs)],
+  ['/calculations/income-facets', (txs) => generateDemoIncomeFacets(txs)],
   [
     '/calculations/category-monthly-history',
     (txs, params) =>


### PR DESCRIPTION
## What changed

The Settings income section now audits the four `*_income_categories` preference lists against the ledger and shows two things it never surfaced before:

1. **Unclassified income buckets** -- any `Category::Subcategory` the user's income transactions carry that appears in none of the four lists, sorted by amount, each with a "Classify as..." picker (suggested bucket marked) plus a bulk "Apply N suggestions" action.
2. **Dead saved keys** -- saved keys matching zero ledger rows, each with a Remove action.

Supporting pieces:

- `GET /api/calculations/income-facets` returns every income `(category, subcategory)` bucket with its row count and sum, aggregated in SQL through `build_transaction_query` (user-scoped, soft-delete and excluded-accounts filtered). It reads raw transactions rather than the `category_trends` rollup: the rollup can lag a fresh import, and a bucket missing from it would read as "already classified", which is exactly the gap being closed.
- `getDefaultIncomeClassifications` now delegates to an extracted `suggestIncomeBucket`, so a suggestion shown in the UI is the same one the first-run defaults would have picked. One source of truth for the keyword rules.
- Demo-mode adapter, TanStack Query hook, and API client entry for the new endpoint.

## Why

The four lists are exact-match key sets, and a stored non-empty list is honoured verbatim by `core/analytics/base.py`, so the shipped defaults never gap-fill a partially-configured list. That gives two silent failure modes:

- A bucket in none of the four lists falls through every consumer's chain (`classifyIncomeType` returns `other`, `_is_taxable_income` returns false), so the money quietly leaves the taxable-income, cashback, and investment-return totals with nothing in the UI saying so.
- A saved key no transaction carries contributes zero, so a drifted spelling reads as configured-and-working while summing nothing.

Once the form was saved even once, an unticked category stayed unclassified forever and the UI only showed a bare count with no amount attached.

## Reviewer notes

- **`core/analytics/base.py` is untouched.** An explicitly configured list stays authoritative. `applyIncomeSuggestions` only ever ADDS buckets no list claims, and the first-run auto-classify effect (which bails out once any list is non-empty) is unchanged. This is the explicit, user-driven equivalent of that effect.
- Matching is case-insensitive to mirror `matchesClassification`, so a key differing only in case is not a false alarm. A key present in two lists is attributed to the first list consumers check.
- The facets list is padded with zero-count entries for buckets present in `/categories/master` but not in `/income-facets`. The two endpoints differ on the excluded-accounts filter, so without the padding an excluded-account-only bucket would be mislabelled as a dead key.
- `abs()` on the bucket total keeps a sign-flipped correction row from subtracting from its bucket and understating the money at stake.

## Verification

- Frontend: `pnpm run type-check` clean, `pnpm run lint` clean, `pnpm test` 358 passed (31 files, 20 new).
- Backend: `uv run ruff check .` clean, `ruff format --check` clean, `uv run mypy src/` clean (144 files), `uv run pytest tests/` 355 passed (7 new).
- Live UI on the demo dataset: un-setting one bucket rendered "1 unclassified income category / 10,376.00 across 11 transactions"; "Apply 1 suggestion" moved it to non-taxable; the dead-key block rendered and Remove cleared it. Zero console errors. At 375px no horizontal overflow, 44px controls, amounts not truncated. Light theme contrast 6.77:1 heading / 5.98:1 body.
- Real-number check against the dev DB (read-only) through the endpoint function, user_id=1: the reported `Refunds & Cashbacks::Product/Service Refunds` (21 rows / 4,475.80) and `::Deposit Return` (1 row / 200.00) figures are exact. In the current DB both keys already sit in `other_income_categories`, so the premise state is covered by a vitest fixture that reproduces it and asserts 22 rows / 4,675.80 are flagged, suggested non-taxable, and fully classified after applying. Live findings in that DB are `One-time Income::Selling Assets` (1 row / 7,000.00) unclassified plus 5 dead keys, all surfaced by the audit.

One correction to the original framing: unclassified income is **excluded** from the tax base, not taxed as income (`_is_taxable_income` returns false; `taxPlanningUtils` returns early on a non-taxable type). The damage is the money silently leaving every classified total, and the UI copy states it that way.

Docs updated: CHANGELOG Unreleased/Added, `docs/API.md` endpoint table, `docs/HANDBOOK.md` settings walkthrough, `docs/PAGES.md` settings entry.
