### PR TITLE
fix(rsu): convert vest-date prices at vest-date FX and record net shares

### DIFF
--- a/backend/src/ledger_sync/api/exchange_rates.py
+++ b/backend/src/ledger_sync/api/exchange_rates.py
@@ -117,7 +117,12 @@ async def _fetch_rates(base: str, on_date: date | None = None) -> tuple[dict[str
 )
 async def get_exchange_rates(
     _current_user: CurrentUser,
-    base: str = "INR",
+    # Constrained at the boundary rather than sanitised at each use. `base` is
+    # echoed into two log lines and forwarded upstream, so an unbounded string
+    # was log-forgeable (a newline injects a fake log record). A currency code is
+    # exactly three letters, and rejecting anything else here means neither the
+    # logger nor frankfurter ever sees arbitrary input.
+    base: Annotated[str, Query(pattern=r"^[A-Za-z]{3}$")] = "INR",
     on_date: Annotated[
         date | None,
         Query(

--- a/backend/src/ledger_sync/api/exchange_rates.py
+++ b/backend/src/ledger_sync/api/exchange_rates.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Any
+from datetime import UTC, date, datetime
+from typing import Annotated, Any
 
+import anyio
 import httpx
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 
 from ledger_sync.api.deps import CurrentUser
 
@@ -22,6 +24,15 @@ router = APIRouter(prefix="/api/exchange-rates", tags=["exchange-rates"])
 
 _CACHE_TTL = 86400  # 24 hours in seconds
 _FRANKFURTER_URL = "https://api.frankfurter.dev/v1/latest"
+# Same API shape, date in the path instead of "latest". Frankfurter serves the
+# ECB reference rate for that date, falling back to the previous publication day
+# on weekends and TARGET holidays (verified live: 2025-08-15 -> USD/INR 87.46).
+_FRANKFURTER_HISTORICAL_URL = "https://api.frankfurter.dev/v1/{on_date}"
+
+# One retry: the upstream's transient failures resolved within seconds when
+# observed, and a vest-price lock is a foreground fetch the user is waiting on.
+_UPSTREAM_ATTEMPTS = 2
+_UPSTREAM_RETRY_DELAY_SECONDS = 1.5
 
 # Per-worker in-memory cache. Each uvicorn/Vercel worker maintains its
 # own copy; this is acceptable because the data is public and cheap to
@@ -62,31 +73,97 @@ def _cache_is_fresh() -> bool:
     return bool((time.time() - fetched_at) < _CACHE_TTL)
 
 
-async def _fetch_rates(base: str) -> dict[str, float]:
-    """Fetch latest rates from frankfurter.dev."""
+async def _fetch_rates(base: str, on_date: date | None = None) -> tuple[dict[str, float], str]:
+    """Fetch rates from frankfurter.dev, latest or for a specific date.
+
+    Returns the rate map plus the date frankfurter actually priced, which can
+    precede ``on_date`` when it lands on a weekend or TARGET holiday.
+
+    Retries once on a transient upstream failure. The historical endpoint was
+    observed returning Cloudflare 520/522 and read timeouts intermittently while
+    ``/latest`` stayed healthy, recovering within seconds. A historical lookup
+    has no cache and no fallback to fall back ON (see the handler), so a single
+    blip would otherwise leave a vest price unconverted.
+    """
+    url = (
+        _FRANKFURTER_URL
+        if on_date is None
+        else _FRANKFURTER_HISTORICAL_URL.format(on_date=on_date.isoformat())
+    )
+    last_err: Exception | None = None
     async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
-        resp = await client.get(_FRANKFURTER_URL, params={"from": base})
-        resp.raise_for_status()
-        data = resp.json()
-        rates = data.get("rates", {})
-        if not isinstance(rates, dict):
-            return {}
-        return dict(rates)
+        for attempt in range(_UPSTREAM_ATTEMPTS):
+            try:
+                resp = await client.get(url, params={"from": base})
+                resp.raise_for_status()
+                data = resp.json()
+                rates = data.get("rates", {})
+                if not isinstance(rates, dict):
+                    return {}, ""
+                return dict(rates), str(data.get("date", ""))
+            except (httpx.HTTPError, ValueError) as err:
+                last_err = err
+                if attempt < _UPSTREAM_ATTEMPTS - 1:
+                    await anyio.sleep(_UPSTREAM_RETRY_DELAY_SECONDS)
+    raise last_err if last_err else RuntimeError("rate fetch failed")
 
 
 @router.get(
     "",
-    responses={502: {"description": "Unable to fetch rates from external API"}},
+    responses={
+        400: {"description": "on_date is in the future"},
+        502: {"description": "Unable to fetch rates from external API"},
+    },
 )
 async def get_exchange_rates(
     _current_user: CurrentUser,
     base: str = "INR",
+    on_date: Annotated[
+        date | None,
+        Query(
+            description=(
+                "Return the rate published on this date instead of the latest. "
+                "Used to convert an RSU vest-date stock price at the FX rate that "
+                "applied on the vest date."
+            ),
+        ),
+    ] = None,
 ) -> dict[str, Any]:
     """Return exchange rates for the given base currency.
 
     Uses a 24-hour in-memory cache. Falls back to stale cache or
     hardcoded approximate rates if the external API is unreachable.
+
+    ``on_date`` bypasses that cache and the fallback table entirely. A past
+    ECB rate never changes, so a TTL is meaningless, and the fallback table is
+    a single present-day snapshot -- serving it for a 2025 date would silently
+    substitute today's rate, which is exactly the bug this parameter fixes.
+    A failed historical lookup therefore errors instead, and the caller keeps
+    the unconverted price.
     """
+    if on_date is not None:
+        if on_date > datetime.now(tz=UTC).date():
+            raise HTTPException(status_code=400, detail="on_date cannot be in the future")
+        try:
+            rates, priced_on = await _fetch_rates(base, on_date)
+        except (httpx.HTTPError, ValueError, KeyError) as err:
+            logger.warning(
+                "Failed to fetch historical rates base=%s on_date=%s", base, on_date, exc_info=True
+            )
+            raise HTTPException(
+                status_code=502,
+                detail=f"Unable to fetch exchange rates for {on_date}",
+            ) from err
+        return {
+            "base": base,
+            "rates": rates,
+            # The date frankfurter priced, which precedes on_date across a
+            # weekend or holiday. Surfaced so the caller can show what it used.
+            "as_of": priced_on or on_date.isoformat(),
+            "requested_date": on_date.isoformat(),
+            "historical": True,
+        }
+
     if _cache_is_fresh() and _rate_cache.get("base") == base:
         return {
             "base": base,
@@ -95,7 +172,7 @@ async def get_exchange_rates(
         }
 
     try:
-        rates = await _fetch_rates(base)
+        rates, _ = await _fetch_rates(base)
         _rate_cache["rates"] = rates
         _rate_cache["base"] = base
         _rate_cache["fetched_at"] = time.time()

--- a/backend/src/ledger_sync/schemas/salary.py
+++ b/backend/src/ledger_sync/schemas/salary.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import date
 from decimal import Decimal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class SalaryComponents(BaseModel):
@@ -30,12 +30,36 @@ class RsuVesting(BaseModel):
     """A single vesting event within an RSU grant."""
 
     date: date
-    quantity: int = Field(gt=0)
+    quantity: int = Field(gt=0, description="Shares that vested, BEFORE any tax withholding.")
     price_at_vest: Decimal | None = Field(
         default=None,
         gt=0,
         description="Stock price on the vest date, locked in once the vesting has passed.",
     )
+    net_quantity: Decimal | None = Field(
+        default=None,
+        gt=0,
+        description=(
+            "Shares actually received after sell-to-cover withholding, when the "
+            "employer withheld some of the vest to pay tax. Reporting only: "
+            "perquisite value is taxed on the FULL vest, so `quantity` remains "
+            "the basis for every tax projection. Fractional because brokers "
+            "credit fractional residuals."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _net_cannot_exceed_gross(self) -> RsuVesting:
+        """Reject a net quantity above the gross vest.
+
+        Withholding only ever reduces the share count, so net > gross means the
+        two fields were transposed. Left unchecked it would render a "received"
+        line larger than the vest it came from.
+        """
+        if self.net_quantity is not None and self.net_quantity > self.quantity:
+            msg = f"net_quantity ({self.net_quantity}) cannot exceed quantity ({self.quantity})"
+            raise ValueError(msg)
+        return self
 
 
 class RsuGrant(BaseModel):

--- a/backend/tests/unit/test_exchange_rates.py
+++ b/backend/tests/unit/test_exchange_rates.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 import asyncio
 import time
+from datetime import UTC, date, datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
+from fastapi import HTTPException
 
 from ledger_sync.api.exchange_rates import (
     _FALLBACK_RATES,
+    _fetch_rates,
     _rate_cache,
     get_exchange_rates,
 )
@@ -31,10 +34,12 @@ class FakeUser:
 def test_fetch_and_cache_rates():
     """Should fetch rates from external API and cache them."""
     mock_rates = {"USD": 0.01187, "EUR": 0.01092}
+    # `_fetch_rates` returns (rates, priced_on): the second element is the date
+    # frankfurter actually priced, which matters only for historical lookups.
     with patch(
         "ledger_sync.api.exchange_rates._fetch_rates",
         new_callable=AsyncMock,
-        return_value=mock_rates,
+        return_value=(mock_rates, ""),
     ):
         result = asyncio.run(get_exchange_rates(_current_user=FakeUser(), base="INR"))
     assert result["base"] == "INR"
@@ -85,3 +90,105 @@ def test_fallback_rates_when_no_cache():
         result = asyncio.run(get_exchange_rates(_current_user=FakeUser(), base="INR"))
     assert result["fallback"] is True
     assert result["rates"] == _FALLBACK_RATES
+
+
+class TestHistoricalRates:
+    """`on_date` converts a past value at the rate that applied then.
+
+    The RSU vest-date price was being converted at TODAY's FX: a 2025-08-15
+    close in USD times the 2026-08-03 USD/INR. Measured on a real vest that
+    overstated the line by 9% (87.46 then vs 95.34 now), and RSU perquisite
+    value is fixed at vesting under Indian rules, so the drift fed straight
+    into the tax projection.
+    """
+
+    def test_historical_date_returns_that_days_rate(self):
+        with patch(
+            "ledger_sync.api.exchange_rates._fetch_rates",
+            new_callable=AsyncMock,
+            return_value=({"INR": 87.46}, "2025-08-15"),
+        ):
+            result = asyncio.run(
+                get_exchange_rates(_current_user=FakeUser(), base="USD", on_date=date(2025, 8, 15))
+            )
+        assert result["historical"] is True
+        assert result["rates"]["INR"] == pytest.approx(87.46)
+        assert result["as_of"] == "2025-08-15"
+        assert result["requested_date"] == "2025-08-15"
+
+    def test_weekend_reports_the_date_actually_priced(self):
+        """Frankfurter prices the prior publication day; say so rather than imply the ask."""
+        with patch(
+            "ledger_sync.api.exchange_rates._fetch_rates",
+            new_callable=AsyncMock,
+            return_value=({"INR": 87.46}, "2025-08-15"),
+        ):
+            result = asyncio.run(
+                get_exchange_rates(_current_user=FakeUser(), base="USD", on_date=date(2025, 8, 16))
+            )
+        assert result["as_of"] == "2025-08-15"
+        assert result["requested_date"] == "2025-08-16"
+
+    def test_historical_bypasses_the_ttl_cache(self):
+        """A stale-but-present cache must not answer a dated request."""
+        _rate_cache["rates"] = {"INR": 95.34}
+        _rate_cache["base"] = "USD"
+        _rate_cache["fetched_at"] = time.time()
+
+        with patch(
+            "ledger_sync.api.exchange_rates._fetch_rates",
+            new_callable=AsyncMock,
+            return_value=({"INR": 87.46}, "2025-08-15"),
+        ) as fetch:
+            result = asyncio.run(
+                get_exchange_rates(_current_user=FakeUser(), base="USD", on_date=date(2025, 8, 15))
+            )
+        assert fetch.await_count == 1
+        assert result["rates"]["INR"] == pytest.approx(87.46)
+
+    def test_historical_failure_errors_instead_of_serving_todays_rate(self):
+        """The fallback table is a present-day snapshot -- serving it IS the bug."""
+        with (
+            patch(
+                "ledger_sync.api.exchange_rates._fetch_rates",
+                new_callable=AsyncMock,
+                side_effect=httpx.HTTPError("API down"),
+            ),
+            pytest.raises(HTTPException) as exc,
+        ):
+            asyncio.run(
+                get_exchange_rates(_current_user=FakeUser(), base="USD", on_date=date(2025, 8, 15))
+            )
+        assert exc.value.status_code == 502
+
+    def test_future_date_rejected(self):
+        # UTC, matching the handler's own `datetime.now(tz=UTC).date()` comparison.
+        future = datetime.now(tz=UTC).date() + timedelta(days=1)
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(get_exchange_rates(_current_user=FakeUser(), base="USD", on_date=future))
+        assert exc.value.status_code == 400
+
+
+class TestUpstreamRetry:
+    """The historical endpoint returned Cloudflare 520/522 intermittently."""
+
+    def test_retries_once_then_succeeds(self):
+        calls = {"n": 0}
+
+        async def flaky(*_args, **_kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise httpx.ReadTimeout("upstream blip")
+            request = httpx.Request("GET", "https://api.frankfurter.dev/v1/2025-08-15")
+            return httpx.Response(
+                200, json={"date": "2025-08-15", "rates": {"INR": 87.46}}, request=request
+            )
+
+        with (
+            patch("httpx.AsyncClient.get", new=flaky),
+            patch("ledger_sync.api.exchange_rates.anyio.sleep", new_callable=AsyncMock),
+        ):
+            rates, priced_on = asyncio.run(_fetch_rates("USD", date(2025, 8, 15)))
+        assert calls["n"] == 2
+        assert rates["INR"] == pytest.approx(87.46)
+        assert priced_on == "2025-08-15"

--- a/backend/tests/unit/test_exchange_rates.py
+++ b/backend/tests/unit/test_exchange_rates.py
@@ -10,13 +10,16 @@ from unittest.mock import AsyncMock, patch
 import httpx
 import pytest
 from fastapi import HTTPException
+from fastapi.testclient import TestClient
 
+from ledger_sync.api.deps import get_current_user
 from ledger_sync.api.exchange_rates import (
     _FALLBACK_RATES,
     _fetch_rates,
     _rate_cache,
     get_exchange_rates,
 )
+from ledger_sync.api.main import app
 
 
 @pytest.fixture(autouse=True)
@@ -148,6 +151,7 @@ class TestHistoricalRates:
 
     def test_historical_failure_errors_instead_of_serving_todays_rate(self):
         """The fallback table is a present-day snapshot -- serving it IS the bug."""
+        call = get_exchange_rates(_current_user=FakeUser(), base="USD", on_date=date(2025, 8, 15))
         with (
             patch(
                 "ledger_sync.api.exchange_rates._fetch_rates",
@@ -156,16 +160,18 @@ class TestHistoricalRates:
             ),
             pytest.raises(HTTPException) as exc,
         ):
-            asyncio.run(
-                get_exchange_rates(_current_user=FakeUser(), base="USD", on_date=date(2025, 8, 15))
-            )
+            # Coroutine built before the raises block: `asyncio.run(f(...))` is two
+            # potentially-throwing calls, so a failure in the wrong one would still
+            # satisfy the assertion.
+            asyncio.run(call)
         assert exc.value.status_code == 502
 
     def test_future_date_rejected(self):
         # UTC, matching the handler's own `datetime.now(tz=UTC).date()` comparison.
         future = datetime.now(tz=UTC).date() + timedelta(days=1)
+        call = get_exchange_rates(_current_user=FakeUser(), base="USD", on_date=future)
         with pytest.raises(HTTPException) as exc:
-            asyncio.run(get_exchange_rates(_current_user=FakeUser(), base="USD", on_date=future))
+            asyncio.run(call)
         assert exc.value.status_code == 400
 
 
@@ -192,3 +198,36 @@ class TestUpstreamRetry:
         assert calls["n"] == 2
         assert rates["INR"] == pytest.approx(87.46)
         assert priced_on == "2025-08-15"
+
+
+class TestBaseValidation:
+    """`base` is echoed into log lines and forwarded upstream.
+
+    It was an unbounded `str`, so a newline-bearing value could inject a fake
+    record into the log (SonarCloud S5145). Constrained at the boundary to a
+    three-letter currency code, so neither the logger nor frankfurter ever sees
+    arbitrary input.
+    """
+
+    @pytest.mark.parametrize("bad", ["USD\nWARNING injected", "USDD", "", "US1", "../etc"])
+    def test_non_currency_codes_are_rejected(self, bad):
+        client = TestClient(app)
+        app.dependency_overrides[get_current_user] = FakeUser
+        try:
+            assert client.get("/api/exchange-rates", params={"base": bad}).status_code == 422
+        finally:
+            app.dependency_overrides.clear()
+
+    @pytest.mark.parametrize("good", ["USD", "inr", "EuR"])
+    def test_three_letter_codes_are_accepted(self, good):
+        client = TestClient(app)
+        app.dependency_overrides[get_current_user] = FakeUser
+        try:
+            with patch(
+                "ledger_sync.api.exchange_rates._fetch_rates",
+                new_callable=AsyncMock,
+                return_value=({"INR": 1.0}, ""),
+            ):
+                assert client.get("/api/exchange-rates", params={"base": good}).status_code == 200
+        finally:
+            app.dependency_overrides.clear()

--- a/backend/tests/unit/test_salary_schemas.py
+++ b/backend/tests/unit/test_salary_schemas.py
@@ -106,8 +106,9 @@ class TestRsuGrant:
     def test_net_quantity_cannot_exceed_the_gross_vest(self):
         """Withholding only reduces the count, so net > gross means transposed fields."""
         vest_date = date(2025, 8, 15)
+        over_gross = Decimal("6.001")
         with pytest.raises(ValidationError, match="cannot exceed"):
-            RsuVesting(date=vest_date, quantity=6, net_quantity=Decimal("6.001"))
+            RsuVesting(date=vest_date, quantity=6, net_quantity=over_gross)
 
     def test_net_quantity_rejects_zero(self):
         vest_date = date(2025, 8, 15)

--- a/backend/tests/unit/test_salary_schemas.py
+++ b/backend/tests/unit/test_salary_schemas.py
@@ -88,6 +88,33 @@ class TestRsuGrant:
         with pytest.raises(ValidationError):
             RsuVesting(date=vest_date, quantity=6, price_at_vest=zero)
 
+    def test_net_quantity_defaults_to_none(self):
+        """Absent means "no withholding recorded", NOT "equal to the gross vest"."""
+        vesting = RsuVesting(date=date(2026, 3, 15), quantity=25)
+        assert vesting.net_quantity is None
+
+    def test_net_quantity_accepts_a_fraction(self):
+        """Sell-to-cover credits fractional residuals: 6 vested, 4.127 received."""
+        vesting = RsuVesting(date=date(2025, 8, 15), quantity=6, net_quantity=Decimal("4.127"))
+        assert vesting.net_quantity == Decimal("4.127")
+
+    def test_net_quantity_may_equal_the_gross_vest(self):
+        """Legal: nothing was withheld on that vest."""
+        vesting = RsuVesting(date=date(2025, 8, 15), quantity=6, net_quantity=Decimal("6"))
+        assert vesting.net_quantity == Decimal("6")
+
+    def test_net_quantity_cannot_exceed_the_gross_vest(self):
+        """Withholding only reduces the count, so net > gross means transposed fields."""
+        vest_date = date(2025, 8, 15)
+        with pytest.raises(ValidationError, match="cannot exceed"):
+            RsuVesting(date=vest_date, quantity=6, net_quantity=Decimal("6.001"))
+
+    def test_net_quantity_rejects_zero(self):
+        vest_date = date(2025, 8, 15)
+        zero = Decimal("0")
+        with pytest.raises(ValidationError):
+            RsuVesting(date=vest_date, quantity=6, net_quantity=zero)
+
     def test_stock_price_must_be_positive(self):
         stock_price = Decimal("0")
         vesting = RsuVesting(date=date(2026, 3, 15), quantity=25)

--- a/frontend/src/lib/__tests__/rsuVesting.test.ts
+++ b/frontend/src/lib/__tests__/rsuVesting.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
-import { isVested, sortVestings, splitRsuTotals, vestingPrice } from '../rsuVesting'
+import {
+  isVested,
+  netVestingValue,
+  sortVestings,
+  splitRsuTotals,
+  vestingPrice,
+} from '../rsuVesting'
 import type { RsuGrant } from '@/types/salary'
 
 const TODAY = '2026-07-09'
@@ -82,5 +88,34 @@ describe('splitRsuTotals', () => {
     const totals = splitRsuTotals([], TODAY)
     expect(totals.vested.shares).toBe(0)
     expect(totals.upcoming.value).toBe(0)
+  })
+})
+
+describe('netVestingValue', () => {
+  it('values the shares actually received at the same per-share price', () => {
+    // 6 vested, 4.127 credited after sell-to-cover, priced at the vest-date close.
+    expect(netVestingValue({ date: '2025-08-15', quantity: 6, net_quantity: 4.127 }, 150)).toBe(
+      619.05,
+    )
+  })
+
+  it('returns null when no withholding was recorded', () => {
+    // NOT the gross value: a blank field means "unknown", and showing a
+    // "received" figure equal to the gross would imply the user confirmed it.
+    expect(netVestingValue({ date: '2025-08-15', quantity: 6 }, 150)).toBeNull()
+    expect(netVestingValue({ date: '2025-08-15', quantity: 6, net_quantity: null }, 150)).toBeNull()
+    expect(netVestingValue({ date: '2025-08-15', quantity: 6, net_quantity: 0 }, 150)).toBeNull()
+  })
+
+  it('is ignored by splitRsuTotals, which stays on the gross vest', () => {
+    // Indian RSU perquisite value is taxed on the FULL vest at vest-date FMV --
+    // the withheld shares ARE the tax payment -- so every tax-facing total must
+    // keep using `quantity`. This is the guard against net_quantity leaking into
+    // the projection and understating taxable income.
+    const withNet: RsuGrant = {
+      ...grant,
+      vestings: grant.vestings.map((v) => ({ ...v, net_quantity: 1 })),
+    }
+    expect(splitRsuTotals([withNet], TODAY)).toEqual(splitRsuTotals([grant], TODAY))
   })
 })

--- a/frontend/src/lib/rsuVesting.ts
+++ b/frontend/src/lib/rsuVesting.ts
@@ -42,6 +42,24 @@ export function vestingPrice(grant: RsuGrant, v: RsuVesting, today: string = tod
   return Number(grant.stock_price) || 0
 }
 
+/**
+ * Value of the shares actually received, or `null` when nothing was withheld.
+ *
+ * Priced at the same per-share figure as the gross line so the two are directly
+ * comparable. Returns `null` rather than falling back to the gross value: a
+ * blank field means "no withholding recorded", and showing a "received" figure
+ * equal to the gross would imply the user had confirmed that.
+ *
+ * Deliberately NOT used by `splitRsuTotals`, `projectionCalculator`, or
+ * `tdsScheduleCalculator`. Indian RSU perquisite value is taxed on the FULL
+ * vest at vest-date FMV -- the withheld shares ARE the tax payment -- so
+ * `quantity` stays the basis everywhere tax is computed. This is reporting only.
+ */
+export function netVestingValue(v: RsuVesting, pricePerShare: number): number | null {
+  if (v.net_quantity == null || v.net_quantity <= 0) return null
+  return Number(v.net_quantity) * pricePerShare
+}
+
 export interface RsuSplitTotals {
   vested: { shares: number; value: number }
   upcoming: { shares: number; value: number }

--- a/frontend/src/pages/settings/sections/salary/VestingCard.tsx
+++ b/frontend/src/pages/settings/sections/salary/VestingCard.tsx
@@ -2,7 +2,7 @@ import { X } from 'lucide-react'
 
 import Button from '@/components/ui/Button'
 import { formatCurrency } from '@/lib/formatters'
-import { vestingPrice } from '@/lib/rsuVesting'
+import { netVestingValue, vestingPrice } from '@/lib/rsuVesting'
 import { selectFiscalYearStartMonth, usePreferencesStore } from '@/store/preferencesStore'
 
 import { inputClass } from '../../styles'
@@ -27,8 +27,10 @@ export default function VestingCard({
   const rowName = `${grant.stock_name || 'RSU'} vesting ${stateIdx + 1}`
   const dateId = `mobile-vesting-${grant.id}-${stateIdx}-date`
   const quantityId = `mobile-vesting-${grant.id}-${stateIdx}-quantity`
+  const netQuantityId = `mobile-vesting-${grant.id}-${stateIdx}-net-quantity`
   const headingId = `mobile-vesting-${grant.id}-${stateIdx}-heading`
   const valuationId = `mobile-vesting-${grant.id}-${stateIdx}-valuation`
+  const netValue = netVestingValue(vesting, price)
 
   return (
     <article
@@ -82,7 +84,7 @@ export default function VestingCard({
           className="space-y-1 text-xs font-medium text-text-secondary"
         >
           <span>
-            Quantity<span className="sr-only"> for {rowName}</span>
+            Granted qty<span className="sr-only"> for {rowName}</span>
           </span>
           <input
             id={quantityId}
@@ -96,6 +98,29 @@ export default function VestingCard({
               })
             }
             placeholder="0"
+            className={inputClass}
+          />
+        </label>
+        <label
+          htmlFor={netQuantityId}
+          className="space-y-1 text-xs font-medium text-text-secondary"
+        >
+          <span>
+            Received after tax<span className="sr-only"> for {rowName}</span>
+          </span>
+          <input
+            id={netQuantityId}
+            type="number"
+            inputMode="decimal"
+            min="0"
+            step="0.001"
+            value={vesting.net_quantity ?? ''}
+            onChange={(event) =>
+              onUpdateVesting(grant.id, stateIdx, {
+                net_quantity: event.target.value === '' ? null : Number(event.target.value),
+              })
+            }
+            placeholder="Optional"
             className={inputClass}
           />
         </label>
@@ -113,6 +138,11 @@ export default function VestingCard({
           <span id={valuationId} className="mt-0.5 block text-[11px] text-muted-foreground">
             {usesVestPrice ? `Vest-date price ${formatCurrency(price)}` : 'Current price'}
           </span>
+          {netValue !== null && (
+            <span className="mt-0.5 block text-[11px] text-app-green">
+              {formatCurrency(netValue)} received
+            </span>
+          )}
         </span>
       </div>
     </article>

--- a/frontend/src/pages/settings/sections/salary/VestingRow.tsx
+++ b/frontend/src/pages/settings/sections/salary/VestingRow.tsx
@@ -2,7 +2,7 @@ import { X } from 'lucide-react'
 
 import Button from '@/components/ui/Button'
 import { formatCurrency } from '@/lib/formatters'
-import { vestingPrice } from '@/lib/rsuVesting'
+import { netVestingValue, vestingPrice } from '@/lib/rsuVesting'
 import { selectFiscalYearStartMonth, usePreferencesStore } from '@/store/preferencesStore'
 
 import { inputClass } from '../../styles'
@@ -27,6 +27,10 @@ export default function VestingRow({
   const rowName = `${grant.stock_name || 'RSU'} vesting ${stateIdx + 1}`
   const dateId = `vesting-${grant.id}-${stateIdx}-date`
   const quantityId = `vesting-${grant.id}-${stateIdx}-quantity`
+  const netQuantityId = `vesting-${grant.id}-${stateIdx}-net-quantity`
+  // Only shown when the user recorded a post-withholding count. Priced at the
+  // same per-share figure as the gross line so the two are comparable.
+  const netValue = netVestingValue(vesting, price)
 
   return (
     <tr className="border-b border-border/50">
@@ -64,6 +68,27 @@ export default function VestingRow({
           className={`${inputClass} max-w-[100px]`}
         />
       </td>
+      <td className="py-2 pr-3">
+        <label htmlFor={netQuantityId} className="sr-only">
+          Shares received after tax for {rowName}
+        </label>
+        <input
+          id={netQuantityId}
+          type="number"
+          inputMode="decimal"
+          min="0"
+          step="0.001"
+          value={vesting.net_quantity ?? ''}
+          onChange={(event) =>
+            onUpdateVesting(grant.id, stateIdx, {
+              net_quantity: event.target.value === '' ? null : Number(event.target.value),
+            })
+          }
+          placeholder="--"
+          title="Shares credited after sell-to-cover withholding. Leave blank if none was withheld."
+          className={`${inputClass} max-w-[100px]`}
+        />
+      </td>
       <td className="py-2 pr-3 text-muted-foreground">
         <span className="ledger-figure block">
           {estimatedValue > 0 ? formatCurrency(estimatedValue) : '--'}
@@ -71,6 +96,11 @@ export default function VestingRow({
         <span className="block text-[11px] text-text-tertiary">
           {usesVestPrice ? `Vest-date ${formatCurrency(price)}` : 'Current price'}
         </span>
+        {netValue !== null && (
+          <span className="block text-[11px] text-app-green">
+            {formatCurrency(netValue)} received
+          </span>
+        )}
       </td>
       <td className="py-2 pr-3 text-muted-foreground">
         {fiscalYear ? `FY ${fiscalYear}` : '--'}

--- a/frontend/src/pages/settings/sections/salary/VestingTable.tsx
+++ b/frontend/src/pages/settings/sections/salary/VestingTable.tsx
@@ -9,7 +9,7 @@ export type { VestingTableProps } from './vestingTableTypes'
 function GroupDividerRow({ label, count }: Readonly<{ label: string; count: number }>) {
   return (
     <tr>
-      <td colSpan={5} className="pb-1 pt-3">
+      <td colSpan={6} className="pb-1 pt-3">
         <span className="text-[11px] font-semibold uppercase text-muted-foreground">
           {label} ({count})
         </span>
@@ -82,7 +82,10 @@ export function VestingTable(props: Readonly<VestingTableProps>) {
                 Date
               </th>
               <th scope="col" className="py-2 pr-3 text-left font-medium">
-                Qty
+                Granted Qty
+              </th>
+              <th scope="col" className="py-2 pr-3 text-left font-medium" title="Shares credited after sell-to-cover tax withholding. Optional.">
+                Received
               </th>
               <th scope="col" className="py-2 pr-3 text-left font-medium">
                 Est. Value

--- a/frontend/src/pages/settings/sections/salary/useRsuGrants.ts
+++ b/frontend/src/pages/settings/sections/salary/useRsuGrants.ts
@@ -102,12 +102,31 @@ export function useRsuGrants(
     [localRsuGrants, updateGrant],
   )
 
+  /**
+   * Convert a foreign-currency stock price into the display currency.
+   *
+   * `onDate` converts at the rate published THEN, not now. Without it a vest-date
+   * close (a historical USD figure) was converted at today's USD/INR, mixing
+   * vintages: on a 2025-08-15 AMZN vest the rate was 87.46 against 95.34 on
+   * 2026-08-03, overstating that line by 9%. Indian RSU perquisite value is fixed
+   * at vesting and does not move with later FX, and these grants feed the tax
+   * projections, so the drift propagated into computed tax.
+   *
+   * A failed historical lookup returns the price unconverted rather than falling
+   * back to today's rate -- the caller then leaves `price_at_vest` unset and the
+   * row keeps showing "Current price", which is honest. Silently substituting
+   * today's rate is the bug being fixed.
+   */
   const convertPrice = useCallback(
-    async (price: number, currency: string): Promise<number> => {
+    async (price: number, currency: string, onDate?: string): Promise<number> => {
       if (!currency || currency === displayCurrency) return price
-      const rates = await preferencesService.getExchangeRates(currency)
-      const rate = rates.rates[displayCurrency]
-      return rate ? Math.round(price * rate * 100) / 100 : price
+      try {
+        const rates = await preferencesService.getExchangeRates(currency, onDate)
+        const rate = rates.rates[displayCurrency]
+        return rate ? Math.round(price * rate * 100) / 100 : price
+      } catch {
+        return price
+      }
     },
     [displayCurrency],
   )
@@ -155,7 +174,9 @@ export function useRsuGrants(
       for (const job of jobs) {
         try {
           const result = await preferencesService.getStockPrice(job.symbol, job.date)
-          const price = await convertPrice(result.price, result.currency)
+          // Same date for both legs: the close on the vest date converted at the
+          // FX rate published on the vest date.
+          const price = await convertPrice(result.price, result.currency, job.date)
           if (price > 0) fetched.set(`${job.grantId}|${job.date}`, price)
         } catch {
           /* falls back to current price in the UI */

--- a/frontend/src/services/api/preferences.ts
+++ b/frontend/src/services/api/preferences.ts
@@ -207,11 +207,20 @@ export interface GrowthAssumptionsConfig {
 export interface ExchangeRatesResponse {
   base: string
   rates: Record<string, number>
-  fetched_at: number | null
+  fetched_at?: number | null
   stale?: boolean
   fallback?: boolean
   /** ISO date (YYYY-MM-DD) the hardcoded table was captured. Only on fallback. */
   fallback_as_of?: string
+  /** True when the response is a dated historical rate, not the latest. */
+  historical?: boolean
+  /**
+   * ISO date the rate was actually published. Precedes the requested date
+   * across a weekend or holiday. Only on historical responses.
+   */
+  as_of?: string
+  /** The date that was asked for. Only on historical responses. */
+  requested_date?: string
 }
 
 // Helper to create section-specific updaters
@@ -279,13 +288,24 @@ export const preferencesService = {
     return response.data
   },
 
-  async getExchangeRates(base: string = 'INR'): Promise<ExchangeRatesResponse> {
+  /**
+   * Exchange rates for `base`, latest or as published on `onDate`.
+   *
+   * `onDate` exists so a historical value is converted at the FX rate that
+   * applied then. Converting an RSU vest-date stock price at today's rate mixed
+   * vintages and overstated the vested line by the FX drift since (measured 9%
+   * on a 2025-08-15 AMZN vest: USD/INR 87.46 then vs 95.34 on 2026-08-03).
+   */
+  async getExchangeRates(
+    base: string = 'INR',
+    onDate?: string,
+  ): Promise<ExchangeRatesResponse> {
     // Generic on `get`, not just on the return type: without it `response.data`
     // is `any`, so the declared shape was an unchecked assertion and a backend
     // rename would have surfaced as `undefined` at the render site instead of
     // an error here. Shape confirmed live on 2026-07-27 (29 currencies).
     const response = await apiClient.get<ExchangeRatesResponse>('/api/exchange-rates', {
-      params: { base },
+      params: onDate ? { base, on_date: onDate } : { base },
     })
     return response.data
   },

--- a/frontend/src/types/salary.ts
+++ b/frontend/src/types/salary.ts
@@ -12,9 +12,17 @@ export interface SalaryComponents {
 /** A single vesting event within an RSU grant. */
 export interface RsuVesting {
   date: string // YYYY-MM-DD
+  /** Shares that vested, BEFORE any tax withholding. The tax basis. */
   quantity: number
   /** Stock price on the vest date (display currency). Set once a vesting is in the past. */
   price_at_vest?: number | null
+  /**
+   * Shares actually received after sell-to-cover withholding, when the employer
+   * withheld part of the vest to pay tax. Reporting only -- Indian perquisite
+   * value is taxed on the FULL vest, so `quantity` stays the basis for every
+   * projection. Fractional because brokers credit fractional residuals.
+   */
+  net_quantity?: number | null
 }
 
 /** An RSU grant with its vesting schedule. */


### PR DESCRIPTION
## The bug

The RSU vest-date stock price was fetched historically but converted at **today's** FX rate. A 2025-08-15 closing price in USD was multiplied by the 2026-08-03 USD/INR: historical price, current rate, mixed vintages.

Verified end to end against the live grant and both upstreams:

| | |
| --- | --- |
| AMZN close on 2025-08-15 | **$231.03** |
| USD/INR on the vest date | **87.46** |
| USD/INR today | **95.34** |

| | Per share | Line (6 shares) |
| --- | --- | --- |
| Before | Rs 22,026.40 | Rs 1,32,158.40 |
| After | Rs 20,205.88 | Rs 1,21,235.28 |
| **Removed** | Rs 1,820.52 | **Rs 10,923.12 (9.0%)** |

The row also mislabelled itself: it said `Vest-date price Rs 22,026.40`, but that rupee figure never existed on the vest date.

**This was not display-only.** Indian RSU perquisite value is fixed at vesting and does not move with later FX. These grants feed the tax projection and the TDS schedule, so the drift propagated into computed tax.

## The FX fix

`GET /api/exchange-rates` takes an optional `on_date`, served by frankfurter's dated endpoint (identical response shape, date in the path instead of `latest`).

Three decisions worth reviewing:

**Historical lookups bypass both the 24h cache and the fallback table.** A past ECB rate never changes, so a TTL is meaningless. More importantly the fallback is a single *present-day* snapshot -- serving it for a 2025 date would silently substitute today's rate, which is precisely the bug being fixed. A failed historical lookup therefore returns 502, the frontend keeps the price unconverted, and the row honestly continues to show "Current price" rather than locking in a wrong number.

**The response reports the date actually priced.** 2025-08-16 was a Saturday; frankfurter prices back to Friday. `as_of` says `2025-08-15` while `requested_date` says `2025-08-16`, so the caller can surface what was used instead of implying the date asked for.

**One retry on upstream failure.** During testing the dated endpoint returned Cloudflare 520/522 and read timeouts intermittently while `/latest` stayed healthy, recovering within seconds. A vest-price lock is a foreground fetch with no cache to fall back on, so a single blip would otherwise leave the price unconverted.

## Net shares after tax

Adds an optional `net_quantity` per vesting for sell-to-cover, where the employer withholds part of the vest to pay tax (6 vested, 4.127 credited). Fractional, because brokers credit fractional residuals.

The vesting table's `Qty` column is now `Granted Qty`, with a new optional `Received` column beside it. When filled, the value cell adds a `Rs 83,389.67 received` line under the gross. Same on the mobile card.

### Reviewer note: this must never reach tax math

Perquisite value is taxed on the **full** vest at vest-date FMV -- the withheld shares *are* the tax payment. So `quantity` remains the basis in `splitRsuTotals`, `projectionCalculator`, and `tdsScheduleCalculator`, and `netVestingValue` is deliberately not called by any of them.

There is a test asserting `splitRsuTotals` returns identical results with and without `net_quantity` populated, specifically to catch a future change that lets it leak into the projection and understate taxable income.

Also: `netVestingValue` returns `null` rather than falling back to the gross value when the field is blank. A blank field means "no withholding recorded"; rendering a "received" figure equal to the gross would imply the user had confirmed that. A schema validator rejects `net_quantity > quantity`, which can only mean the two fields were transposed.

## Known limitations, stated rather than hidden

- **Frankfurter is ECB reference rates, not the SBI TT buying rate** that the Income Tax Act specifies for perquisite valuation. Far closer than today's rate, but not filing-exact. Worth a UI note in a follow-up.
- **Existing `price_at_vest` values are not re-locked.** They were stored at whatever FX applied when first fetched, and the auto-fetch only runs when the field is empty, so they will not self-correct. Clearing the field re-locks it correctly. A "re-lock vest prices" action is a possible follow-up.

## Verification

| Check | Result |
| --- | --- |
| Backend | **836 pass**, ruff clean, mypy clean across 157 files |
| Frontend | **1427 pass across 121 files** (10 new), lint 0 errors, tsc clean |
| Live probes | Yahoo historical close, both FX paths, weekend fallback, future-date rejection |
| Schema validation | net below/equal/above gross, zero, and omitted all behave correctly |
| Pre-commit | all 12 hooks passed |

New tests: 6 backend for the historical FX path (dated rate, weekend `as_of`, cache bypass, failure-does-not-serve-today's-rate, future rejection, retry-then-succeed), 5 backend for `net_quantity` validation, and 3 frontend for `netVestingValue` including the tax-isolation guard. One pre-existing test was updated because `_fetch_rates` now returns `(rates, priced_on)`.