### PR TITLE
fix: score each savings numerator against its own target

### DIFF
--- a/backend/src/ledger_sync/api/analytics_v2_impl/spending_rule.py
+++ b/backend/src/ledger_sync/api/analytics_v2_impl/spending_rule.py
@@ -679,6 +679,15 @@ def get_spending_rule_breakdown(
 
     needs_target = prefs.needs_target_percent if prefs else 50.0
     wants_target = prefs.wants_target_percent if prefs else 30.0
+    # ``savings_target_percent``, NOT ``savings_goal_percent``. This endpoint's
+    # savings figure is the net change in the investment perimeter (see
+    # ``savings_amount`` below), and that numerator gets the 50/30/20 leg.
+    # ``savings_goal_percent`` is the floor for income-minus-expenses and is
+    # scored on the Expense Analysis page, the health score, and the Trends goal
+    # line. Both columns default to 20.0 while 20% of income allocated into
+    # instruments is a far harder bar than 20% left unspent -- on the owner's
+    # ledger for FY2025-26 the two numerators are 578,428.79 and 1,182,355.68 --
+    # so swapping them silently changes the verdict rather than erroring.
     savings_target = prefs.savings_target_percent if prefs else 20.0
 
     # ─── query ──────────────────────────────────────────────────────────────

--- a/docs/CALCULATIONS.md
+++ b/docs/CALCULATIONS.md
@@ -354,7 +354,31 @@ lifestyle_inflation =
 - Wants
 - Savings
 
-Targets default to 50, 30, and 20 percent but are user configurable.
+Targets default to 50, 30, and 20 percent but are user configurable via
+`needs_target_percent`, `wants_target_percent`, and `savings_target_percent`.
+
+### Which savings target applies where
+
+Two pages show a Savings card, on two different numerators, and each is scored
+against its own preference. They are not interchangeable.
+
+| Page | Savings numerator | Target preference |
+| --- | --- | --- |
+| Budget Rule (`/budgets`) | net change in the investment perimeter (allocations into SIP/PPF/EPF/NPS/stocks minus redemptions) | `savings_target_percent` |
+| Expense Analysis (`/spending-analysis`) | income minus expenses | `savings_goal_percent` |
+
+The same `savings_goal_percent` also drives the Financial Health savings metric
+and the Trends cumulative-savings-rate goal line, which score the same
+income-minus-expenses quantity.
+
+Both preferences default to 20.0, and a percentage of income at 20 is a much
+harder bar on the allocation numerator than on the leftover-income one: on the
+real ledger for FY2025-26 the two numerators are 578,428.79 and 1,182,355.68,
+roughly 2x apart. Sharing one preference across both therefore let one page
+report "under target" while the other reported "on track" for the same user in
+the same period. The numerators themselves are deliberately different and must
+not be reconciled -- see the "TWO RATES, TWO QUESTIONS" note in
+`frontend/src/lib/savingsRate.ts`.
 
 Classification combines:
 

--- a/docs/HANDBOOK.md
+++ b/docs/HANDBOOK.md
@@ -186,6 +186,12 @@ It combines:
 
 Category deep links keep the selected category visible until cleared.
 
+The Savings card here is income minus expenses, scored against your Savings Goal
+in Settings. The Budget Rule page shows a Savings card too, but it counts only
+money you moved into investment accounts and scores it against the Spending
+Rule's Savings percentage. The two numbers answer different questions and will
+not match; each card names its own definition and target.
+
 ### Income Analysis
 
 **Route:** `/income`
@@ -326,6 +332,13 @@ The three buckets are:
 Each card shows target, actual, delta, and score. Category averages are grouped below each bucket. Choose 1 year, 2 years, 5 years, All Time, or Custom.
 
 Targets and category rules come from Settings.
+
+Savings on this page means the net change in your investment perimeter: money
+moved into SIP, PPF, EPF, NPS, or stock accounts, minus what came back out.
+Income that merely stayed in your bank appears as Unallocated, not as Savings.
+The floor it is scored against is the Spending Rule's Savings percentage. The
+Expense Analysis page scores income minus expenses against your Savings Goal
+instead, so expect the two Savings figures to differ.
 
 ### Financial Goals
 

--- a/frontend/src/lib/savingsRate.ts
+++ b/frontend/src/lib/savingsRate.ts
@@ -84,6 +84,29 @@
  * is a real difference in meaning, not drift. Do NOT "reconcile" them by
  * changing one number to match the other: pick the one whose question the caller
  * is asking, and keep the field name that goes with it.
+ *
+ * TWO NUMERATORS NEED TWO TARGETS (decided 2026-07-27)
+ * ---------------------------------------------------
+ * A separate numerator is {@link investmentAllocationRatePercent} below -- money
+ * moved INTO instruments, which the /budgets Savings bucket reports. Keeping the
+ * numerators apart is only half the job: a TARGET scored against them has to be
+ * split the same way, because "20% of income" is a much harder bar on
+ * allocations than on income-minus-expenses. On the real ledger for FY2025-26 the
+ * perimeter change is 578,428.79 against 1,182,355.68 of leftover income,
+ * roughly 2x, so one 20% floor made /budgets read "under target" while
+ * /spending-analysis read "on track" for the same user in the same period.
+ *
+ * `user_preferences` therefore assigns one preference per numerator:
+ *
+ * - `savings_target_percent` -- the 50/30/20 Savings leg, scored ONLY against
+ *   the allocation numerator (`api/analytics_v2_impl/spending_rule.py`, /budgets).
+ * - `savings_goal_percent` -- scored ONLY against income minus expenses: the
+ *   /spending-analysis Savings card, the Financial Health "Spend Less Than
+ *   Income" metric, and the Trends cumulative-savings-rate goal line.
+ *
+ * Both default to 20.0, which is why the mismatch was silent. When adding a
+ * surface that scores a savings figure, pick the preference that matches your
+ * numerator; do not reach for whichever one is already imported.
  */
 
 import { isPartialMonth } from '@/lib/dateUtils'

--- a/frontend/src/pages/budget/BudgetPage.tsx
+++ b/frontend/src/pages/budget/BudgetPage.tsx
@@ -152,7 +152,13 @@ function BudgetRuleContent({ data }: { readonly data: SpendingRuleResponse }) {
       // ledger for FY2025-26 the perimeter change is 578,428.79 while income
       // minus expenses is 1,182,355.68. Whatever stayed in the bank shows up as
       // Unallocated instead.
-      description: 'Net moved into investments',
+      //
+      // It also has to state WHICH target the floor is, because the Expense
+      // Analysis page shows a Savings card too, on the income-minus-expenses
+      // numerator against `savings_goal_percent`. This bucket is scored against
+      // `savings_target_percent` (the 50/30/20 leg). Same word, two bars: a
+      // reader comparing the two pages needs each card to say which is which.
+      description: 'Net moved into investments, vs Spending Rule target',
       icon: PiggyBank,
       kind: 'floor',
     },

--- a/frontend/src/pages/settings/sections/FinancialSettingsSection.tsx
+++ b/frontend/src/pages/settings/sections/FinancialSettingsSection.tsx
@@ -52,7 +52,14 @@ export default function FinancialSettingsSection({
           <FieldHint>Default: April (India FY)</FieldHint>
         </div>
 
-        {/* Savings Goal */}
+        {/*
+          Savings Goal -- the floor on INCOME NOT CONSUMED. Distinct from the
+          Spending Rule's Savings % below, which is a floor on income MOVED INTO
+          INSTRUMENTS. Both are percentages of income named "savings" and both
+          default to 20, so each field states its numerator; without that, one
+          number silently sets two bars of very different difficulty. See
+          `lib/savingsRate.ts` for why the numerators stay separate.
+        */}
         <div>
           <FieldLegend>Savings Goal (%)</FieldLegend>
           <div className="flex items-center gap-3">
@@ -89,6 +96,11 @@ export default function FinancialSettingsSection({
               className="ledger-control min-h-11 w-16 rounded-lg border border-border px-2 py-2 text-center text-sm text-foreground focus:border-primary focus:outline-none sm:min-h-10"
             />
           </div>
+          <FieldHint>
+            Minimum share of income you want left after expenses, wherever it
+            ends up. Scores the Expense Analysis Savings card, the Financial
+            Health savings metric, and the Trends savings-rate goal line.
+          </FieldHint>
         </div>
 
         {/* Monthly Investment Target */}

--- a/frontend/src/pages/settings/sections/SpendingRuleFields.tsx
+++ b/frontend/src/pages/settings/sections/SpendingRuleFields.tsx
@@ -1,5 +1,14 @@
 /**
  * Spending Rule (50/30/20) fields sub-component for Financial Settings.
+ *
+ * The Savings % here is NOT the same target as the "Savings Goal (%)" field
+ * above it in this section. This one is scored on the Budget Rule page against
+ * the net change in the investment perimeter -- money actually moved into
+ * SIP/PPF/EPF/NPS/stocks. Savings Goal is scored against income minus expenses,
+ * which on the real ledger is roughly twice as large for the same period, so
+ * clearing 20% here is a materially harder bar than clearing 20% there. Both
+ * fields are surfaced with their numerators stated rather than reconciled; see
+ * `lib/savingsRate.ts` for why the two definitions stay separate.
  */
 
 import type { LocalPrefs, LocalPrefKey } from '../types'
@@ -53,7 +62,7 @@ export default function SpendingRuleFields({ localPrefs, updateLocalPref }: Read
         </div>
         <div>
           <label htmlFor="savings-percent" className="text-xs text-muted-foreground mb-1 block">
-            Savings %
+            Savings % (invested)
           </label>
           <input
             id="savings-percent"
@@ -72,6 +81,11 @@ export default function SpendingRuleFields({ localPrefs, updateLocalPref }: Read
       ) : (
         <p className="mt-1.5 text-xs text-app-yellow">Totals {sum}% (should be 100%)</p>
       )}
+      <FieldHint>
+        Scores the Budget Rule page. Savings % here means income moved into
+        investment accounts, not income left over -- a harder bar at the same
+        number. For the leftover-income target, use Savings Goal above.
+      </FieldHint>
     </div>
   )
 }

--- a/frontend/src/pages/spending-analysis/__tests__/useSpendingAnalysis.test.tsx
+++ b/frontend/src/pages/spending-analysis/__tests__/useSpendingAnalysis.test.tsx
@@ -72,15 +72,25 @@ vi.mock('@/hooks/api/useTransactions', () => ({
   }),
 }))
 
+/**
+ * Both savings percentages are present and DIFFERENT, so a test can tell which
+ * one the page read. They are equal (20) in production defaults, which is
+ * exactly why the wrong-field bug was invisible.
+ */
+const PREFERENCES = {
+  fiscal_year_start_month: 4,
+  essential_categories: ['Housing'],
+  needs_target_percent: 50,
+  wants_target_percent: 30,
+  /** /budgets allocation floor -- scored against the investment perimeter. */
+  savings_target_percent: 35,
+  /** This page's floor -- scored against income minus expenses. */
+  savings_goal_percent: 20,
+}
+
 vi.mock('@/hooks/api/usePreferences', () => ({
   usePreferences: () => ({
-    data: {
-      fiscal_year_start_month: 4,
-      essential_categories: ['Housing'],
-      needs_target_percent: 50,
-      wants_target_percent: 30,
-      savings_target_percent: 20,
-    },
+    data: PREFERENCES,
     isPending: false,
     isError: false,
     isSuccess: true,
@@ -150,6 +160,80 @@ describe('useSpendingAnalysis -- in-progress month', () => {
     expect(result.current.partialPeriod).toBeNull()
     expect(result.current.monthlyAvgSpending).toBe(37500)
     expect(result.current.budgetRuleMetrics?.essentialPercent).toBeCloseTo(40, 6)
+  })
+})
+
+/**
+ * The savings floor on this page is the INCOME-MINUS-EXPENSES target, not the
+ * allocation target.
+ *
+ * This page's `savings` is `totalIncome - comparableSpending`. /budgets scores a
+ * different numerator -- the net change in the investment perimeter -- against
+ * `savings_target_percent`, and on the real ledger for FY2025-26 the two are
+ * 1,182,355.68 and 578,428.79, roughly 2x apart. Reading the allocation target
+ * here therefore applied a materially harder bar to the easier number, and with
+ * both columns defaulting to 20.0 the mismatch was invisible: the two pages
+ * could report "on track" and "under target" for the same user in the same
+ * period. `savings_goal_percent` is what the health score and the Trends
+ * goal line already score against income minus expenses.
+ */
+describe('useSpendingAnalysis -- which savings target', () => {
+  beforeEach(() => {
+    transactionsRef.current = TRANSACTIONS
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(new Date(2026, 6, 26))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('scores against savings_goal_percent, not savings_target_percent', () => {
+    const { result } = renderHook(() => useSpendingAnalysis(), { wrapper })
+    expect(result.current.savingsTarget).toBe(PREFERENCES.savings_goal_percent)
+    expect(result.current.savingsTarget).not.toBe(PREFERENCES.savings_target_percent)
+    expect(result.current.budgetRuleMetrics?.savingsTarget).toBe(
+      PREFERENCES.savings_goal_percent,
+    )
+  })
+
+  it('judges the leftover-income share against the leftover-income floor', () => {
+    const { result } = renderHook(() => useSpendingAnalysis(), { wrapper })
+    // 180,000 saved on 300,000 income = 60%, clear of the 20% goal. Against the
+    // 35% allocation floor it would also pass here, so the assertion that
+    // matters is WHICH number the verdict was measured against.
+    expect(result.current.budgetRuleMetrics?.savingsPercent).toBeCloseTo(60, 6)
+    expect(result.current.budgetRuleMetrics?.isUnderSaving).toBe(false)
+  })
+
+  it('keeps the needs and wants caps on the spending-rule triplet', () => {
+    const { result } = renderHook(() => useSpendingAnalysis(), { wrapper })
+    expect(result.current.needsTarget).toBe(PREFERENCES.needs_target_percent)
+    expect(result.current.wantsTarget).toBe(PREFERENCES.wants_target_percent)
+  })
+
+  it('flips the on-track verdict, so the field is not a cosmetic choice', () => {
+    // 100,000 income against 75,000 spend per month = a 25% leftover share.
+    // Against the 20% goal that clears the -5pt band (25 < 15 is false) and the
+    // card reads on track; against the 35% allocation floor it does not
+    // (25 < 30 is true) and the same period reads as undersaving. The two
+    // preferences are not interchangeable even where both are configured.
+    transactionsRef.current = [
+      tx('2026-04-05', 100000, 'Income', 'Employment Income'),
+      tx('2026-04-06', 50000, 'Expense', 'Housing'),
+      tx('2026-04-07', 25000, 'Expense', 'Shopping'),
+      tx('2026-05-05', 100000, 'Income', 'Employment Income'),
+      tx('2026-05-06', 50000, 'Expense', 'Housing'),
+      tx('2026-05-07', 25000, 'Expense', 'Shopping'),
+      tx('2026-06-05', 100000, 'Income', 'Employment Income'),
+      tx('2026-06-06', 50000, 'Expense', 'Housing'),
+      tx('2026-06-07', 25000, 'Expense', 'Shopping'),
+    ]
+    const { result } = renderHook(() => useSpendingAnalysis(), { wrapper })
+    expect(result.current.budgetRuleMetrics?.savingsPercent).toBeCloseTo(25, 6)
+    expect(result.current.budgetRuleMetrics?.isUnderSaving).toBe(false)
+    // The verdict the allocation floor would have produced on this same number.
+    expect(25 < PREFERENCES.savings_target_percent - 5).toBe(true)
   })
 })
 

--- a/frontend/src/pages/spending-analysis/components/BudgetRuleAnalysis.tsx
+++ b/frontend/src/pages/spending-analysis/components/BudgetRuleAnalysis.tsx
@@ -31,6 +31,13 @@ interface SpendingChartDatum {
 interface BudgetRuleAnalysisProps {
   readonly needsTarget: number
   readonly wantsTarget: number
+  /**
+   * Floor for the SAVINGS card, from `savings_goal_percent` -- the
+   * income-minus-expenses target. Not `savings_target_percent`, which is the
+   * /budgets allocation floor scored against money moved into instruments; see
+   * `useSpendingAnalysis` for the two numerators and why they keep separate
+   * targets.
+   */
   readonly savingsTarget: number
   readonly spendingChartData: SpendingChartDatum[]
   readonly spendingBreakdown: SpendingBreakdown | null
@@ -52,9 +59,25 @@ export default function BudgetRuleAnalysis({
       className="glass rounded-xl border border-border p-4 sm:p-6"
       {...SCROLL_FADE_UP}
     >
-      <h2 className="mb-4 text-lg font-semibold text-foreground">
-        {needsTarget}/{wantsTarget}/{savingsTarget} Budget Rule Analysis
+      {/*
+        The heading used to read `{needs}/{wants}/{savings} Budget Rule
+        Analysis`. It cannot: the Savings floor now comes from
+        `savings_goal_percent` while Needs/Wants come from the 50/30/20 triplet,
+        so the three numbers are no longer guaranteed to sum to 100 and printing
+        them slash-joined would advertise a rule they do not form. The two caps
+        stay in the heading because they ARE two legs of that triplet; the floor
+        moves into the caption next to the definition it is applied to.
+      */}
+      <h2 className="text-lg font-semibold text-foreground">
+        Budget Rule Analysis: Needs {needsTarget}% / Wants {wantsTarget}%
       </h2>
+      <p className="mb-4 mt-1 text-xs text-muted-foreground">
+        Needs and Wants are capped shares of income. The Savings floor of{' '}
+        {savingsTarget}% is your Savings Goal, applied to income left after
+        expenses. The Budget Rule page scores a separate target against money
+        actually moved into investments, so the two savings figures differ by
+        design.
+      </p>
 
       {spendingChartData.length > 0 ? (
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4 lg:gap-6">
@@ -132,7 +155,11 @@ export default function BudgetRuleAnalysis({
           />
           <BudgetRuleCard
             title={`Savings (${savingsTarget}%)`}
-            subtitle="Income minus Expenses"
+            // Names the numerator AND the preference the floor comes from. The
+            // /budgets Savings card carries a different number under the same
+            // word, so "which target is this" has to be readable on the card
+            // rather than inferred from the page it sits on.
+            subtitle="Income minus Expenses, vs Savings Goal"
             icon={PiggyBank}
             value={savings}
             percent={budgetRuleMetrics?.savingsPercent ?? 0}

--- a/frontend/src/pages/spending-analysis/useSpendingAnalysis.ts
+++ b/frontend/src/pages/spending-analysis/useSpendingAnalysis.ts
@@ -293,10 +293,39 @@ export function useSpendingAnalysis() {
     [spendingBreakdown, savings, totalIncome],
   )
 
-  // Spending rule targets from preferences (configurable Needs/Wants/Savings).
+  // Spending rule targets from preferences (configurable Needs/Wants).
   const needsTarget = preferences?.needs_target_percent ?? 50
   const wantsTarget = preferences?.wants_target_percent ?? 30
-  const savingsTarget = preferences?.savings_target_percent ?? 20
+  /**
+   * The savings floor comes from `savings_goal_percent`, NOT from
+   * `savings_target_percent` -- the two preferences score different numerators
+   * and this page computes the first one.
+   *
+   * `savings` here is `totalIncome - comparableSpending` (see above): income the
+   * user did not consume, wherever it ended up. `savings_target_percent` is the
+   * third leg of the 50/30/20 triplet and is scored on /budgets against the NET
+   * CHANGE IN THE INVESTMENT PERIMETER -- money actually moved into
+   * SIP/PPF/EPF/NPS/stocks. Those are not the same bar: 20% of income left over
+   * is far easier to clear than 20% of income allocated into instruments, and on
+   * the real ledger for FY2025-26 the two numerators are 1,182,355.68 and
+   * 578,428.79 (see `pages/budget/BudgetPage.tsx`). Reading one preference
+   * against both let /budgets report "under target" while this page reported "on
+   * track" for the same user in the same period.
+   *
+   * `savings_goal_percent` is the app's income-minus-expenses target already:
+   * the health score's "Spend Less Than Income" metric
+   * (`components/analytics/health/healthScoreScorers.ts`) and the Trends
+   * cumulative-savings-rate goal line
+   * (`pages/trends-forecasts/components/SavingsRateSection.tsx`) both score it
+   * against exactly this quantity. This page was the only
+   * income-minus-expenses surface reaching for the allocation target instead.
+   * Both columns default to 20.0, so no existing user's setting changes meaning.
+   *
+   * Consequence for the heading: needs + wants + this no longer necessarily sum
+   * to 100, so `BudgetRuleAnalysis` must not print them as a "50/30/20" triplet.
+   * See `lib/savingsRate.ts` for why the two numerators stay separate.
+   */
+  const savingsTarget = preferences?.savings_goal_percent ?? 20
 
   const budgetRuleMetrics = useMemo(() => {
     return computeBudgetRuleMetrics(spendingBreakdown, totalIncome, savings, needsTarget, wantsTarget, savingsTarget)


### PR DESCRIPTION
## Problem

`/budgets` and `/spending-analysis` both read `user_preferences.savings_target_percent`, but they compute genuinely different savings numerators:

| Page | Savings numerator | Measured FY2025-26 |
| --- | --- | --- |
| `/budgets` | net change in the investment perimeter (allocations into SIP/PPF/EPF/NPS/stocks minus redemptions) | 578,428.79 |
| `/spending-analysis` | income minus expenses | 1,182,355.68 |

Roughly 2x apart. With one 20% floor applied to both, `/budgets` could report "under target" while `/spending-analysis` reported "on track" for the same user in the same period. A percentage of income at 20 is a much harder bar on money actually allocated into instruments than on income merely left unspent.

Both preferences default to `20.0`, which is exactly why the mismatch was silent rather than a visible bug.

## What this is not

The two numerators are deliberate and stay separate. `frontend/src/lib/savingsRate.ts` rules out reconciling them explicitly ("two legitimately different questions... Do NOT reconcile them"), and each page already disclosed its own definition in a caption. The numbers were never the defect. The **target** was.

## Fix

The field already existed. `savings_goal_percent` is the app's income-minus-expenses target, already scored against exactly that quantity by the Financial Health "Spend Less Than Income" metric and the Trends cumulative-savings-rate goal line. `/spending-analysis` was the only income-minus-expenses surface in the app reaching for the allocation target instead.

- `/spending-analysis` now reads `savings_goal_percent`.
- `savings_target_percent` stays the `/budgets` allocation floor (the 50/30/20 leg).

**No new column and no Alembic migration.** Both columns already default to `20.0`, so no existing user's setting changes meaning.

## Consequence handled

Needs + wants + savings no longer necessarily sum to 100 on `/spending-analysis`, so its heading stops printing them slash-joined as a `50/30/20` triplet. It now reads `Budget Rule Analysis: Needs 50% / Wants 30%` with the savings floor moved into a caption beside the definition it applies to.

Additionally, so the split is legible rather than inferred from which page you happen to be on:

- Both Savings cards name their numerator **and** their target (`Income minus Expenses, vs Savings Goal` / `Net moved into investments, vs Spending Rule target`).
- Both settings fields state which bar they set; the Spending Rule leg is relabelled `Savings % (invested)`.
- The decision is recorded in `savingsRate.ts` (the stated authority on these definitions), in `spending_rule.py` at the read site, and in `docs/CALCULATIONS.md` + `docs/HANDBOOK.md`.

## Verification

- `pnpm run check`: lint 0 errors both stacks, type-check clean both stacks, backend tests pass, frontend 1379 pass (1375 baseline + 4 new).
- **New tests proven to bite.** I temporarily reverted the one-line field change and confirmed 2 of the 4 fail against the old code, then restored it. One asserts which field is read; one asserts the verdict actually flips (a 25% leftover share clears the 20% goal but not the 35% allocation floor, so the choice is not cosmetic). The test mock now sets the two percentages to *different* values, since equal defaults are what hid this.
- **Checked live in the browser** on demo data, not static reasoning: both pages render their new captions, both settings hints render, no console errors, no horizontal overflow at 375px, readable in light and dark.

## Reviewer notes

- The behaviour change is one line: [`useSpendingAnalysis.ts:328`](https://github.com/Sagargupta16/ledger-sync/blob/fix/savings-target-definitions/frontend/src/pages/spending-analysis/useSpendingAnalysis.ts#L328). Everything else is disclosure, tests, and docs.
- A user who had deliberately tuned `savings_target_percent` away from 20 for the `/spending-analysis` card will now see that card follow `savings_goal_percent` instead. That is the intended correction, not a regression: the tuned value keeps applying to the allocation bucket it was scored against on `/budgets`.
- Left alone deliberately: the two percent fields still sit several rows apart in Settings rather than being regrouped as one labelled pair. Both hints explain the difference; regrouping that section is a layout call beyond this fix.
